### PR TITLE
[JUJU-1504] Add trust flag for application resources

### DIFF
--- a/docs/resources/application.md
+++ b/docs/resources/application.md
@@ -25,7 +25,6 @@ resource "juju_application" "this" {
     series   = "trusty"
   }
 
-  trust = true
   units = 3
 
   config = {

--- a/docs/resources/application.md
+++ b/docs/resources/application.md
@@ -45,6 +45,7 @@ resource "juju_application" "this" {
 
 - `config` (Map of String) Application specific configuration.
 - `name` (String) A custom name for the application deployment. If empty, uses the charm's name.
+- `trust` (Boolean) Set the trust for the application.
 - `units` (Number) The number of application units to deploy for the charm.
 
 ### Read-Only

--- a/docs/resources/application.md
+++ b/docs/resources/application.md
@@ -25,6 +25,7 @@ resource "juju_application" "this" {
     series   = "trusty"
   }
 
+  trust = true
   units = 3
 
   config = {

--- a/internal/juju/applications.go
+++ b/internal/juju/applications.go
@@ -374,7 +374,6 @@ func (c applicationsClient) ReadApplication(input *ReadApplicationInput) (*ReadA
 		return nil, fmt.Errorf("failed to parse charm: %v", err)
 	}
 
-	charmsAPIClient.CharmInfo(charmURL.String())
 	conf, _ := applicationAPIClient.GetConfig("", charmURL.Name)
 	log.Debug().Msgf("Application Config : %v", conf)
 
@@ -463,9 +462,12 @@ func (c applicationsClient) UpdateApplication(input *UpdateApplicationInput) err
 	}
 
 	if input.Trust != nil {
-		applicationAPIClient.Set(input.AppName, map[string]string{
+		err := applicationAPIClient.Set(input.AppName, map[string]string{
 			"trust": fmt.Sprintf("%v", *input.Trust),
 		})
+		if err != nil {
+			return err
+		}
 	}
 
 	if input.Revision != nil {

--- a/internal/provider/resource_application_test.go
+++ b/internal/provider/resource_application_test.go
@@ -22,6 +22,7 @@ func TestAcc_ResourceApplication_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("juju_application.this", "model", modelName),
 					resource.TestCheckResourceAttr("juju_application.this", "charm.#", "1"),
 					resource.TestCheckResourceAttr("juju_application.this", "charm.0.name", "tiny-bash"),
+					resource.TestCheckResourceAttr("juju_application.this", "trust", "true"),
 				),
 			},
 			{
@@ -78,6 +79,7 @@ resource "juju_application" "this" {
   charm {
     name = "tiny-bash"
   }
+  trust = true
 }
 `, modelName)
 }
@@ -95,6 +97,7 @@ resource "juju_application" "this" {
     name     = "ubuntu"
     revision = %d
   }
+  trust = true
 }
 `, modelName, units, revision)
 }


### PR DESCRIPTION
#### Description

This PR attempts to add a `trust` flag for certain charms/applications to work properly (e.g. integrators etc) after deploy.

Currently it's in a draft state, because I can't yet figure out how to get the `trust` information from the juju state (see `applicationsClient.ReadApplication`).

#### QA Steps

I modified the `resource_application_test`s, so those should pass. But we probably need a test/example that actually uses the `trust` flag to do stuff. QA steps will be complete when the PR is ready.

#### Notes & Discussion

