### PR TITLE
implements read for `juju_integration` resource

### DIFF
--- a/internal/juju/integrations.go
+++ b/internal/juju/integrations.go
@@ -114,7 +114,7 @@ func (c integrationsClient) ReadIntegration(input *IntegrationInput) (*params.Re
 		}
 	}
 
-	if relation.Id != 0 && relation.Key == "" {
+	if relation.Id == 0 && relation.Key == "" {
 		keyReversed := fmt.Sprintf("%v:%v %v:%v", apps[1][0], apps[1][1], apps[0][0], apps[0][1])
 		for _, v := range relations {
 			if v.Key == keyReversed {
@@ -123,7 +123,7 @@ func (c integrationsClient) ReadIntegration(input *IntegrationInput) (*params.Re
 		}
 	}
 
-	if relation.Id != 0 && relation.Key == "" {
+	if relation.Id == 0 && relation.Key == "" {
 		return nil, fmt.Errorf("relation not found in model")
 	}
 

--- a/internal/provider/resource_integration_test.go
+++ b/internal/provider/resource_integration_test.go
@@ -10,8 +10,6 @@ import (
 )
 
 func TestAcc_ResourceIntegration(t *testing.T) {
-	// TODO: remove once other operations are implemented
-	t.Skip("skipped until read operation is implemented")
 	modelName := acctest.RandomWithPrefix("tf-test-integration")
 
 	resource.UnitTest(t, resource.TestCase{
@@ -24,6 +22,8 @@ func TestAcc_ResourceIntegration(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("juju_integration.this", "model", modelName),
 					resource.TestCheckResourceAttr("juju_integration.this", "id", fmt.Sprintf("%v:%v:%v", modelName, "one:db", "two:db")),
+					resource.TestCheckResourceAttr("juju_integration.this", "application.0.endpoint", "db"),
+					resource.TestCheckResourceAttr("juju_integration.this", "application.#", "2"),
 				),
 			},
 		},


### PR DESCRIPTION
This implements read on the `juju_integration` resource.

It also modifies the schema slightly to set the endpoint to computed so that it can be stored in the state when not specified in the HCL and adds to the create function to store this value

also removes some superfluous input and response structs in `internal/juju/integrations.go` and enables acceptance tests