### PR TITLE
Release v0.1.0 preparation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,17 +25,18 @@ jobs:
         with:
           go-version-file: 'go.mod'
           cache: true
+      # TODO: allow signing artifacts (see Card #75)
       # This uses an action (hashicorp/ghaction-import-gpg) that assumes you set your
       # private key in the `GPG_PRIVATE_KEY` secret and passphrase in the `PASSPHRASE`
       # secret. If you would rather own your own GPG handling, please fork this action
       # or use an alternative one for key handling.
-      - name: Import GPG key
-        id: import_gpg
-        uses: hashicorp/ghaction-import-gpg@v2.1.0
-        env:
-          # These secrets will need to be configured for the repository:
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-          PASSPHRASE: ${{ secrets.PASSPHRASE }}
+      #      - name: Import GPG key
+      #        id: import_gpg
+      #        uses: hashicorp/ghaction-import-gpg@v2.1.0
+      #        env:
+      #          # These secrets will need to be configured for the repository:
+      #          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+      #          PASSPHRASE: ${{ secrets.PASSPHRASE }}
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3
         with:
@@ -43,4 +44,5 @@ jobs:
         env:
           # GitHub sets the GITHUB_TOKEN secret automatically.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
+          # TODO: allow signing artifacts (see Card #75)
+          # GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,8 +2,8 @@
 # behavior.
 before:
   hooks:
-    # this is just an example and not a requirement for provider building/publishing
-    - go mod tidy
+    # TODO: don't tidy beforehand to avoid current ambiguous import error
+    # - go mod tidy
 builds:
 - env:
     # goreleaser does not work with CGO, it could also complicate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
-## 0.1.0 (Unreleased)
+## 0.2.0 (Unreleased)
+
+## 0.1.0 (June 27, 2022)
+
+NOTES:
+
+* provider: The provider has a dependency on Juju CLI configuration store. It expects configuration to be found in either `$XDG_DATA_HOME/juju` or `~/.local/share/juju`.
 
 FEATURES:
+
+* **New Data Source:** `juju_model`
+* **New Resource:** `juju_model`


### PR DESCRIPTION
Includes:

- Temporarily disable code signing,
- Tweaks to Go releaser
- Update `CHANGELOG.md`