### PR TITLE
Add project decisions relating to the Juju CLI and Connection Factory

### DIFF
--- a/project-docs/decisions/0003-juju-cli-dependency.md
+++ b/project-docs/decisions/0003-juju-cli-dependency.md
@@ -1,0 +1,19 @@
+# Dependency on the Juju CLI Client Store
+
+## Context and Problem Statement
+
+The provider requires information stored under `~/.local/share/juju` to fulfill some of its functionality  – for example the mapping between a model name and its UUID.
+
+This directory is populated and managed by the Juju command-line tool. It is not possible to obtain some information held here via any of the available APIs.   
+
+In code, the directory is accessed via the filesystem-based client store implementation. There is a memory-based implementation, however, this is only used for testing purposes and cannot be populated from a server-side component.
+
+## Decision
+
+The provider is dependent on the configuration and if not present it will not be able to function. 
+
+This limits the provider to running only where `~/.local/share/juju` is available. The MVP will assume the directory and its configuration always exist and an error will be thrown if it doesn't.    
+
+## Recommendation
+
+Our recommendation is to break this dependency as it impacts the flexibility of Terraform.

--- a/project-docs/decisions/0004-connection-factory.md
+++ b/project-docs/decisions/0004-connection-factory.md
@@ -1,0 +1,35 @@
+# Add a connection factory to enable model-specific client connections
+
+## Context and Problem Statement
+
+Mutating a model may only be performed using a connection made with its UUID, for example:
+
+```go
+connr, err := connector.NewSimple(connector.SimpleConfig{
+    ControllerAddresses: "10.43.9.55:17070",
+    Username:            "admin",
+    Password:            "...",
+    CACert:              "...",
+    ModelUUID:           "64e1b6ae-b383-404b-ae09-a48585c96112",
+})
+```
+
+Using a connection with the above configuration we can only modify model `64e1b6ae-b383-404b-ae09-a48585c96112`.
+
+It is not possible to switch the model once a connection is established, you must create a new connection.
+
+The provider creates a single connection without specifying a model, and so we cannot support all model operations.
+
+## Decision
+
+The provider will be refactored to introduce a connection factory that will create connections on-demand. Per-operation a connection will be created with a model UUID and then closed. 
+
+## Concerns
+
+We do not know the impact of opening many short-lived connections on the controller. 
+
+We do not know the impact on provider usability. The connections will scale with the number resources in a Terraform project. This may introduce latency for each operation. 
+
+## Recommendation
+
+Potential concerns may be alleviated by introducing a connection pool, however, we recommend that the connection is not be coupled to a model.

--- a/project-docs/decisions/README.md
+++ b/project-docs/decisions/README.md
@@ -5,5 +5,6 @@ A catalog of project decisions using [MADR][0]. MADR (Markdown Any Decision Reco
 - [Initial Scope of the Juju Terraform Provider](./0001-initial-scope.md)
 - [Options for Controller Authentication](./0002-controller-authentication.md)
 - [Dependency on the Juju CLI Client Store](./0003-juju-cli-dependency.md)
+- [Add a connection factory to enable model-specific client connections](./0004-connection-factory.md)
 
 [0]: https://adr.github.io/madr/

--- a/project-docs/decisions/README.md
+++ b/project-docs/decisions/README.md
@@ -4,5 +4,6 @@ A catalog of project decisions using [MADR][0]. MADR (Markdown Any Decision Reco
 
 - [Initial Scope of the Juju Terraform Provider](./0001-initial-scope.md)
 - [Options for Controller Authentication](./0002-controller-authentication.md)
+- [Dependency on the Juju CLI Client Store](./0003-juju-cli-dependency.md)
 
 [0]: https://adr.github.io/madr/


### PR DESCRIPTION
Adds decisions:

- Dependency on the Juju CLI Client Store
- Add a connection factory to enable model-specific client connections (implemented)