### PR TITLE
adds client connection test in provider configure

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -82,6 +82,7 @@ func configure(version string, p *schema.Provider) func(context.Context, *schema
 				Summary:  "Username and password must be set",
 				Detail:   "Currently the provider can only authenticate using username and password based authentication, if both are empty the provider will panic",
 			})
+			return nil, diags
 		}
 
 		config := juju.Configuration{

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -95,10 +95,13 @@ func configure(version string, p *schema.Provider) func(context.Context, *schema
 			return nil, diag.FromErr(err)
 		}
 
-		_, err = client.Models.GetConnection(nil)
+		// Here we are testing that we can connect successfully to the Juju server
+		// this prevents having logic to check the connection is OK in every function
+		testConn, err := client.Models.GetConnection(nil)
 		if err != nil {
 			return nil, checkClientErr(err, diags, config)
 		}
+		testConn.Close()
 
 		return client, diags
 	}


### PR DESCRIPTION
This adds a connection test to the provider that will allow us to fail early and provide more useful feedback to the user. Alongside this it adds a check for an unknown authority that will be able to return some hints to the user about the issues in their configuration. 