### PR TITLE
Add linting for go

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,6 @@ on:
     paths-ignore:
       - "README.md"
       - "project-docs/**"
-  workflow_dispatch:
 
 # Testing only needs permissions to read the repository contents.
 permissions:
@@ -37,6 +36,7 @@ jobs:
 
   generate:
     runs-on: ubuntu-latest
+    needs: build
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
@@ -52,6 +52,7 @@ jobs:
   # This runs golangci-lint against the codebase
   lint:
     name: golangci-lint
+    needs: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -66,7 +67,9 @@ jobs:
   # Run acceptance tests in a matrix with Terraform CLI versions
   test:
     name: Terraform Provider Acceptance Tests
-    needs: build
+    needs:
+      - generate
+      - lint
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
@@ -89,7 +92,6 @@ jobs:
           terraform_version: ${{ matrix.terraform }}
           terraform_wrapper: false
       - uses: ./.github/actions/setup-juju
-        if: ${{ !env.ACT }} # skip when running locally with `act`
       - name: "Set environment to configure provider"
         # language=bash
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ on:
     paths-ignore:
       - 'README.md'
       - 'project-docs/**'
+  workflow_dispatch:
 
 # Testing only needs permissions to read the repository contents.
 permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,6 +54,11 @@ jobs:
     name: golangci-lint
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version-file: "go.mod"
+          cache: true
       - uses: golangci/golangci-lint-action@v3
         with:
           version: latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,7 @@ on:
   push:
     branches:
       - 'main'
+      - "add-linting-for-go"
     paths-ignore:
       - 'README.md'
       - 'project-docs/**'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,15 @@ jobs:
           git diff --compact-summary --exit-code || \
             (echo; echo "Unexpected difference in directories after code generation. Run 'go generate ./...' command and commit."; exit 1)
 
+  # This runs golangci-lint against the codebase
+  lint:
+    name: golangci-lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: golangci/golangci-lint-action@v3
+        with:
+          version: latest
+
   # Run acceptance tests in a matrix with Terraform CLI versions
   test:
     name: Terraform Provider Acceptance Tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,15 +5,15 @@ name: Tests
 on:
   pull_request:
     paths-ignore:
-      - 'README.md'
-      - 'project-docs/**'
+      - "README.md"
+      - "project-docs/**"
   push:
     branches:
-      - 'main'
+      - "main"
       - "add-linting-for-go"
     paths-ignore:
-      - 'README.md'
-      - 'project-docs/**'
+      - "README.md"
+      - "project-docs/**"
   workflow_dispatch:
 
 # Testing only needs permissions to read the repository contents.
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version-file: 'go.mod'
+          go-version-file: "go.mod"
           cache: true
       - run: go mod download
       - run: go build -v .
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version-file: 'go.mod'
+          go-version-file: "go.mod"
           cache: true
       - run: go generate ./...
       - name: git diff
@@ -68,16 +68,16 @@ jobs:
       fail-fast: false
       matrix:
         terraform:
-          - '0.15.*'
-          - '1.0.*'
-          - '1.1.*'
-          - '1.2.*'
+          - "0.15.*"
+          - "1.0.*"
+          - "1.1.*"
+          - "1.2.*"
 
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version-file: 'go.mod'
+          go-version-file: "go.mod"
           cache: true
       - uses: hashicorp/setup-terraform@v2
         with:
@@ -89,7 +89,7 @@ jobs:
         # language=bash
         run: |
           CONTROLLER=$(juju whoami --format yaml | yq .controller)
-  
+
           echo "JUJU_CONTROLLER_ADDRESSES=$(juju show-controller | yq -o=json .$CONTROLLER.details.api-endpoints | jq -r '. | join(",")')" >> $GITHUB_ENV
           echo "JUJU_USERNAME=$(juju show-controller | yq .$CONTROLLER.account.user)"  >> $GITHUB_ENV
           echo "JUJU_PASSWORD=$(cat ~/.local/share/juju/accounts.yaml | yq .controllers.$CONTROLLER.password)"  >> $GITHUB_ENV

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,8 +58,8 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version-file: "go.mod"
-          cache: true
-      - uses: golangci/golangci-lint-action@v3
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
         with:
           version: latest
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,6 @@ on:
   push:
     branches:
       - "main"
-      - "add-linting-for-go"
     paths-ignore:
       - "README.md"
       - "project-docs/**"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,5 @@
+linters:
+  enable:
+    - misspell
+    - prealloc
+    - whitespace

