### PR TITLE
Add test for `juju_integration` import

### DIFF
--- a/internal/provider/resource_integration_test.go
+++ b/internal/provider/resource_integration_test.go
@@ -26,6 +26,11 @@ func TestAcc_ResourceIntegration(t *testing.T) {
 					resource.TestCheckTypeSetElemNestedAttrs("juju_integration.this", "application.*", map[string]string{"name": "one", "endpoint": "db"}),
 				),
 			},
+			{
+				ImportStateVerify: true,
+				ImportState:       true,
+				ResourceName:      "juju_integration.this",
+			},
 		},
 	})
 }


### PR DESCRIPTION
Adds a step to verify importing of a `juju_integration`.

I should've spotted this in the earlier PR, but I missed it.