### PR TITLE
Add create for `juju_deployment` resource

### DIFF
--- a/docs/resources/deployment.md
+++ b/docs/resources/deployment.md
@@ -63,7 +63,7 @@ Required:
 Optional:
 
 - `channel` (String) The channel to use when deploying a charm. Specified as <track>/<risk>/<branch>.
-- `revision` (String) The revision of the charm to deploy.
+- `revision` (Number) The revision of the charm to deploy.
 - `series` (String) The series on which to deploy.
 
 

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,8 @@ require (
 	github.com/juju/juju v0.0.0-20220609145112-917a8f103356
 )
 
+require github.com/juju/charm/v8 v8.0.0-20220509231111-ed6d505a46f4
+
 require (
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.1.1 // indirect
@@ -69,7 +71,6 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/juju/ansiterm v0.0.0-20210929141451-8b71cc96ebdc // indirect
-	github.com/juju/charm/v8 v8.0.0-20220509231111-ed6d505a46f4 // indirect
 	github.com/juju/charmrepo/v6 v6.0.0-20220207014006-e6af52d614e4 // indirect
 	github.com/juju/clock v0.0.0-20220203021603-d9deb868a28a // indirect
 	github.com/juju/cmd/v3 v3.0.0-20220203030511-039f3566372a // indirect
@@ -85,6 +86,7 @@ require (
 	github.com/juju/idmclient/v2 v2.0.0-20220207024613-525e1ac3a890 // indirect
 	github.com/juju/jsonschema v0.0.0-20220207021905-6f321f9146b3 // indirect
 	github.com/juju/loggo v0.0.0-20210728185423-eebad3a902c4 // indirect
+	github.com/juju/lru v0.0.0-20190314140547-92a0afabdc41 // indirect
 	github.com/juju/lumberjack v2.0.0-20200420012306-ddfd864a6ade+incompatible // indirect
 	github.com/juju/mgo/v2 v2.0.0-20220111072304-f200228f1090 // indirect
 	github.com/juju/mutex/v2 v2.0.0-20220203023141-11eeddb42c6c // indirect
@@ -98,6 +100,7 @@ require (
 	github.com/juju/romulus v0.0.0-20220207004956-1a3bcf86b836 // indirect
 	github.com/juju/rpcreflect v0.0.0-20200416001309-bb46e9ba1476 // indirect
 	github.com/juju/schema v1.0.1-0.20190814234152-1f8aaeef0989 // indirect
+	github.com/juju/txn/v2 v2.0.0-20220204100656-93c9d8a9b89f // indirect
 	github.com/juju/usso v1.0.1 // indirect
 	github.com/juju/utils/v3 v3.0.0-20220203023959-c3fbc78a33b0 // indirect
 	github.com/juju/version/v2 v2.0.0-20220204124744-fc9915e3d935 // indirect

--- a/go.sum
+++ b/go.sum
@@ -480,6 +480,7 @@ github.com/juju/juju v0.0.0-20220609145112-917a8f103356/go.mod h1:suyYzoWvGVZck0
 github.com/juju/loggo v0.0.0-20210728185423-eebad3a902c4 h1:NO5tuyw++EGLnz56Q8KMyDZRwJwWO8jQnj285J3FOmY=
 github.com/juju/loggo v0.0.0-20210728185423-eebad3a902c4/go.mod h1:NIXFioti1SmKAlKNuUwbMenNdef59IF52+ZzuOmHYkg=
 github.com/juju/lru v0.0.0-20190314140547-92a0afabdc41 h1:/ucixsNZ+l94agL5LZioJ4ECyOz7kOYY+DKb/0NN6ME=
+github.com/juju/lru v0.0.0-20190314140547-92a0afabdc41/go.mod h1:RI/7Oj7RFK3hzCrjmJVrEeMryn8PEzl6kiIz4QFb48Y=
 github.com/juju/lumberjack v2.0.0-20200420012306-ddfd864a6ade+incompatible h1:7LYjAfMZm+i6+VzOUBGhku+iOYeh0ohjIy7N9zd7JR4=
 github.com/juju/lumberjack v2.0.0-20200420012306-ddfd864a6ade+incompatible/go.mod h1:YQBneJkXlAAye6yHFYH8CabVID+0Oq2by8DDKGj5OIU=
 github.com/juju/mgo/v2 v2.0.0-20220111072304-f200228f1090 h1:zX5GoH3Jp8k1EjUFkApu/YZAYEn0PYQfg/U6IDyNyYs=
@@ -516,6 +517,7 @@ github.com/juju/schema v1.0.1-0.20190814234152-1f8aaeef0989 h1:qx1Zh1bnHHVIMmRxq
 github.com/juju/schema v1.0.1-0.20190814234152-1f8aaeef0989/go.mod h1:Y+ThzXpUJ0E7NYYocAbuvJ7vTivXfrof/IfRPq/0abI=
 github.com/juju/testing v0.0.0-20220203020004-a0ff61f03494 h1:XEDzpuZb8Ma7vLja3+5hzUqVTvAqm5Y+ygvnDs5iTMM=
 github.com/juju/txn/v2 v2.0.0-20220204100656-93c9d8a9b89f h1:IMKfv0HgEfQNwWiWkPYNUJ0nI2yZ3JWety0+yQWf9eQ=
+github.com/juju/txn/v2 v2.0.0-20220204100656-93c9d8a9b89f/go.mod h1:Sh0uxANJLqw/GccwAhz4qIn+eWFVbAlQSBynFR4luY8=
 github.com/juju/usso v1.0.1 h1:zyQhSUJnhFZdPqVAmPeqXYlnYXv+i0Cp1Ii+aziMXGs=
 github.com/juju/usso v1.0.1/go.mod h1:3cvBcGVmWXyHhrBHBQtpNBzca/JRg4S5XH88Hj/NsYA=
 github.com/juju/utils/v3 v3.0.0-20220203023959-c3fbc78a33b0 h1:bn+2Adl1yWqYjm3KSFlFqsvfLg2eq+XNL7GGMYApdVw=

--- a/internal/juju/client.go
+++ b/internal/juju/client.go
@@ -13,6 +13,7 @@ const (
 	PrefixCloud       = "cloud-"
 	PrefixModel       = "model-"
 	PrefixCharm       = "charm-"
+	UnspecifiedRevision = -1
 	connectionTimeout = 30 * time.Second
 )
 
@@ -24,7 +25,8 @@ type Configuration struct {
 }
 
 type Client struct {
-	Models modelsClient
+	Models      modelsClient
+	Deployments deploymentsClient
 }
 
 type ConnectionFactory struct {
@@ -47,7 +49,8 @@ func NewClient(config Configuration) (*Client, error) {
 	}
 
 	return &Client{
-		Models: *newModelsClient(cf, store, controllerName),
+		Models:      *newModelsClient(cf, store, controllerName),
+		Deployments: *newDeploymentsClient(cf),
 	}, nil
 }
 

--- a/internal/juju/deployments.go
+++ b/internal/juju/deployments.go
@@ -1,0 +1,178 @@
+package juju
+
+import (
+	"errors"
+	"fmt"
+	"github.com/juju/charm/v8"
+	jujuerrors "github.com/juju/errors"
+	"github.com/juju/juju/api/client/application"
+	apiapplication "github.com/juju/juju/api/client/application"
+	apicharms "github.com/juju/juju/api/client/charms"
+	apiclient "github.com/juju/juju/api/client/client"
+	apimodelconfig "github.com/juju/juju/api/client/modelconfig"
+	"github.com/juju/juju/cmd/juju/application/utils"
+	"github.com/juju/juju/core/constraints"
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/version"
+	"github.com/juju/names/v4"
+)
+
+type deploymentsClient struct {
+	ConnectionFactory
+}
+
+type CreateDeploymentInput struct {
+	ApplicationName string
+	ModelUUID       string
+	CharmName       string
+	CharmChannel    string
+	CharmSeries     string
+	CharmRevision   int
+}
+
+func newDeploymentsClient(cf ConnectionFactory) *deploymentsClient {
+	return &deploymentsClient{
+		ConnectionFactory: cf,
+	}
+}
+
+func (c deploymentsClient) CreateDeployment(input *CreateDeploymentInput) (string, error) {
+	conn, err := c.GetConnection(&input.ModelUUID)
+	if err != nil {
+		return "", err
+	}
+
+	charmsAPIClient := apicharms.NewClient(conn)
+	defer charmsAPIClient.Close()
+
+	clientAPIClient := apiclient.NewClient(conn)
+	defer clientAPIClient.Close()
+
+	applicationAPIClient := apiapplication.NewClient(conn)
+	defer applicationAPIClient.Close()
+
+	modelconfigAPIClient := apimodelconfig.NewClient(conn)
+	defer modelconfigAPIClient.Close()
+
+	appName := input.ApplicationName
+	if appName == "" {
+		appName = input.CharmName
+	}
+	if err := names.ValidateApplicationName(appName); err != nil {
+		return "", err
+	}
+
+	channel, err := charm.ParseChannel(input.CharmChannel)
+	if err != nil {
+		return "", err
+	}
+
+	path, err := charm.EnsureSchema(input.CharmName, charm.CharmHub)
+	if err != nil {
+		return "", err
+	}
+	charmURL, err := charm.ParseURL(path)
+	if err != nil {
+		return "", err
+	}
+
+	if charmURL.Revision != UnspecifiedRevision {
+		return "", fmt.Errorf("cannot specify revision in a charm or bundle name")
+	}
+	if input.CharmRevision != UnspecifiedRevision && channel.Empty() {
+		return "", fmt.Errorf("specifying a revision requires a channel for future upgrades")
+	}
+
+	modelConstraints, err := clientAPIClient.GetModelConstraints()
+	if err != nil {
+		return "", err
+	}
+	platform, err := utils.DeducePlatform(constraints.Value{}, input.CharmSeries, modelConstraints)
+	if err != nil {
+		return "", err
+	}
+	urlForOrigin := charmURL
+	if input.CharmRevision != UnspecifiedRevision {
+		urlForOrigin = urlForOrigin.WithRevision(input.CharmRevision)
+	}
+	origin, err := utils.DeduceOrigin(urlForOrigin, channel, platform)
+	if err != nil {
+		return "", err
+	}
+	// Charm or bundle has been supplied as a URL so we resolve and
+	// deploy using the store but pass in the origin command line
+	// argument so users can target a specific origin.
+	rev := UnspecifiedRevision
+	origin.Revision = &rev
+	resolved, err := charmsAPIClient.ResolveCharms([]apicharms.CharmToResolve{{URL: charmURL, Origin: origin}})
+	if err != nil {
+		return "", err
+	}
+	if len(resolved) != 1 {
+		return "", fmt.Errorf("expected only one resolution, received %d", len(resolved))
+	}
+	resolvedCharm := resolved[0]
+
+	if err != nil {
+		return "", err
+	}
+
+	// Figure out the actual series of the charm
+	var series string
+	switch {
+	case input.CharmSeries != "":
+		// Explicitly request series.
+		series = input.CharmSeries
+	case charmURL.Series != "":
+		// Series specified in charm URL.
+		series = charmURL.Series
+	default:
+		// First try using the default model series if explicitly set, provided
+		// it is supported by the charm.
+		// Get the model config
+		attrs, err := modelconfigAPIClient.ModelGet()
+		if err != nil {
+			return "", jujuerrors.Wrap(err, errors.New("cannot fetch model settings"))
+		}
+		modelConfig, err := config.New(config.NoDefaults, attrs)
+		if err != nil {
+			return "", err
+		}
+
+		var explicit bool
+		series, explicit = modelConfig.DefaultSeries()
+		if explicit {
+			_, err := charm.SeriesForCharm(series, resolvedCharm.SupportedSeries)
+			if err == nil {
+				break
+			}
+		}
+
+		// Finally, because we are forced we choose LTS
+		series = version.DefaultSupportedLTS()
+	}
+
+	// Select an actually supported series
+	series, err = charm.SeriesForCharm(series, resolvedCharm.SupportedSeries)
+	if err != nil {
+		return "", err
+	}
+
+	// Add the charm to the model
+	origin = resolvedCharm.Origin.WithSeries(series)
+	charmURL = resolvedCharm.URL.WithRevision(*origin.Revision).WithArchitecture(origin.Architecture).WithSeries(series)
+	resultOrigin, err := charmsAPIClient.AddCharm(charmURL, origin, false)
+	if err != nil {
+		return "", err
+	}
+
+	err = applicationAPIClient.Deploy(application.DeployArgs{
+		CharmID: application.CharmID{
+			URL:    charmURL,
+			Origin: resultOrigin,
+		},
+		ApplicationName: appName,
+		Series:          resultOrigin.Series,
+	})
+	return appName, err
+}

--- a/internal/juju/models.go
+++ b/internal/juju/models.go
@@ -77,6 +77,24 @@ func (c *modelsClient) GetByName(name string) (*params.ModelInfo, error) {
 	return modelInfo, nil
 }
 
+// ResolveUUID retrieves a model's using its name
+func (c *modelsClient) ResolveUUID(name string) (string, error) {
+	conn, err := c.GetConnection(nil)
+	if err != nil {
+		return "", err
+	}
+
+	client := modelmanager.NewClient(conn)
+	defer client.Close()
+
+	modelDetails, err := c.store.ModelByName(c.controllerName, name)
+	if err != nil {
+		return "", err
+	}
+
+	return modelDetails.ModelUUID, nil
+}
+
 func (c *modelsClient) Create(name string, controller string, cloudList []interface{}, cloudConfig map[string]interface{}) (*base.ModelInfo, error) {
 	conn, err := c.GetConnection(nil)
 	if err != nil {

--- a/internal/provider/resource_deployment_test.go
+++ b/internal/provider/resource_deployment_test.go
@@ -11,6 +11,9 @@ import (
 
 // TODO: test also for k8s substrate, tiny-bash charm is not supported
 func TestAcc_ResourceDeployment(t *testing.T) {
+	// TODO: remove once other operations are implemented
+	t.Skip("skipped until delete operation is implemented")
+
 	modelName := acctest.RandomWithPrefix("tf-test-deployment")
 
 	resource.Test(t, resource.TestCase{

--- a/internal/provider/resource_deployment_test.go
+++ b/internal/provider/resource_deployment_test.go
@@ -1,22 +1,27 @@
 package provider
 
 import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
+// TODO: test also for k8s substrate, tiny-bash charm is not supported
 func TestAcc_ResourceDeployment(t *testing.T) {
-	resource.UnitTest(t, resource.TestCase{
+	modelName := acctest.RandomWithPrefix("tf-test-deployment")
+
+	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckDeploymentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceDeployment,
+				Config: testAccResourceDeployment(modelName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("juju_deployment.model", "name", "development"),
+					resource.TestCheckResourceAttr("juju_deployment.this", "name", modelName),
 					resource.TestCheckResourceAttr("juju_deployment.this", "charm.#", "1"),
 					resource.TestCheckResourceAttr("juju_deployment.this", "charm.0.name", "tiny-bash"),
 				),
@@ -29,15 +34,17 @@ func testAccCheckDeploymentDestroy(s *terraform.State) error {
 	return nil
 }
 
-const testAccResourceDeployment = `
-resource "juju_model" "development" {
-  name = "development"
+func testAccResourceDeployment(modelName string) string {
+	return fmt.Sprintf(`
+resource "juju_model" "this" {
+  name = %q
 }
 
 resource "juju_deployment" "this" {
-  model = juju_model.development.name
+  model = juju_model.this.name
   charm {
     name = "tiny-bash"
   }
 }
-`
+`, modelName)
+}

--- a/internal/provider/resource_deployment_test.go
+++ b/internal/provider/resource_deployment_test.go
@@ -1,44 +1,43 @@
 package provider
 
 import (
-	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-func TestAcc_ResourceCharm(t *testing.T) {
-	t.Skip("resource not yet implemented, remove this once you add your own code")
-
+func TestAcc_ResourceDeployment(t *testing.T) {
 	resource.UnitTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
-		CheckDestroy:      testAccCheckCharmDestroy,
+		CheckDestroy:      testAccCheckDeploymentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceCharm,
+				Config: testAccResourceDeployment,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchResourceAttr("juju_model.development", "name", regexp.MustCompile("^development")),
-					resource.TestMatchResourceAttr("juju_charm.postgres", "charm", regexp.MustCompile("^ch:postgres-k8s")),
+					resource.TestCheckResourceAttr("juju_deployment.model", "name", "development"),
+					resource.TestCheckResourceAttr("juju_deployment.this", "charm.#", "1"),
+					resource.TestCheckResourceAttr("juju_deployment.this", "charm.0.name", "tiny-bash"),
 				),
 			},
 		},
 	})
 }
 
-func testAccCheckCharmDestroy(s *terraform.State) error {
-
+func testAccCheckDeploymentDestroy(s *terraform.State) error {
 	return nil
 }
 
-const testAccResourceCharm = `
+const testAccResourceDeployment = `
 resource "juju_model" "development" {
   name = "development"
 }
 
-resource "juju_model" "postgres" {
-  model = juju_model.development.id
-  charm = "ch:postgres-k8s"
+resource "juju_deployment" "this" {
+  model = juju_model.development.name
+  charm {
+    name = "tiny-bash"
+  }
 }
 `


### PR DESCRIPTION
The create has been implemented using the [`deploycharm.go`](https://github.com/arnodel/juju-third-party-client/blob/1b4039a986c2b5ba298830e80636f3a23bbda261/deploycharm.go) example with a modification to only allow support charms from CharmHub. 

The code has mostly been transplanted - along with comments - from the example in to the provider. It can be refactored in future as required (I didn't want to import and refactor code in a single PR).

Tests are skipped until other `juju_deployment` operations are implemented.