### PR TITLE
adds units property to deployment

### DIFF
--- a/internal/juju/deployments.go
+++ b/internal/juju/deployments.go
@@ -3,6 +3,7 @@ package juju
 import (
 	"errors"
 	"fmt"
+
 	"github.com/juju/charm/v8"
 	jujuerrors "github.com/juju/errors"
 	"github.com/juju/juju/api/client/application"
@@ -28,6 +29,7 @@ type CreateDeploymentInput struct {
 	CharmChannel    string
 	CharmSeries     string
 	CharmRevision   int
+	Units           int
 }
 
 func newDeploymentsClient(cf ConnectionFactory) *deploymentsClient {
@@ -172,6 +174,7 @@ func (c deploymentsClient) CreateDeployment(input *CreateDeploymentInput) (strin
 			Origin: resultOrigin,
 		},
 		ApplicationName: appName,
+		NumUnits:        input.Units,
 		Series:          resultOrigin.Series,
 	})
 	return appName, err

--- a/internal/provider/resource_deployment.go
+++ b/internal/provider/resource_deployment.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/juju/terraform-provider-juju/internal/juju"
@@ -91,6 +92,7 @@ func resourceDeploymentCreate(ctx context.Context, d *schema.ResourceData, meta 
 	channel := charm["channel"].(string)
 	revision := charm["revision"].(int)
 	series := charm["series"].(string)
+	units := d.Get("units").(int)
 
 	deployedName, err := client.Deployments.CreateDeployment(&juju.CreateDeploymentInput{
 		ApplicationName: name,
@@ -99,6 +101,7 @@ func resourceDeploymentCreate(ctx context.Context, d *schema.ResourceData, meta 
 		CharmChannel:    channel,
 		CharmRevision:   revision,
 		CharmSeries:     series,
+		Units:           units,
 	})
 	if err != nil {
 		return diag.FromErr(err)


### PR DESCRIPTION
This fixes a previous issue with deployments where they were defaulting to 0 units by passing the Units property through from the provider to the client