### PR TITLE
Refactor client connections

### DIFF
--- a/internal/provider/resource_model_test.go
+++ b/internal/provider/resource_model_test.go
@@ -10,8 +10,6 @@ import (
 )
 
 func TestAcc_ResourceModel(t *testing.T) {
-	// TODO: Enable this acceptance test once full CRUD functionality has been coded
-	t.Skip("resource not yet implemented, remove this once you add your own code")
 	modelName := acctest.RandomWithPrefix("tf-test-model")
 
 	resource.Test(t, resource.TestCase{


### PR DESCRIPTION
Refactors the connection handling to pass a ConnectionFactory object to the clients instead of a connection. Each action (for now at least) then creates a connection with or without a model UUID to associate with the connection.