### PR TITLE
Restrict release compilation to darwin and linux

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,8 +16,9 @@ builds:
   ldflags:
     - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}'
   goos:
-    - freebsd
-    - windows
+    # TODO: remove restriction
+    # - freebsd
+    # - windows
     - linux
     - darwin
   goarch:


### PR DESCRIPTION
Add restriction temporarily until issues with windows and freebsd can be investigated.