### PR TITLE
adds check for resolvedCharm.Error

### DIFF
--- a/internal/juju/deployments.go
+++ b/internal/juju/deployments.go
@@ -3,8 +3,9 @@ package juju
 import (
 	"errors"
 	"fmt"
-	"github.com/juju/juju/rpc/params"
 	"math"
+
+	"github.com/juju/juju/rpc/params"
 
 	"github.com/juju/charm/v8"
 	jujuerrors "github.com/juju/errors"
@@ -157,8 +158,8 @@ func (c applicationsClient) CreateApplication(input *CreateApplicationInput) (*C
 	}
 	resolvedCharm := resolved[0]
 
-	if err != nil {
-		return nil, err
+	if resolvedCharm.Error != nil {
+		return nil, resolvedCharm.Error
 	}
 
 	// Figure out the actual series of the charm


### PR DESCRIPTION
Line 161 of deployments.go checks for an error but it checks the wrong variable (err instead of resolvedCharm.Error) meaning if the latter is populated you get a segfault later in the function