### PR TITLE
renames model client functions to verb-noun naming pattern

### DIFF
--- a/internal/juju/models.go
+++ b/internal/juju/models.go
@@ -3,9 +3,10 @@ package juju
 import (
 	"errors"
 	"fmt"
-	"github.com/juju/juju/api/client/modelconfig"
 	"log"
 	"time"
+
+	"github.com/juju/juju/api/client/modelconfig"
 
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/client/modelmanager"
@@ -43,8 +44,8 @@ func (c *modelsClient) getControllerNameByUUID(uuid string) (*string, error) {
 	return nil, errors.New(fmt.Sprintf("cannot find controller name from uuid: %s", uuid))
 }
 
-// GetByName retrieves a model by name
-func (c *modelsClient) GetByName(name string) (*params.ModelInfo, error) {
+// GetModelByName retrieves a model by name
+func (c *modelsClient) GetModelByName(name string) (*params.ModelInfo, error) {
 	conn, err := c.GetConnection(nil)
 	if err != nil {
 		return nil, err
@@ -77,8 +78,8 @@ func (c *modelsClient) GetByName(name string) (*params.ModelInfo, error) {
 	return modelInfo, nil
 }
 
-// ResolveUUID retrieves a model's using its name
-func (c *modelsClient) ResolveUUID(name string) (string, error) {
+// ResolveModelUUID retrieves a model's using its name
+func (c *modelsClient) ResolveModelUUID(name string) (string, error) {
 	conn, err := c.GetConnection(nil)
 	if err != nil {
 		return "", err
@@ -95,7 +96,7 @@ func (c *modelsClient) ResolveUUID(name string) (string, error) {
 	return modelDetails.ModelUUID, nil
 }
 
-func (c *modelsClient) Create(name string, controller string, cloudList []interface{}, cloudConfig map[string]interface{}) (*base.ModelInfo, error) {
+func (c *modelsClient) CreateModel(name string, controller string, cloudList []interface{}, cloudConfig map[string]interface{}) (*base.ModelInfo, error) {
 	conn, err := c.GetConnection(nil)
 	if err != nil {
 		return nil, err
@@ -148,7 +149,7 @@ func (c *modelsClient) Create(name string, controller string, cloudList []interf
 	return &modelInfo, nil
 }
 
-func (c *modelsClient) Read(uuid string) (*string, *params.ModelInfo, map[string]interface{}, error) {
+func (c *modelsClient) ReadModel(uuid string) (*string, *params.ModelInfo, map[string]interface{}, error) {
 	modelmanagerConn, err := c.GetConnection(nil)
 	if err != nil {
 		return nil, nil, nil, err
@@ -191,7 +192,7 @@ func (c *modelsClient) Read(uuid string) (*string, *params.ModelInfo, map[string
 	return controllerName, modelInfo, modelConfig, nil
 }
 
-func (c *modelsClient) Update(uuid string, config map[string]interface{}, unset []string) error {
+func (c *modelsClient) UpdateModel(uuid string, config map[string]interface{}, unset []string) error {
 	conn, err := c.GetConnection(&uuid)
 	if err != nil {
 		return err
@@ -213,7 +214,7 @@ func (c *modelsClient) Update(uuid string, config map[string]interface{}, unset 
 	return nil
 }
 
-func (c *modelsClient) Destroy(uuid string) error {
+func (c *modelsClient) DestroyModel(uuid string) error {
 	conn, err := c.GetConnection(nil)
 	if err != nil {
 		return err

--- a/internal/provider/data_source_model.go
+++ b/internal/provider/data_source_model.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/juju/terraform-provider-juju/internal/juju"
@@ -31,7 +32,7 @@ func dataSourceModelRead(ctx context.Context, d *schema.ResourceData, meta inter
 
 	modelName := d.Get("name").(string)
 
-	model, err := client.Models.GetByName(modelName)
+	model, err := client.Models.GetModelByName(modelName)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/internal/provider/resource_deployment.go
+++ b/internal/provider/resource_deployment.go
@@ -3,10 +3,11 @@ package provider
 import (
 	"context"
 	"fmt"
+	"strings"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/juju/terraform-provider-juju/internal/juju"
-	"strings"
 )
 
 func resourceDeployment() *schema.Resource {
@@ -91,7 +92,7 @@ func resourceDeploymentCreate(ctx context.Context, d *schema.ResourceData, meta 
 	client := meta.(*juju.Client)
 
 	modelName := d.Get("model").(string)
-	modelUUID, err := client.Models.ResolveUUID(modelName)
+	modelUUID, err := client.Models.ResolveModelUUID(modelName)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -137,7 +138,7 @@ func resourceDeploymentRead(ctx context.Context, d *schema.ResourceData, meta in
 	client := meta.(*juju.Client)
 	id := strings.Split(d.Id(), ":")
 	modelName, appName := id[0], id[1]
-	modelUUID, err := client.Models.ResolveUUID(modelName)
+	modelUUID, err := client.Models.ResolveModelUUID(modelName)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -204,7 +205,7 @@ func resourceDeploymentDelete(ctx context.Context, d *schema.ResourceData, meta 
 	client := meta.(*juju.Client)
 
 	modelName := d.Get("model").(string)
-	modelUUID, err := client.Models.ResolveUUID(modelName)
+	modelUUID, err := client.Models.ResolveModelUUID(modelName)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/internal/provider/resource_model.go
+++ b/internal/provider/resource_model.go
@@ -83,7 +83,7 @@ func resourceModelCreate(ctx context.Context, d *schema.ResourceData, meta inter
 	cloud := d.Get("cloud").([]interface{})
 	config := d.Get("config").(map[string]interface{})
 
-	modelInfo, err := client.Models.Create(name, controller, cloud, config)
+	modelInfo, err := client.Models.CreateModel(name, controller, cloud, config)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -102,7 +102,7 @@ func resourceModelRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	var diags diag.Diagnostics
 
 	uuid := d.Id()
-	controllerName, modelInfo, modelConfig, err := client.Models.Read(uuid)
+	controllerName, modelInfo, modelConfig, err := client.Models.ReadModel(uuid)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -169,7 +169,7 @@ func resourceModelUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 			}
 		}
 
-		err := client.Models.Update(modelUUID, newConfigMap, unsetConfigKeys)
+		err := client.Models.UpdateModel(modelUUID, newConfigMap, unsetConfigKeys)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -187,7 +187,7 @@ func resourceModelDelete(ctx context.Context, d *schema.ResourceData, meta inter
 
 	modelUUID := d.Id()
 
-	err := client.Models.Destroy(modelUUID)
+	err := client.Models.DestroyModel(modelUUID)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -204,7 +204,7 @@ func resourceModelImporter(ctx context.Context, d *schema.ResourceData, meta int
 	//because we import based on model name we load it into `modelName` here for clarity
 	modelName := d.Id()
 
-	model, err := client.Models.GetByName(modelName)
+	model, err := client.Models.GetModelByName(modelName)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/provider/resource_model_test.go
+++ b/internal/provider/resource_model_test.go
@@ -2,11 +2,12 @@ package provider
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/juju/juju/api/client/modelconfig"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/terraform-provider-juju/internal/juju"
-	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -89,7 +90,7 @@ func testAccCheckDevelopmentConfigIsUnset(modelName string) resource.TestCheckFu
 	return func(s *terraform.State) error {
 		client := Provider.Meta().(*juju.Client)
 
-		uuid, err := client.Models.ResolveUUID(modelName)
+		uuid, err := client.Models.ResolveModelUUID(modelName)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Function naming should follow the verb-noun pattern, e.g. CreateFoo, DeleteFoo etc... This style has been introduced in the deployment resource.

See the attached conversation for more context: 
https://github.com/juju/terraform-provider-juju/pull/23#discussion_r907171064
