### PR TITLE
Integrate acceptance test automation

### DIFF
--- a/.github/actions/setup-juju/action.yaml
+++ b/.github/actions/setup-juju/action.yaml
@@ -1,0 +1,30 @@
+name: "Setup Juju"
+description: "An action to setup and bootstrap Juju"
+
+runs:
+  using: "composite"
+  steps:
+    - name: install dependencies
+      if: ${{ !env.ACT }}
+      shell: bash
+      # language=bash
+      run: |
+          set -euxo pipefail
+          sudo apt remove lxd lxd-client
+          sudo snap install lxd yq
+          sudo lxd waitready
+          sudo lxd init --auto
+          sudo chmod a+wr /var/snap/lxd/common/lxd/unix.socket
+          echo "/snap/bin" >> $GITHUB_PATH
+    - name: install juju
+      shell: bash
+      # language=bash
+      run: |
+        set -euxo pipefail
+        sudo snap install juju --classic
+        lxc network set lxdbr0 ipv6.address none
+    - name: bootstrap
+      shell: bash
+      # language=bash
+      run: |
+        juju bootstrap localhost

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,7 @@
 # Terraform Provider testing workflow.
 name: Tests
 
-# This GitHub action runs your tests for each pull request and push.
-# Optionally, you can turn it on using a schedule for regular testing.
+# This GitHub action runs your tests for each pull request.
 on:
   pull_request:
     paths-ignore:
@@ -75,6 +74,19 @@ jobs:
         with:
           terraform_version: ${{ matrix.terraform }}
           terraform_wrapper: false
+      - uses: ./.github/actions/setup-juju
+        if: ${{ !env.ACT }} # skip when running locally with `act`
+      - name: "Set environment to configure provider"
+        # language=bash
+        run: |
+          CONTROLLER=$(juju whoami --format yaml | yq .controller)
+  
+          echo "JUJU_CONTROLLER_ADDRESSES=$(juju show-controller | yq -o=json .$CONTROLLER.details.api-endpoints | jq -r '. | join(",")')" >> $GITHUB_ENV
+          echo "JUJU_USERNAME=$(juju show-controller | yq .$CONTROLLER.account.user)"  >> $GITHUB_ENV
+          echo "JUJU_PASSWORD=$(cat ~/.local/share/juju/accounts.yaml | yq .controllers.$CONTROLLER.password)"  >> $GITHUB_ENV
+          echo "JUJU_CA_CERT<<EOF" >> $GITHUB_ENV
+          juju show-controller | yq .$CONTROLLER.details.ca-cert >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
       - run: go mod download
       - env:
           TF_ACC: "1"

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -24,13 +24,6 @@ func TestProvider(t *testing.T) {
 }
 
 func testAccPreCheck(t *testing.T) {
-	// TODO: skipped whilst setting up workflows for acceptance tests
-	if v := os.Getenv("CI"); v != "" {
-		t.Skip("skip running acceptance tests on GitHub Actions")
-	} else {
-		t.Log("no CI environment detected, executing acceptance tests", v)
-	}
-
 	if v := os.Getenv(JujuUsernameEnvKey); v == "" {
 		t.Fatalf("%s must be set for acceptance tests", JujuUsernameEnvKey)
 	}


### PR DESCRIPTION
Integrate automation from Max's `acc-test-actions` branch and allow acceptance tests to run on GitHub Actions.