### PR TITLE
Tweaked controller provider configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,25 +41,27 @@ To generate or update documentation, run `go generate`.
 
 In order to run the full suite of Acceptance tests, run `make testacc`.
 
-*Note:* Acceptance tests create real resources.
+_Note:_ Acceptance tests create real resources.
 
 Prior to running the tests locally, ensure you have the following environmental variables set:
 
-* `JUJU_CONTROLLER`
-* `JUJU_USERNAME`
-* `JUJU_PASSWORD`
-* `JUJU_CA_CERT`
+- `JUJU_CONTROLLER_ADDRESSES`
+- `JUJU_USERNAME`
+- `JUJU_PASSWORD`
+- `JUJU_CA_CERT`
 
-For example, here they are set using a controller named `overlord`:
+For example, here they are set using the currently active controller:
 
 ```shell
-export JUJU_CONTROLLER="127.0.0.1:17070"
-export JUJU_USERNAME="$(cat ~/.local/share/juju/accounts.yaml | yq .controllers.overlord.user)"
-export JUJU_PASSWORD="$(cat ~/.local/share/juju/accounts.yaml | yq .controllers.overlord.password)"
-export JUJU_CA_CERT="$(juju show-controller overlord | yq .overlord.details.ca-cert)"
+CONTROLLER=$(juju whoami | yq .Controller)
+export JUJU_CONTROLLER_ADDRESSES="$(juju show-controller | yq .$CONTROLLER.details.api-endpoints)"
+export JUJU_USERNAME="$(cat ~/.local/share/juju/accounts.yaml | yq .controllers.$CONTROLLER.user)"
+export JUJU_PASSWORD="$(cat ~/.local/share/juju/accounts.yaml | yq .controllers.$CONTROLLER.password)"
+export JUJU_CA_CERT="$(juju show-controller $CONTROLLER | yq .$CONTROLLER.details.ca-cert)"
 ```
 
