### PR TITLE
implements delete for juju_integration resource

### DIFF
--- a/internal/provider/resource_integration_test.go
+++ b/internal/provider/resource_integration_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestAcc_ResourceIntegration(t *testing.T) {
 	// TODO: remove once other operations are implemented
-	t.Skip("skipped until delete operation is implemented")
+	t.Skip("skipped until read operation is implemented")
 	modelName := acctest.RandomWithPrefix("tf-test-integration")
 
 	resource.UnitTest(t, resource.TestCase{


### PR DESCRIPTION
This implements the Delete action for `juju_integration`.

Note: This is known in Juju as destroy rather than delete so the client has a method Destroy that is called by the provider's delete command.

Tests are currently skipped pending read:
```=== RUN   TestAcc_ResourceIntegration
    resource_integration_test.go:17: Step 1/1 error: Error running post-apply refresh: exit status 1
        
        Error: not implemented
        
          with juju_integration.this,
          on terraform_plugin_test.tf line 24, in resource "juju_integration" "this":
          24: resource "juju_integration" "this" {
        
--- FAIL: TestAcc_ResourceIntegration (9.13s)```