### PR TITLE
 Implement Delete action for juju_model resource #9 

### DIFF
--- a/internal/juju/models.go
+++ b/internal/juju/models.go
@@ -3,13 +3,15 @@ package juju
 import (
 	"errors"
 	"fmt"
+	"log"
+	"time"
+
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/client/modelmanager"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/names/v4"
-	"log"
 )
 
 type Model struct {
@@ -139,4 +141,25 @@ func (c *modelsClient) Read(uuid string) (*string, *params.ModelInfo, error) {
 	}
 
 	return controllerName, modelInfo, nil
+
+}
+
+func (c *modelsClient) Delete(uuid string) error {
+	client := modelmanager.NewClient(c.conn)
+	defer client.Close()
+
+	maxWait := 10 * time.Minute
+	timeout := 30 * time.Minute
+
+	tag := names.NewModelTag(uuid)
+
+	destroyStorage := true
+	forceDestroy := false
+
+	err := client.DestroyModel(tag, &destroyStorage, &forceDestroy, &maxWait, timeout)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/internal/juju/models.go
+++ b/internal/juju/models.go
@@ -144,7 +144,7 @@ func (c *modelsClient) Read(uuid string) (*string, *params.ModelInfo, error) {
 
 }
 
-func (c *modelsClient) Delete(uuid string) error {
+func (c *modelsClient) Destroy(uuid string) error {
 	client := modelmanager.NewClient(c.conn)
 	defer client.Close()
 

--- a/internal/provider/resource_model.go
+++ b/internal/provider/resource_model.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/juju/terraform-provider-juju/internal/juju"
@@ -121,5 +122,18 @@ func resourceModelUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 
 func resourceModelDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	// TODO: Add client function to handle the appropriate JuJu API Facade Endpoint
-	return diag.Errorf("not implemented")
+	client := meta.(*juju.Client)
+
+	var diags diag.Diagnostics
+
+	modelUUID := d.Id()
+
+	err := client.Models.Delete(modelUUID)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId("")
+
+	return diags
 }

--- a/internal/provider/resource_model.go
+++ b/internal/provider/resource_model.go
@@ -120,6 +120,8 @@ func resourceModelUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 	return diag.Errorf("not implemented")
 }
 
+// Juju refers to model deletion as "destroy" so we call the Destroy function of our client here rather than delete
+// This function remains named Delete for parity across the provider and to stick within terraform naming conventions
 func resourceModelDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	// TODO: Add client function to handle the appropriate JuJu API Facade Endpoint
 	client := meta.(*juju.Client)
@@ -128,7 +130,7 @@ func resourceModelDelete(ctx context.Context, d *schema.ResourceData, meta inter
 
 	modelUUID := d.Id()
 
-	err := client.Models.Delete(modelUUID)
+	err := client.Models.Destroy(modelUUID)
 	if err != nil {
 		return diag.FromErr(err)
 	}


### PR DESCRIPTION
This implements the Delete action for `juju_model`.

*Note* This is known in Juju as `destroy` rather than delete so the client has a method Destroy that is called by the provider's delete command.


```^_^ make testacc
TF_ACC=1 go test ./... -v  -timeout 120m
?       github.com/juju/terraform-provider-juju [no test files]
?       github.com/juju/terraform-provider-juju/internal/juju   [no test files]
=== RUN   TestAcc_DataSourceModel
    provider_test.go:31: no CI environment detected, executing acceptance tests 
--- PASS: TestAcc_DataSourceModel (1.25s)
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestAcc_ResourceCharm
    resource_charm_test.go:12: resource not yet implemented, remove this once you add your own code
--- SKIP: TestAcc_ResourceCharm (0.00s)
=== RUN   TestAcc_ResourceModel
    provider_test.go:31: no CI environment detected, executing acceptance tests 
--- PASS: TestAcc_ResourceModel (1.09s)
=== RUN   TestAcc_ResourceRelation
    resource_relation_test.go:12: resource not yet implemented, remove this once you add your own code
--- SKIP: TestAcc_ResourceRelation (0.00s)
PASS
ok      github.com/juju/terraform-provider-juju/internal/provider       (cached)```