--- a/README.md
+++ b/README.md
@@ -78,3 +78,12 @@ Then, finally, run the tests:
 make testacc
 ```
 
+#### Linting
+
+This repository uses [golangci-lint](https://golangci-lint.run/) as a linting tool as it can run multiple linters. The configuration for this tool is all handled in the file `.golangci.yaml` in the root of the repository allowing all runs of the tool to run with the same settings. When installed you can run the analysis with:
+
+```shell
+golangci-lint run
+```
+
+You can also integrate `golangci-lint` with some IDEs following instructions available here: [Editor integration](https://golangci-lint.run/usage/integrations)

--- a/internal/juju/applications.go
+++ b/internal/juju/applications.go
@@ -8,8 +8,9 @@ package juju
 import (
 	"errors"
 	"fmt"
-	"github.com/juju/juju/core/model"
 	"math"
+
+	"github.com/juju/juju/core/model"
 
 	"github.com/juju/juju/rpc/params"
 
@@ -354,7 +355,7 @@ func (c applicationsClient) UpdateApplication(input *UpdateApplicationInput) err
 
 			if unitDiff < 0 {
 				var unitNames []string
-				for unitName, _ := range appStatus.Units {
+				for unitName := range appStatus.Units {
 					unitNames = append(unitNames, unitName)
 				}
 

--- a/internal/juju/integrations.go
+++ b/internal/juju/integrations.go
@@ -84,7 +84,6 @@ func (c integrationsClient) ReadIntegration(input *IntegrationInput) (*params.Re
 
 	apps := make([][]string, 0, len(input.Endpoints))
 	for _, v := range input.Endpoints {
-
 		app := strings.Split(v, ":")
 		apps = append(apps, []string{
 			app[0],

--- a/internal/juju/models.go
+++ b/internal/juju/models.go
@@ -1,7 +1,6 @@
 package juju
 
 import (
-	"errors"
 	"fmt"
 	"log"
 	"time"
@@ -42,7 +41,7 @@ func (c *modelsClient) getControllerNameByUUID(uuid string) (*string, error) {
 		}
 	}
 
-	return nil, errors.New(fmt.Sprintf("cannot find controller name from uuid: %s", uuid))
+	return nil, fmt.Errorf("cannot find controller name from uuid: %s", uuid)
 }
 
 // GetModelByName retrieves a model by name
@@ -174,10 +173,10 @@ func (c *modelsClient) ReadModel(uuid string) (*string, *params.ModelInfo, map[s
 	}
 
 	if len(models) > 1 {
-		return nil, nil, nil, errors.New(fmt.Sprintf("more than one model returned for UUID: %s", uuid))
+		return nil, nil, nil, fmt.Errorf("more than one model returned for UUID: %s", uuid)
 	}
 	if len(models) < 1 {
-		return nil, nil, nil, errors.New(fmt.Sprintf("no model returned for UUID: %s", uuid))
+		return nil, nil, nil, fmt.Errorf("no model returned for UUID: %s", uuid)
 	}
 
 	modelInfo := models[0].Result

--- a/internal/provider/data_source_model.go
+++ b/internal/provider/data_source_model.go
@@ -38,8 +38,12 @@ func dataSourceModelRead(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 
 	d.SetId(model.UUID)
-	d.Set("uuid", model.UUID)
-	d.Set("name", model.Name)
+	if err = d.Set("uuid", model.UUID); err != nil {
+		return diag.FromErr(err)
+	}
+	if err = d.Set("name", model.Name); err != nil {
+		return diag.FromErr(err)
+	}
 
 	return nil
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -68,7 +68,6 @@ func New(version string) func() *schema.Provider {
 
 func configure(version string, p *schema.Provider) func(context.Context, *schema.ResourceData) (interface{}, diag.Diagnostics) {
 	return func(_ context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
-
 		var diags diag.Diagnostics
 
 		ControllerAddresses := strings.Split(d.Get("controller_addresses").(string), ",")
@@ -110,7 +109,6 @@ func configure(version string, p *schema.Provider) func(context.Context, *schema
 }
 
 func checkClientErr(err error, diags diag.Diagnostics, config juju.Configuration) diag.Diagnostics {
-
 	var errDetail string
 
 	x509error := &x509.UnknownAuthorityError{}

--- a/internal/provider/resource_application.go
+++ b/internal/provider/resource_application.go
@@ -120,11 +120,15 @@ func resourceApplicationCreate(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	// These values can be computed, and so set from the response.
-	d.Set("name", response.AppName)
+	if err = d.Set("name", response.AppName); err != nil {
+		return diag.FromErr(err)
+	}
 
 	charm["revision"] = response.Revision
 	charm["series"] = response.Series
-	d.Set("charm", []map[string]interface{}{charm})
+	if err = d.Set("charm", []map[string]interface{}{charm}); err != nil {
+		return diag.FromErr(err)
+	}
 
 	id := fmt.Sprintf("%s:%s", modelName, response.AppName)
 	d.SetId(id)
@@ -176,7 +180,9 @@ func resourceApplicationRead(ctx context.Context, d *schema.ResourceData, meta i
 			"series":   response.Series,
 		}
 	}
-	d.Set("charm", []map[string]interface{}{charmList})
+	if err = d.Set("charm", []map[string]interface{}{charmList}); err != nil {
+		return diag.FromErr(err)
+	}
 
 	// TODO: Once we can pull the channel from the API, remove the above and uncomment below
 	//charmList := []map[string]interface{}{
@@ -188,9 +194,15 @@ func resourceApplicationRead(ctx context.Context, d *schema.ResourceData, meta i
 	//	},
 	//}
 	//d.Set("charm", charmList)
-	d.Set("model", modelName)
-	d.Set("name", appName)
-	d.Set("units", response.Units)
+	if err = d.Set("model", modelName); err != nil {
+		return diag.FromErr(err)
+	}
+	if err = d.Set("name", appName); err != nil {
+		return diag.FromErr(err)
+	}
+	if err = d.Set("units", response.Units); err != nil {
+		return diag.FromErr(err)
+	}
 
 	// TODO: Add client function to handle the appropriate JuJu API Facade Endpoint
 	return nil

--- a/internal/provider/resource_integration.go
+++ b/internal/provider/resource_integration.go
@@ -58,7 +58,6 @@ func resourceIntegration() *schema.Resource {
 }
 
 func resourceIntegrationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-
 	client := meta.(*juju.Client)
 
 	modelName := d.Get("model").(string)
@@ -101,7 +100,6 @@ func resourceIntegrationCreate(ctx context.Context, d *schema.ResourceData, meta
 }
 
 func resourceIntegrationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-
 	client := meta.(*juju.Client)
 
 	id := strings.Split(d.Id(), ":")
@@ -147,7 +145,6 @@ func resourceIntegrationRead(ctx context.Context, d *schema.ResourceData, meta i
 }
 
 func resourceIntegrationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-
 	client := meta.(*juju.Client)
 
 	modelName := d.Get("model").(string)
@@ -203,7 +200,6 @@ func resourceIntegrationUpdate(ctx context.Context, d *schema.ResourceData, meta
 }
 
 func resourceIntegrationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-
 	client := meta.(*juju.Client)
 
 	modelName := d.Get("model").(string)
@@ -233,7 +229,6 @@ func resourceIntegrationDelete(ctx context.Context, d *schema.ResourceData, meta
 }
 
 func generateID(modelName string, endpoints map[string]params.CharmRelation) string {
-
 	//In order to generate a stable iterable order we sort the endpoints keys by the role value (provider is always first to match `juju status` output)
 	//TODO: verify we always get only 2 endpoints and that the role value is consistent
 	keys := make([]string, len(endpoints))
@@ -256,7 +251,6 @@ func generateID(modelName string, endpoints map[string]params.CharmRelation) str
 
 //This function can be used to parse the terraform data into usable juju endpoints
 func parseEndpoints(apps []interface{}) ([]string, error) {
-
 	var endpoints []string
 
 	for _, app := range apps {
@@ -265,7 +259,7 @@ func parseEndpoints(apps []interface{}) ([]string, error) {
 		}
 
 		//Here we check if the endpoint is empty and pass just the application name, this allows juju to attempt to infer endpoints
-		//If the endpoint is specifed we pass the format <applicationName>:<endpoint>
+		//If the endpoint is specified we pass the format <applicationName>:<endpoint>
 		a := app.(map[string]interface{})
 		if a["endpoint"].(string) == "" {
 			endpoints = append(endpoints, a["name"].(string))

--- a/internal/provider/resource_model.go
+++ b/internal/provider/resource_model.go
@@ -127,7 +127,7 @@ func resourceModelRead(ctx context.Context, d *schema.ResourceData, meta interfa
 
 	// Only read model config that is tracked in Terraform
 	config := d.Get("config").(map[string]interface{})
-	for k, _ := range config {
+	for k := range config {
 		if value, exists := modelConfig[k]; exists {
 			var serialised string
 			switch value.(type) {
@@ -145,7 +145,9 @@ func resourceModelRead(ctx context.Context, d *schema.ResourceData, meta interfa
 			config[k] = serialised
 		}
 	}
-	d.Set("config", config)
+	if err = d.Set("config", config); err != nil {
+		return diag.FromErr(err)
+	}
 
 	return diags
 }
@@ -163,7 +165,7 @@ func resourceModelUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 		newConfigMap := newConfig.(map[string]interface{})
 
 		var unsetConfigKeys []string
-		for k, _ := range oldConfigMap {
+		for k := range oldConfigMap {
 			if _, ok := newConfigMap[k]; !ok {
 				unsetConfigKeys = append(unsetConfigKeys, k)
 			}
@@ -209,7 +211,9 @@ func resourceModelImporter(ctx context.Context, d *schema.ResourceData, meta int
 		return nil, err
 	}
 
-	d.Set("name", model.Name)
+	if err = d.Set("name", model.Name); err != nil {
+		return nil, err
+	}
 	d.SetId(model.UUID)
 
 	return []*schema.ResourceData{d}, nil


### PR DESCRIPTION
This PR adds a linting step to the test workflow, additionally it adds a configuration file `.golangci.yml` for configuring this linting tool.

The workflow steps are rearranged to this order for now (Can be revised later as the codebase grows): 

1. Build 
3. Lint & Generate
4. Acceptance Tests