### PR TITLE
Refactor model data source test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,12 +57,10 @@ jobs:
       fail-fast: false
       matrix:
         terraform:
-          - '0.12.*'
-          - '0.13.*'
-          - '0.14.*'
           - '0.15.*'
           - '1.0.*'
           - '1.1.*'
+          - '1.2.*'
 
     steps:
       - uses: actions/checkout@v3

--- a/internal/juju/models.go
+++ b/internal/juju/models.go
@@ -14,12 +14,6 @@ import (
 	"github.com/juju/names/v4"
 )
 
-type Model struct {
-	Name string
-	Type string
-	UUID string
-}
-
 type modelsClient struct {
 	ConnectionFactory
 	store          jujuclient.ClientStore
@@ -50,10 +44,10 @@ func (c *modelsClient) getControllerNameByUUID(uuid string) (*string, error) {
 }
 
 // GetByName retrieves a model by name
-func (c *modelsClient) GetByName(name string) (Model, error) {
+func (c *modelsClient) GetByName(name string) (*params.ModelInfo, error) {
 	conn, err := c.GetConnection(nil)
 	if err != nil {
-		return Model{}, err
+		return nil, err
 	}
 
 	client := modelmanager.NewClient(conn)
@@ -61,7 +55,7 @@ func (c *modelsClient) GetByName(name string) (Model, error) {
 
 	modelDetails, err := c.store.ModelByName(c.controllerName, name)
 	if err != nil {
-		return Model{}, err
+		return nil, err
 	}
 
 	modelTag := names.NewModelTag(modelDetails.ModelUUID)
@@ -70,21 +64,17 @@ func (c *modelsClient) GetByName(name string) (Model, error) {
 		modelTag,
 	})
 	if err != nil {
-		return Model{}, err
+		return nil, err
 	}
 	if results[0].Error != nil {
-		return Model{}, results[0].Error
+		return nil, results[0].Error
 	}
 
 	modelInfo := results[0].Result
 
 	log.Printf("[DEBUG] Reading model: %s, %+v", name, modelInfo)
 
-	return Model{
-		Name: modelInfo.Name,
-		Type: modelInfo.Type,
-		UUID: modelInfo.UUID,
-	}, nil
+	return modelInfo, nil
 }
 
 func (c *modelsClient) Create(name string, controller string, cloudList []interface{}, cloudConfig map[string]interface{}) (*base.ModelInfo, error) {

--- a/internal/provider/data_source_model_test.go
+++ b/internal/provider/data_source_model_test.go
@@ -2,15 +2,10 @@ package provider
 
 import (
 	"fmt"
-	"os/exec"
 	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/juju/juju/cmd/modelcmd"
-	"github.com/juju/juju/jujuclient"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
@@ -29,77 +24,16 @@ func TestAcc_DataSourceModel(t *testing.T) {
 				),
 			},
 		},
-		CheckDestroy: testAccDataSourceModelDestroy,
 	})
 }
 
 func testAccDataSourceModel(t *testing.T, modelName string) string {
-	// TODO: required until we can use a resource to create a model
-	addModel(t, modelName)
-
 	return fmt.Sprintf(`
+resource "juju_model" "model" {
+	name = %q
+}
+
 data "juju_model" "model" {
-  name = %q
+  name = juju_model.model.name
 }`, modelName)
-}
-
-// This function destroys the model created for this test
-func testAccDataSourceModelDestroy(s *terraform.State) error {
-
-	for _, rs := range s.RootModule().Resources {
-		err := destroyModel(rs.Primary.Attributes["name"])
-
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-// addModel adds a model using the Juju command-line
-//
-// This function will be removed once we can support creating a
-// model resource.
-func addModel(t *testing.T, modelName string) {
-	store := modelcmd.QualifyingClientStore{
-		ClientStore: jujuclient.NewFileClientStore(),
-	}
-
-	controllerName, err := store.CurrentController()
-	if err != nil {
-		t.Logf("warning: %s", controllerName)
-		return
-	}
-
-	cmd := exec.Command("juju", "add-model", "--no-switch", modelName)
-
-	err = cmd.Run()
-	if err != nil {
-		t.Fatalf("error whilst creating model %s: %s", modelName, err)
-	}
-}
-
-// destroyModel destroys a model using the Juju command-line
-//
-// This function will be removed once we can support destroying a
-// model resource.
-func destroyModel(modelName string) error {
-	store := modelcmd.QualifyingClientStore{
-		ClientStore: jujuclient.NewFileClientStore(),
-	}
-
-	controllerName, err := store.CurrentController()
-	if err != nil {
-		return fmt.Errorf("warning: %s", controllerName)
-	}
-
-	cmd := exec.Command("juju", "destroy-model", "-y", modelName)
-
-	err = cmd.Run()
-	if err != nil {
-		return fmt.Errorf("error whilst destroying model %s: %s", modelName, err)
-	}
-
-	return nil
 }

--- a/internal/provider/data_source_model_test.go
+++ b/internal/provider/data_source_model_test.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -19,8 +18,7 @@ func TestAcc_DataSourceModel(t *testing.T) {
 			{
 				Config: testAccDataSourceModel(t, modelName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchResourceAttr(
-						"data.juju_model.model", "name", regexp.MustCompile("^"+modelName+"$")),
+					resource.TestCheckResourceAttr("data.juju_model.model", "name", modelName),
 				),
 			},
 		},

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -31,6 +31,15 @@ func testAccPreCheck(t *testing.T) {
 		t.Fatalf("%s must be set for acceptance tests", JujuPasswordEnvKey)
 	}
 	if v := os.Getenv(JujuCACertEnvKey); v == "" {
-		t.Fatalf("%s must be set for acceptance tests", JujuCACertEnvKey)
+		if v := os.Getenv("JUJU_CA_CERT_FILE"); v != "" {
+			t.Logf("reading certificate from: %s", v)
+			cert, err := os.ReadFile(v)
+			if err != nil {
+				t.Fatalf("cannot read file specified by JUJU_CA_CERT_FILE for acceptance tests: %s", err)
+			}
+			os.Setenv(JujuCACertEnvKey, string(cert))
+		} else {
+			t.Fatalf("%s must be set for acceptance tests", JujuCACertEnvKey)
+		}
 	}
 }

--- a/internal/provider/resource_model_test.go
+++ b/internal/provider/resource_model_test.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -21,9 +20,7 @@ func TestAcc_ResourceModel(t *testing.T) {
 			{
 				Config: testAccResourceModel(t, modelName, logLevelInfo),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchResourceAttr(
-						"juju_model.model", "name", regexp.MustCompile("^"+modelName+"$"),
-					),
+					resource.TestCheckResourceAttr("juju_model.model", "name", modelName),
 					resource.TestCheckResourceAttr(
 						"juju_model.model", "config.logging-config", fmt.Sprintf("<root>=%s", logLevelInfo),
 					),
@@ -52,9 +49,7 @@ func TestAcc_ResourceModelImport(t *testing.T) {
 			{
 				Config: testAccResourceModelImport(t, modelName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchResourceAttr(
-						"juju_model.model", "name", regexp.MustCompile("^"+modelName+"$"),
-					),
+					resource.TestCheckResourceAttr("juju_model.model", "name", modelName),
 				),
 			},
 			{


### PR DESCRIPTION
Allow test to create a model without relying on the cli. 

Only test on newer versions of Terraform. Guidance from HashiCorp is to use the v1.0 series as older versions will not see updates - with v0.15.5 being the last pre-1.0 release.

Includes other small changes: 

- a new env-var (`JUJU_CA_CERT_FILE`) for acceptance tests. It allows you to specify a path to a file containing the certificate. This can be used instead of `JUJU_CA_CERT` when it's difficult to set multi-line env-vars,
- make test and `GetByName` more consistent.

