### PR TITLE
Add create for `juju_integration` resource

### DIFF
--- a/docs/resources/integration.md
+++ b/docs/resources/integration.md
@@ -33,7 +33,7 @@ resource "juju_integration" "this" {
 
 ### Required
 
-- `application` (Block List, Min: 1, Max: 2) The two applications to integrate. (see [below for nested schema](#nestedblock--application))
+- `application` (Block List, Min: 2, Max: 2) The two applications to integrate. (see [below for nested schema](#nestedblock--application))
 - `model` (String) The name of the model to operate in.
 
 ### Read-Only

--- a/internal/juju/client.go
+++ b/internal/juju/client.go
@@ -27,6 +27,7 @@ type Configuration struct {
 type Client struct {
 	Models       modelsClient
 	Applications applicationsClient
+	Integrations integrationsClient
 }
 
 type ConnectionFactory struct {
@@ -51,6 +52,7 @@ func NewClient(config Configuration) (*Client, error) {
 	return &Client{
 		Models:       *newModelsClient(cf, store, controllerName),
 		Applications: *newApplicationClient(cf),
+		Integrations: *newIntegrationsClient(cf),
 	}, nil
 }
 

--- a/internal/juju/integrations.go
+++ b/internal/juju/integrations.go
@@ -1,0 +1,103 @@
+package juju
+
+import (
+	"fmt"
+	"strings"
+
+	apiapplication "github.com/juju/juju/api/client/application"
+	"github.com/juju/juju/rpc/params"
+	"github.com/juju/names/v4"
+)
+
+type integrationsClient struct {
+	ConnectionFactory
+}
+
+type CreateIntegrationInput struct {
+	ModelUUID string
+	Endpoints []string
+}
+
+type CreateIntegrationResponse struct {
+	Endpoints map[string]params.CharmRelation
+}
+
+func newIntegrationsClient(cf ConnectionFactory) *integrationsClient {
+	return &integrationsClient{
+		ConnectionFactory: cf,
+	}
+}
+
+func (c integrationsClient) CreateIntegration(input *CreateIntegrationInput) (*CreateIntegrationResponse, error) {
+	conn, err := c.GetConnection(&input.ModelUUID)
+	if err != nil {
+		return nil, err
+	}
+
+	client := apiapplication.NewClient(conn)
+	defer client.Close()
+
+	var endpoints []string = input.Endpoints
+
+	for i := range endpoints {
+		val, err := validateEndpoint(endpoints[i], client)
+		if err != nil {
+			return nil, err
+		}
+		endpoints[i] = val
+	}
+
+	response, err := client.AddRelation(
+		endpoints,
+		[]string(nil),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := CreateIntegrationResponse{
+		Endpoints: response.Endpoints,
+	}
+
+	return &resp, nil
+}
+
+func validateEndpoint(endpoint string, client *apiapplication.Client) (string, error) {
+	var separator string = ":"
+	spl := strings.Split(endpoint, separator)
+
+	if spl[1] == "" {
+		return getDefaultEndpoint(spl[0], client)
+	}
+
+	return endpoint, nil
+}
+
+func getDefaultEndpoint(applicationName string, client *apiapplication.Client) (string, error) {
+
+	apps, err := client.ApplicationsInfo([]names.ApplicationTag{names.NewApplicationTag(applicationName)})
+	if err != nil {
+		return "", err
+	}
+	if len(apps) > 1 || len(apps) == 0 {
+		return "", fmt.Errorf("unable to find single application called %s", applicationName)
+	}
+	endpointBindings := apps[0].Result.EndpointBindings
+
+	// charms always return an empty binding in addition to the endpoints it provides
+	if len(endpointBindings) <= 2 {
+		var endpoint string
+		//TODO: validate safety of deleting this item
+		for val := range endpointBindings {
+			if val == "" {
+				delete(endpointBindings, val)
+			} else {
+				endpoint = val
+			}
+		}
+		return fmt.Sprintf("%v:%v", applicationName, endpoint), nil
+	}
+
+	//TODO: reconcile with default juju behaviour that will match endpoints without specifying
+	return "", fmt.Errorf("unable to discern a default endpoint for %s", applicationName)
+}

--- a/internal/provider/resource_integration_test.go
+++ b/internal/provider/resource_integration_test.go
@@ -40,7 +40,7 @@ resource "juju_model" "this" {
 	name = %q
 }
 
-resource "juju_deployment" "one" {
+resource "juju_application" "one" {
 	model = juju_model.this.name
 	name  = "one" 
 	
@@ -49,7 +49,7 @@ resource "juju_deployment" "one" {
 	}
 }
 
-resource "juju_deployment" "two" {
+resource "juju_application" "two" {
 	model = juju_model.this.name
 	name  = "two"
 
@@ -62,11 +62,11 @@ resource "juju_integration" "this" {
 	model = juju_model.this.name
 
 	application {
-		name = juju_deployment.one.name
+		name = juju_application.one.name
 	}
 
 	application {
-		name     = juju_deployment.two.name
+		name     = juju_application.two.name
 		endpoint = "db"
 	}
 }


### PR DESCRIPTION
Create has been implemented to have parity with the CLI behaviour - it relies on server side validation to allow inferred endpoints.

pending ~~#45 &~~ closure of https://trello.com/c/K0F0RD7o/72-create-deployment-release