### PR TITLE
Replace `hashicorp/ghaction-import-gpg` action with its upstream version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,16 +25,12 @@ jobs:
         with:
           go-version-file: 'go.mod'
           cache: true
-      # This uses an action (hashicorp/ghaction-import-gpg) that assumes you set your
-      # private key in the `GPG_PRIVATE_KEY` secret and passphrase in the `PASSPHRASE`
-      # secret. If you would rather own your own GPG handling, please fork this action
-      # or use an alternative one for key handling.
       - name: Import GPG key
         id: import_gpg
-        uses: hashicorp/ghaction-import-gpg@v2.1.0
-        env:
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-          PASSPHRASE: ${{ secrets.PASSPHRASE }}
+        uses: crazy-max/ghaction-import-gpg@34ea557550c84ea665cae5c61c3b084feac7e042 # => v5
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.PASSPHRASE }}
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3
         with:


### PR DESCRIPTION
Hashicorp's ghaction-import-gpg has been deprecated in favour of this
action - additionally their action has a bug which they are not intending
on fixing and recommend people switch.

Reference: https://github.com/hashicorp/terraform-provider-scaffolding/pull/127
Reference: https://github.com/hashicorp/ghaction-import-gpg/issues/11