-Then, finally, run the tests: 
+Then, finally, run the tests:
+
 ```shell
 make testacc
 ```

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ For example, here they are set using the currently active controller:
 
 ```shell
 CONTROLLER=$(juju whoami | yq .Controller)
-export JUJU_CONTROLLER_ADDRESSES="$(juju show-controller | yq .$CONTROLLER.details.api-endpoints)"
+export JUJU_CONTROLLER_ADDRESSES="$(juju show-controller | yq .$CONTROLLER.details.api-endpoints | tr -d "[]' ")"
 export JUJU_USERNAME="$(cat ~/.local/share/juju/accounts.yaml | yq .controllers.$CONTROLLER.user)"
 export JUJU_PASSWORD="$(cat ~/.local/share/juju/accounts.yaml | yq .controllers.$CONTROLLER.password)"
 export JUJU_CA_CERT="$(juju show-controller $CONTROLLER | yq .$CONTROLLER.details.ca-cert)"

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,6 +29,6 @@ provider "juju" {
 ### Optional
 
 - `ca_certificate` (String) This is the certificate to use for identification. This can also be set by the `JUJU_CA_CERT` environment variable
-- `controller_addresses` (String) This is the Controller addresses to connect to, defaults to ['localhost:17070'], multiple addresses can be provided in this format: ['<host>:<port>', '<host>:<port>', ...]. This can also be set by the `JUJU_CONTROLLER_ADDRESSES` environment variable.
+- `controller_addresses` (String) This is the Controller addresses to connect to, defaults to localhost:17070, multiple addresses can be provided in this format: <host>:<port>,<host>:<port>,.... This can also be set by the `JUJU_CONTROLLER_ADDRESSES` environment variable.
 - `password` (String, Sensitive) This is the password of the username to be used. This can also be set by the `JUJU_PASSWORD` environment variable
 - `username` (String) This is the username registered with the controller to be used. This can also be set by the `JUJU_USERNAME` environment variable

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,6 +29,6 @@ provider "juju" {
 ### Optional
 
 - `ca_certificate` (String) This is the certificate to use for identification. This can also be set by the `JUJU_CA_CERT` environment variable
-- `controller` (String) This is the Controller address to connect to, defaults to localhost:17070. This can also be set by the `JUJU_CONTROLLER` environment variable.
+- `controller_addresses` (String) This is the Controller addresses to connect to, defaults to ['localhost:17070'], multiple addresses can be provided in this format: ['<host>:<port>', '<host>:<port>', ...]. This can also be set by the `JUJU_CONTROLLER_ADDRESSES` environment variable.
 - `password` (String, Sensitive) This is the password of the username to be used. This can also be set by the `JUJU_PASSWORD` environment variable
 - `username` (String) This is the username registered with the controller to be used. This can also be set by the `JUJU_USERNAME` environment variable

--- a/internal/provider/data_source_model_test.go
+++ b/internal/provider/data_source_model_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestAcc_DataSourceModel(t *testing.T) {
-	modelName := acctest.RandomWithPrefix("tf-test-model")
+	modelName := acctest.RandomWithPrefix("tf-datasource-model-test")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -23,9 +23,9 @@ func New(version string) func() *schema.Provider {
 			Schema: map[string]*schema.Schema{
 				"controller_addresses": {
 					Type:        schema.TypeString,
-					Description: fmt.Sprintf("This is the Controller addresses to connect to, defaults to ['localhost:17070'], multiple addresses can be provided in this format: ['<host>:<port>', '<host>:<port>', ...]. This can also be set by the `%s` environment variable.", JujuControllerEnvKey),
+					Description: fmt.Sprintf("This is the Controller addresses to connect to, defaults to localhost:17070, multiple addresses can be provided in this format: <host>:<port>,<host>:<port>,.... This can also be set by the `%s` environment variable.", JujuControllerEnvKey),
 					Optional:    true,
-					DefaultFunc: schema.EnvDefaultFunc(JujuControllerEnvKey, "['localhost:17070']"),
+					DefaultFunc: schema.EnvDefaultFunc(JujuControllerEnvKey, "localhost:17070"),
 				},
 				"username": {
 					Type:        schema.TypeString,
@@ -68,11 +68,7 @@ func configure(version string, p *schema.Provider) func(context.Context, *schema
 
 		var diags diag.Diagnostics
 
-		ControllerAddresses := d.Get("controller_addresses").(string)
-		ControllerAddresses = strings.Replace(ControllerAddresses, "[", "", -1)
-		ControllerAddresses = strings.Replace(ControllerAddresses, "]", "", -1)
-		ControllerAddresses = strings.Replace(ControllerAddresses, "'", "", -1)
-		ControllerAddressesParsed := strings.Split(ControllerAddresses, ",")
+		ControllerAddresses := strings.Split(d.Get("controller_addresses").(string), ",")
 		username := d.Get("username").(string)
 		password := d.Get("password").(string)
 		caCert := d.Get("ca_certificate").(string)
@@ -86,7 +82,7 @@ func configure(version string, p *schema.Provider) func(context.Context, *schema
 		}
 
 		config := juju.Configuration{
-			ControllerAddresses: ControllerAddressesParsed,
+			ControllerAddresses: ControllerAddresses,
 			Username:            username,
 			Password:            password,
 			CACert:              caCert,

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -31,13 +31,13 @@ func testAccPreCheck(t *testing.T) {
 		t.Log("no CI environment detected, executing acceptance tests", v)
 	}
 
-	if v := os.Getenv("JUJU_USERNAME"); v == "" {
-		t.Fatal("JUJU_USERNAME must be set for acceptance tests")
+	if v := os.Getenv(JujuUsernameEnvKey); v == "" {
+		t.Fatalf("%s must be set for acceptance tests", JujuUsernameEnvKey)
 	}
-	if v := os.Getenv("JUJU_PASSWORD"); v == "" {
-		t.Fatal("JUJU_PASSWORD must be set for acceptance tests")
+	if v := os.Getenv(JujuPasswordEnvKey); v == "" {
+		t.Fatalf("%s must be set for acceptance tests", JujuPasswordEnvKey)
 	}
-	if v := os.Getenv("JUJU_CA_CERT"); v == "" {
-		t.Fatal("JUJU_CA_CERT must be set for acceptance tests")
+	if v := os.Getenv(JujuCACertEnvKey); v == "" {
+		t.Fatalf("%s must be set for acceptance tests", JujuCACertEnvKey)
 	}
 }


### PR DESCRIPTION
This PR adjusts the environment variables used to configure the provider to avoid conflicts with the existing Juju CLI. Any non-conflicting environment variables have been moved to `internal/provider/provider.go` so that if a conflict arises in the future it only needs to be adjusted in a single location.

It also adds destroy functionality to `data_source_model_test.go` to compliment the existing model add functionality and allows the test to clean up after itself.