### PR TITLE
Added resources resolution code.

### DIFF
--- a/internal/juju/applications.go
+++ b/internal/juju/applications.go
@@ -119,6 +119,7 @@ func (c applicationsClient) CreateApplication(input *CreateApplicationInput) (*C
 	if err != nil {
 		return nil, err
 	}
+
 	defer resourcesAPIClient.Close()
 
 	appName := input.ApplicationName
@@ -244,8 +245,6 @@ func (c applicationsClient) CreateApplication(input *CreateApplicationInput) (*C
 		Origin: resultOrigin,
 	}
 
-	// populate the required resources for this charm
-
 	resources, err := c.processResources(charmsAPIClient, resourcesAPIClient, charmID, input.ApplicationName)
 	if err != nil {
 		return nil, err
@@ -294,8 +293,9 @@ func (c applicationsClient) processResources(charmsAPIClient *apicharms.Client, 
 				Path:        v.Path,
 				Description: v.Description,
 			},
-			Origin:   charmresources.OriginStore,
-			Revision: charmInfo.Revision,
+			Origin: charmresources.OriginStore,
+			// TODO: prepare for resources with different versions
+			Revision: -1,
 		}
 		pendingResources = append(pendingResources, aux)
 	}

--- a/internal/juju/applications.go
+++ b/internal/juju/applications.go
@@ -241,7 +241,7 @@ func (c applicationsClient) CreateApplication(input *CreateApplicationInput) (*C
 
 	charmID := apiapplication.CharmID{
 		URL:    charmURL,
-		Origin: resultOrigin,
+		Origin: resolvedCharm.Origin,
 	}
 
 	// populate the required resources for this charm
@@ -274,7 +274,6 @@ func (c applicationsClient) CreateApplication(input *CreateApplicationInput) (*C
 // processResources is a helper function to process the charm
 // metadata and request the download of any additional resource.
 func (c applicationsClient) processResources(charmsAPIClient *apicharms.Client, resourcesAPIClient *apiresources.Client, charmID apiapplication.CharmID, appName string) (map[string]string, error) {
-
 	charmInfo, err := charmsAPIClient.CharmInfo(charmID.URL.String())
 	if err != nil {
 		return nil, err

--- a/internal/juju/applications.go
+++ b/internal/juju/applications.go
@@ -241,10 +241,11 @@ func (c applicationsClient) CreateApplication(input *CreateApplicationInput) (*C
 
 	charmID := apiapplication.CharmID{
 		URL:    charmURL,
-		Origin: resolvedCharm.Origin,
+		Origin: resultOrigin,
 	}
 
 	// populate the required resources for this charm
+
 	resources, err := c.processResources(charmsAPIClient, resourcesAPIClient, charmID, input.ApplicationName)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This PR includes additional code to populate a list of pending resources when requested in the META section of a charm file. Basically, it replicates part of the logic inside the Juju CLI. It checks if any resources were set in the charm metadata, if so requests the controller to add this resources to pending, and finally deploy the requested solution with the corresponding resources.

Please, test before merging with grafana-k8s, postgresql-k8s, etc.