### PR TITLE
changes `juju_integration` ID to provider requirer

### DIFF
--- a/internal/juju/integrations.go
+++ b/internal/juju/integrations.go
@@ -111,8 +111,8 @@ func (c integrationsClient) ReadIntegration(input *IntegrationInput) (*params.Re
 		return nil, fmt.Errorf("no relations exist in specified model")
 	}
 
-	// the key is built assuming that the ID is "<requirer>:<endpoint> <provider>:<endpoint>"
-	key := fmt.Sprintf("%v:%v %v:%v", apps[0][0], apps[0][1], apps[1][0], apps[1][1])
+	// the key is built assuming that the ID is "<provider>:<endpoint> <requirer>:<endpoint>"
+	key := fmt.Sprintf("%v:%v %v:%v", apps[1][0], apps[1][1], apps[0][0], apps[0][1])
 
 	for _, v := range relations {
 		if v.Key == key {

--- a/internal/provider/resource_integration.go
+++ b/internal/provider/resource_integration.go
@@ -234,13 +234,13 @@ func resourceIntegrationDelete(ctx context.Context, d *schema.ResourceData, meta
 
 func generateID(modelName string, endpoints map[string]params.CharmRelation) string {
 
-	//In order to generate a stable iterable order we sort the endpoints keys by the role value (requirer is always first)
+	//In order to generate a stable iterable order we sort the endpoints keys by the role value (provider is always first to match `juju status` output)
 	//TODO: verify we always get only 2 endpoints and that the role value is consistent
 	keys := make([]string, len(endpoints))
 	for k, v := range endpoints {
-		if v.Role == "requirer" {
+		if v.Role == "provider" {
 			keys[0] = k
-		} else if v.Role == "provider" {
+		} else if v.Role == "requirer" {
 			keys[1] = k
 		}
 	}

--- a/internal/provider/resource_integration_test.go
+++ b/internal/provider/resource_integration_test.go
@@ -12,7 +12,7 @@ import (
 func TestAcc_ResourceIntegration(t *testing.T) {
 	modelName := acctest.RandomWithPrefix("tf-test-integration")
 
-	resource.UnitTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckIntegrationDestroy,
@@ -21,7 +21,7 @@ func TestAcc_ResourceIntegration(t *testing.T) {
 				Config: testAccResourceIntegration(modelName, "two"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("juju_integration.this", "model", modelName),
-					resource.TestCheckResourceAttr("juju_integration.this", "id", fmt.Sprintf("%v:%v:%v", modelName, "one:db", "two:db")),
+					resource.TestCheckResourceAttr("juju_integration.this", "id", fmt.Sprintf("%v:%v:%v", modelName, "two:db", "one:db")),
 					resource.TestCheckResourceAttr("juju_integration.this", "application.#", "2"),
 					resource.TestCheckTypeSetElemNestedAttrs("juju_integration.this", "application.*", map[string]string{"name": "one", "endpoint": "db"}),
 				),
@@ -35,7 +35,7 @@ func TestAcc_ResourceIntegration(t *testing.T) {
 				Config: testAccResourceIntegration(modelName, "three"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("juju_integration.this", "model", modelName),
-					resource.TestCheckResourceAttr("juju_integration.this", "id", fmt.Sprintf("%v:%v:%v", modelName, "one:db", "three:db")),
+					resource.TestCheckResourceAttr("juju_integration.this", "id", fmt.Sprintf("%v:%v:%v", modelName, "three:db", "one:db")),
 					resource.TestCheckResourceAttr("juju_integration.this", "application.#", "2"),
 					resource.TestCheckTypeSetElemNestedAttrs("juju_integration.this", "application.*", map[string]string{"name": "three", "endpoint": "db"}),
 				),


### PR DESCRIPTION
This takes the ID generated for the `juju_integration` resource and flips the requirer and provider so that IDs are now:
```
<model>:<provider>:<endpoint>:<requirer>:<endpoint>
```

This has been done so that when importing you have some parity with the CLI output from status - if you run: `juju status` to get relation details then the relations will be listed with provider first:

```
Relation provider  Requirer          Interface    Type     Message
```