### PR TITLE
Implement juju deployment delete

### DIFF
--- a/internal/juju/deployments.go
+++ b/internal/juju/deployments.go
@@ -32,6 +32,11 @@ type CreateDeploymentInput struct {
 	Units           int
 }
 
+type DestroyDeploymentInput struct {
+	ApplicationName string
+	ModelUUID       string
+}
+
 func newDeploymentsClient(cf ConnectionFactory) *deploymentsClient {
 	return &deploymentsClient{
 		ConnectionFactory: cf,
@@ -178,4 +183,29 @@ func (c deploymentsClient) CreateDeployment(input *CreateDeploymentInput) (strin
 		Series:          resultOrigin.Series,
 	})
 	return appName, err
+}
+
+func (c deploymentsClient) DestroyDeployment(input *DestroyDeploymentInput) error {
+	conn, err := c.GetConnection(&input.ModelUUID)
+	if err != nil {
+		return err
+	}
+
+	applicationAPIClient := apiapplication.NewClient(conn)
+	defer applicationAPIClient.Close()
+
+	var destroyParams = apiapplication.DestroyApplicationsParams{
+		Applications: []string{
+			input.ApplicationName,
+		},
+		DestroyStorage: true,
+	}
+
+	_, err = applicationAPIClient.DestroyApplications(destroyParams)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/internal/provider/resource_deployment_test.go
+++ b/internal/provider/resource_deployment_test.go
@@ -2,8 +2,9 @@ package provider
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -12,7 +13,7 @@ import (
 // TODO: test also for k8s substrate, tiny-bash charm is not supported
 func TestAcc_ResourceDeployment(t *testing.T) {
 	// TODO: remove once other operations are implemented
-	t.Skip("skipped until delete operation is implemented")
+	t.Skip("skipped until read operation is implemented")
 
 	modelName := acctest.RandomWithPrefix("tf-test-deployment")
 
@@ -24,7 +25,7 @@ func TestAcc_ResourceDeployment(t *testing.T) {
 			{
 				Config: testAccResourceDeployment(modelName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("juju_deployment.this", "name", modelName),
+					resource.TestCheckResourceAttr("juju_deployment.this", "model", modelName),
 					resource.TestCheckResourceAttr("juju_deployment.this", "charm.#", "1"),
 					resource.TestCheckResourceAttr("juju_deployment.this", "charm.0.name", "tiny-bash"),
 				),


### PR DESCRIPTION
This implements the Delete action for `juju_deployment`.

Note This is known in Juju as `destroy` rather than delete so the client has a method Destroy that is called by the provider's delete command.

Tests are currently skipped pending read:
```
=== RUN   TestAcc_ResourceDeployment
    resource_deployment_test.go:20: Step 1/1 error: Error running post-apply refresh: exit status 1
        
        Error: not implemented
        
          with juju_deployment.this,
          on terraform_plugin_test.tf line 6, in resource "juju_deployment" "this":
           6: resource "juju_deployment" "this" {
        
--- FAIL: TestAcc_ResourceDeployment (4.01s)
```