### PR TITLE
adds check for credentials being set in provider

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -73,16 +73,8 @@ func configure(version string, p *schema.Provider) func(context.Context, *schema
 		password := d.Get("password").(string)
 		caCert := d.Get("ca_certificate").(string)
 
-		if !((username != "" && password != "") || (username == "" && password == "")) {
-			diags = append(diags, diag.Diagnostic{
-				Severity: diag.Error,
-				Summary:  "Username and password must both be present or both should be omitted",
-				Detail:   "If only one of username or password is defined, the provider will not be able to authenticate via the credentials method",
-			})
-		}
-
 		//TODO: remove this check when other auth methods are added
-		if username == "" && password == "" {
+		if username == "" || password == "" {
 			diags = append(diags, diag.Diagnostic{
 				Severity: diag.Error,
 				Summary:  "Username and password must be set",

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -81,6 +81,15 @@ func configure(version string, p *schema.Provider) func(context.Context, *schema
 			})
 		}
 
+		//TODO: remove this check when other auth methods are added
+		if username == "" && password == "" {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Error,
+				Summary:  "Username and password must be set",
+				Detail:   "Currently the provider can only authenticate using username and password based authentication, if both are empty the provider will panic",
+			})
+		}
+
 		config := juju.Configuration{
 			ControllerAddresses: ControllerAddresses,
 			Username:            username,


### PR DESCRIPTION
Currently if you do not set the `username` and `password` properties in the provider then it will panic.

```
Exception has occurred: panic
"invalid user tag \"\""
```

this adds a check to the provider that will return a more descriptive error message to the user and allow the provider to fail gracefully.