### PR TITLE
implements import for `juju_integration` resource

### DIFF
--- a/docs/resources/integration.md
+++ b/docs/resources/integration.md
@@ -33,7 +33,7 @@ resource "juju_integration" "this" {
 
 ### Required
 
-- `application` (Block List, Min: 2, Max: 2) The two applications to integrate. (see [below for nested schema](#nestedblock--application))
+- `application` (Block Set, Min: 2, Max: 2) The two applications to integrate. (see [below for nested schema](#nestedblock--application))
 - `model` (String) The name of the model to operate in.
 
 ### Read-Only

--- a/internal/provider/resource_integration.go
+++ b/internal/provider/resource_integration.go
@@ -20,6 +20,10 @@ func resourceIntegration() *schema.Resource {
 		UpdateContext: resourceIntegrationUpdate,
 		DeleteContext: resourceIntegrationDelete,
 
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
 		Schema: map[string]*schema.Schema{
 			"model": {
 				Description: "The name of the model to operate in.",
@@ -28,7 +32,7 @@ func resourceIntegration() *schema.Resource {
 			},
 			"application": {
 				Description: "The two applications to integrate.",
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Required:    true,
 				MaxItems:    2,
 				MinItems:    2,
@@ -63,7 +67,7 @@ func resourceIntegrationCreate(ctx context.Context, d *schema.ResourceData, meta
 		return diag.FromErr(err)
 	}
 
-	apps := d.Get("application").([]interface{})
+	apps := d.Get("application").(*schema.Set).List()
 	endpoints, err := parseEndpoints(apps)
 	if err != nil {
 		return diag.FromErr(err)
@@ -157,7 +161,7 @@ func resourceIntegrationDelete(ctx context.Context, d *schema.ResourceData, meta
 		return diag.FromErr(err)
 	}
 
-	apps := d.Get("application").([]interface{})
+	apps := d.Get("application").(*schema.Set).List()
 	endpoints, err := parseEndpoints(apps)
 	if err != nil {
 		return diag.FromErr(err)

--- a/internal/provider/resource_integration_test.go
+++ b/internal/provider/resource_integration_test.go
@@ -22,8 +22,8 @@ func TestAcc_ResourceIntegration(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("juju_integration.this", "model", modelName),
 					resource.TestCheckResourceAttr("juju_integration.this", "id", fmt.Sprintf("%v:%v:%v", modelName, "one:db", "two:db")),
-					resource.TestCheckResourceAttr("juju_integration.this", "application.0.endpoint", "db"),
 					resource.TestCheckResourceAttr("juju_integration.this", "application.#", "2"),
+					resource.TestCheckTypeSetElemNestedAttrs("juju_integration.this", "application.*", map[string]string{"name": "one", "endpoint": "db"}),
 				),
 			},
 		},


### PR DESCRIPTION
This implements import for the `juju_integration` resource.  This is using the state pass through and read function to set the values in the state.

In order to support this the `application` property has been changed to `TypeSet` from `TypeList` meaning the order you define the application blocks in the hcl has no bearing on the order in the code - this prevents the import from immediately requiring an apply to correct the order if the slice coming from the juju client is ordered the other way.

Additionally the acceptance test has been changed to support this schema change