### PR TITLE
adds check for os in x509 test

### DIFF
--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"os"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -82,29 +83,37 @@ const (
 	invalidCA = "-----BEGIN CERTIFICATE-----\nMIIDazCCAlOgAwIBAgIULHtYyq/mjGAaZTTFcfd4Dmi6LtkwDQYJKoZIhvcNAQEL\nBQAwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoM\nGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDAeFw0yMjA2MjQxNTQzMTFaFw0yMjA3\nMjQxNTQzMTFaMEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEw\nHwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwggEiMA0GCSqGSIb3DQEB\nAQUAA4IBDwAwggEKAoIBAQCgSrxunimy/Nig3y5mAUtc3quvJI7MVdlWrhhWcNP4\nacF6bsAYDMa02Praf3pUBkyU9Fe83nalcimVO1NO18/FvKK4ZYuwQi4B+Rx1ltF/\nZx5czxrH+kb9FsZJNAtxbAo0hT9rusuCd1m0zhzSOZCTWkmguDew41IQHUtW7Wgy\nM0TlmrCzJkf2w+GwmhxFbJLR37b7N2ylyrFyuLTEKSMAxSw7k4+Djqgat5NdVGmo\niTZST86Br9Xg+goVjFTHxj/f84OaazM6DhyIdizyntkIV6nZVxZmhisO9iWk41Q/\noPeN4ZYUCe+VpZoZShMZ7H281tOYfgCOP2IHyQxxwLQBAgMBAAGjUzBRMB0GA1Ud\nDgQWBBS1ziAYMPkbTHaOfgpKlX70/wkusDAfBgNVHSMEGDAWgBS1ziAYMPkbTHaO\nfgpKlX70/wkusDAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQAN\n76z4TTrH5Wj7nPBROyx9Ab3TCF+gSqi2lhxCo5obtdAUdnfsbTtIGH82Ayduz13R\nvWcqn0EXgi2jJ8fMQxujalBwqhw2BPLgXPhIlR8/IcvUp9CIQA3FasvqNrSrfUzJ\ntO9oA3LG5EGnlxeDS5ehkx/bAOQl4yz70Vh+xssU/E5T74Zb8Kgf8uSZbj2jbRh7\nBC4qYzO7jVFOLkIWUjIeKlE2iG3OJnb17NMuODApPLyRslKvRyxwITtWr/jhaTNQ\n4L64mCtPPU2bMLScqsEYDOx237na8m9Xej6MOGb1D4noe59ML/4IwCmG2iK982mQ\n2zpE+UCo97FGq4kDK6bc\n-----END CERTIFICATE-----\n"
 )
 
+//TODO: find an alternative way of running test on Mac
 func TestProviderConfigurex509(t *testing.T) {
-	provider := New("dev")()
-	t.Setenv(JujuCACertEnvKey, "")
-	t.Setenv("JUJU_CA_CERT_FILE", "")
-	diags := provider.Configure(context.Background(), terraform.NewResourceConfigRaw(nil))
-	if diags == nil {
-		//In case the CA is in the system trust store we want to verify error functionality
-		//setting this property to an invalid CA will test both parts of our error
-		//Juju will ignore the system trust store if we set the CA property
-		t.Setenv(JujuCACertEnvKey, invalidCA)
-		diags = provider.Configure(context.Background(), terraform.NewResourceConfigRaw(nil))
+	switch runtime.GOOS {
+	case "darwin":
+		//Due to a bug in Go this test does not work on darwin OS
+		//https://github.com/golang/go/issues/52010
+		t.Skip("This test does not work on MacOS")
+	default:
+		provider := New("dev")()
+		t.Setenv(JujuCACertEnvKey, "")
+		t.Setenv("JUJU_CA_CERT_FILE", "")
+		diags := provider.Configure(context.Background(), terraform.NewResourceConfigRaw(nil))
 		if diags == nil {
-			t.Fatal("provider should error")
+			//In case the CA is in the system trust store we want to verify error functionality
+			//setting this property to an invalid CA will test both parts of our error
+			//Juju will ignore the system trust store if we set the CA property
+			t.Setenv(JujuCACertEnvKey, invalidCA)
+			diags = provider.Configure(context.Background(), terraform.NewResourceConfigRaw(nil))
+			if diags == nil {
+				t.Fatal("provider should error")
+			} else {
+				err := diags[len(diags)-1]
+				if err.Detail != "Verify the ca_certificate property set on the provider" {
+					t.Errorf("unexpected error: %+v", err)
+				}
+			}
 		} else {
 			err := diags[len(diags)-1]
-			if err.Detail != "Verify the ca_certificate property set on the provider" {
+			if err.Detail != "The ca_certificate provider property is not set and the Juju certificate authority is not trusted by your system" {
 				t.Errorf("unexpected error: %+v", err)
 			}
-		}
-	} else {
-		err := diags[len(diags)-1]
-		if err.Detail != "The ca_certificate provider property is not set and the Juju certificate authority is not trusted by your system" {
-			t.Errorf("unexpected error: %+v", err)
 		}
 	}
 }


### PR DESCRIPTION
This modifies the x509 test that relies on the system trust store to skip on MacOS.

Related go issue:
https://github.com/golang/go/issues/52010
