### PR TITLE
Enable import for `juju_deployment`

### DIFF
--- a/internal/juju/client.go
+++ b/internal/juju/client.go
@@ -10,11 +10,11 @@ import (
 )
 
 const (
-	PrefixCloud       = "cloud-"
-	PrefixModel       = "model-"
-	PrefixCharm       = "charm-"
+	PrefixCloud         = "cloud-"
+	PrefixModel         = "model-"
+	PrefixCharm         = "charm-"
 	UnspecifiedRevision = -1
-	connectionTimeout = 30 * time.Second
+	connectionTimeout   = 30 * time.Second
 )
 
 type Configuration struct {

--- a/internal/provider/resource_deployment_test.go
+++ b/internal/provider/resource_deployment_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-// TODO: test also for k8s substrate, tiny-bash charm is not supported
 func TestAcc_ResourceDeployment(t *testing.T) {
 	modelName := acctest.RandomWithPrefix("tf-test-deployment")
 
@@ -24,6 +23,11 @@ func TestAcc_ResourceDeployment(t *testing.T) {
 					resource.TestCheckResourceAttr("juju_deployment.this", "charm.#", "1"),
 					resource.TestCheckResourceAttr("juju_deployment.this", "charm.0.name", "tiny-bash"),
 				),
+			},
+			{
+				ImportStateVerify: true,
+				ImportState:       true,
+				ResourceName:      "juju_deployment.this",
 			},
 		},
 	})

--- a/internal/provider/resource_model.go
+++ b/internal/provider/resource_model.go
@@ -23,7 +23,6 @@ func resourceModel() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			// TODO: this needs to be reviewed
 			"name": {
 				Description: "The name to be assigned to the model",
 				Type:        schema.TypeString,


### PR DESCRIPTION
This PR will enable the ability to import an existing juju deployment by specifying its ID (modelName:appName)

** Known Issue **
As the API cannot currently record and return the charm channel information, this has to be backfilled. It populates the state with the default value "latest/stable", which will resolve consistently unless a channel other than "latest/stable" is explicitly defined.