### PR TITLE
FIX: Allow deployment revision selection in create

### DIFF
--- a/internal/juju/deployments.go
+++ b/internal/juju/deployments.go
@@ -4,9 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-
 	"github.com/juju/juju/rpc/params"
-
 	"time"
 
 	"github.com/juju/charm/v8"
@@ -203,7 +201,15 @@ func (c deploymentsClient) CreateDeployment(input *CreateDeploymentInput) (*Crea
 
 	// Add the charm to the model
 	origin = resolvedCharm.Origin.WithSeries(series)
-	charmURL = resolvedCharm.URL.WithRevision(*origin.Revision).WithArchitecture(origin.Architecture).WithSeries(series)
+
+	var deployRevision int
+	if input.CharmRevision > -1 {
+		deployRevision = input.CharmRevision
+	} else {
+		deployRevision = *origin.Revision
+	}
+
+	charmURL = resolvedCharm.URL.WithRevision(deployRevision).WithArchitecture(origin.Architecture).WithSeries(series)
 	resultOrigin, err := charmsAPIClient.AddCharm(charmURL, origin, false)
 	if err != nil {
 		return nil, err

--- a/internal/provider/resource_deployment.go
+++ b/internal/provider/resource_deployment.go
@@ -100,9 +100,12 @@ func resourceDeploymentCreate(ctx context.Context, d *schema.ResourceData, meta 
 	charm := d.Get("charm").([]interface{})[0].(map[string]interface{})
 	charmName := charm["name"].(string)
 	channel := charm["channel"].(string)
-	revision := charm["revision"].(int)
 	series := charm["series"].(string)
 	units := d.Get("units").(int)
+	revision := charm["revision"].(int)
+	if _, exist := d.GetOk("charm.0.revision"); !exist {
+		revision = -1
+	}
 
 	response, err := client.Deployments.CreateDeployment(&juju.CreateDeploymentInput{
 		ApplicationName: name,


### PR DESCRIPTION
This PR will fix revision selection. Previously, the latest available revision was always being selected regardless of any explicitly defined revision.

The behaviour now reflects the behaviour of the CLI where no explicit value for revision will select the latest, but any defined value will be honoured