### PR TITLE
Remove release workflow timeout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,6 @@ permissions:
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
It's taking far longer than expected, but we need it to complete so removing limit again.