### PR TITLE
Enable code signing of build artefacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,18 +25,17 @@ jobs:
         with:
           go-version-file: 'go.mod'
           cache: true
-      # TODO: allow signing artifacts (see Card #75)
       # This uses an action (hashicorp/ghaction-import-gpg) that assumes you set your
       # private key in the `GPG_PRIVATE_KEY` secret and passphrase in the `PASSPHRASE`
       # secret. If you would rather own your own GPG handling, please fork this action
       # or use an alternative one for key handling.
-      #      - name: Import GPG key
-      #        id: import_gpg
-      #        uses: hashicorp/ghaction-import-gpg@v2.1.0
-      #        env:
-      #          # These secrets will need to be configured for the repository:
-      #          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-      #          PASSPHRASE: ${{ secrets.PASSPHRASE }}
+      - name: Import GPG key
+        id: import_gpg
+        uses: hashicorp/ghaction-import-gpg@v2.1.0
+        env:
+          # These secrets will need to be configured for the repository:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          PASSPHRASE: ${{ secrets.PASSPHRASE }}
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3
         with:
@@ -44,5 +43,4 @@ jobs:
         env:
           # GitHub sets the GITHUB_TOKEN secret automatically.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # TODO: allow signing artifacts (see Card #75)
-          # GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
+          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,6 @@ jobs:
         id: import_gpg
         uses: hashicorp/ghaction-import-gpg@v2.1.0
         env:
-          # These secrets will need to be configured for the repository:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           PASSPHRASE: ${{ secrets.PASSPHRASE }}
       - name: Run GoReleaser

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -43,24 +43,23 @@ checksum:
       name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
   name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
   algorithm: sha256
-# TODO: allow signing artifacts (see Card #75)
-#signs:
-#  - artifacts: checksum
-#    args:
-#      # if you are using this in a GitHub action or some other automated pipeline, you
-#      # need to pass the batch flag to indicate its not interactive.
-#      - "--batch"
-#      - "--local-user"
-#      - "{{ .Env.GPG_FINGERPRINT }}" # set this environment variable for your signing key
-#      - "--output"
-#      - "${signature}"
-#      - "--detach-sign"
-#      - "${artifact}"
+signs:
+  - artifacts: checksum
+    args:
+      # if you are using this in a GitHub action or some other automated pipeline, you
+      # need to pass the batch flag to indicate its not interactive.
+      - "--batch"
+      - "--local-user"
+      - "{{ .Env.GPG_FINGERPRINT }}" # set this environment variable for your signing key
+      - "--output"
+      - "${signature}"
+      - "--detach-sign"
+      - "${artifact}"
 release:
   extra_files:
     - glob: 'terraform-registry-manifest.json'
       name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
   # If you want to manually examine the release before its live, uncomment this line:
-  # draft: true
+  draft: true
 changelog:
   skip: true

--- a/main.go
+++ b/main.go
@@ -33,7 +33,6 @@ func main() {
 
 	opts := &plugin.ServeOpts{
 		ProviderFunc: provider.New(version),
-		// TODO: Published name is to be confirmed - see card #41
 		ProviderAddr: "registry.terraform.io/canonical/juju",
 		Debug:        debugMode,
 	}


### PR DESCRIPTION
We can start signing code artefacts as the required secrets have been configured.

This is a pre-cursor to publishing the provider in the Terraform registry.