### PR TITLE
Refactor ModelsClient to be consistent with others

### DIFF
--- a/docs/resources/model.md
+++ b/docs/resources/model.md
@@ -15,7 +15,6 @@ A resource that represent a Juju Model.
 resource "juju_model" "this" {
   name = "development"
 
-  controller = "overlord"
   cloud {
     name   = "aws"
     region = "eu-west-1"
@@ -41,7 +40,6 @@ resource "juju_model" "this" {
 
 - `cloud` (Block List, Max: 1) JuJu Cloud where the model will operate (see [below for nested schema](#nestedblock--cloud))
 - `config` (Map of String) Override default model configuration.
-- `controller` (String) The name of the controller to target. Optional
 
 ### Read-Only
 

--- a/examples/resources/juju_model/resource.tf
+++ b/examples/resources/juju_model/resource.tf
@@ -1,7 +1,6 @@
 resource "juju_model" "this" {
   name = "development"
 
-  controller = "overlord"
   cloud {
     name   = "aws"
     region = "eu-west-1"

--- a/internal/juju/client.go
+++ b/internal/juju/client.go
@@ -5,8 +5,6 @@ import (
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/connector"
-	"github.com/juju/juju/cmd/modelcmd"
-	"github.com/juju/juju/jujuclient"
 )
 
 const (
@@ -40,18 +38,8 @@ func NewClient(config Configuration) (*Client, error) {
 		config: config,
 	}
 
-	var store jujuclient.ClientStore = modelcmd.QualifyingClientStore{
-		ClientStore: jujuclient.NewFileClientStore(),
-	}
-
-	// TODO: should the controller be part of the provider configuration?
-	controllerName, err := store.CurrentController()
-	if err != nil {
-		return nil, err
-	}
-
 	return &Client{
-		Models:       *newModelsClient(cf, store, controllerName),
+		Models:       *newModelsClient(cf),
 		Applications: *newApplicationClient(cf),
 		Integrations: *newIntegrationsClient(cf),
 	}, nil


### PR DESCRIPTION
This PR will refactor the ModelsClient and its functions to be consistent with ApplicationsClient, and IntegrationsClient

* Make use of structs for input and responses
* Update schema to remove controllerName (deprecated)
* Remove references to controllerName and store (deprecated)
* Remove getControllerNameByUUID func (no longer needed)
* Update docs and examples to reflect new structure and usage