### PR TITLE
[JUJU-1589] Include expose field in the deployment plan.

### DIFF
--- a/docs/resources/application.md
+++ b/docs/resources/application.md
@@ -38,7 +38,7 @@ resource "juju_application" "this" {
 
 ### Required
 
-- `charm` (Block List, Min: 1, Max: 1) The name of the charm to be installed from Charmhub. (see [below for nested schema](#nestedblock--charm))
+- `charm` (Block List, Min: 1) The name of the charm to be installed from Charmhub. (see [below for nested schema](#nestedblock--charm))
 - `model` (String) The name of the model where the application is to be deployed.
 
 ### Optional

--- a/docs/resources/application.md
+++ b/docs/resources/application.md
@@ -44,6 +44,7 @@ resource "juju_application" "this" {
 ### Optional
 
 - `config` (Map of String) Application specific configuration.
+- `expose` (Block List, Max: 1) Makes an application publicly available over the network (see [below for nested schema](#nestedblock--expose))
 - `name` (String) A custom name for the application deployment. If empty, uses the charm's name.
 - `trust` (Boolean) Set the trust for the application.
 - `units` (Number) The number of application units to deploy for the charm.
@@ -64,6 +65,16 @@ Optional:
 - `channel` (String) The channel to use when deploying a charm. Specified as <track>/<risk>/<branch>.
 - `revision` (Number) The revision of the charm to deploy.
 - `series` (String) The series on which to deploy.
+
+
+<a id="nestedblock--expose"></a>
+### Nested Schema for `expose`
+
+Optional:
+
+- `cidrs` (String) A comma-delimited list of CIDRs that should be able to access the application ports once exposed.
+- `endpoints` (String) Expose only the ports that charms have opened for this comma-delimited list of endpoints
+- `spaces` (String) A comma-delimited list of spaces that should be able to access the application ports once exposed.
 
 ## Import
 

--- a/internal/juju/applications.go
+++ b/internal/juju/applications.go
@@ -448,23 +448,23 @@ func (c applicationsClient) ReadApplication(input *ReadApplicationInput) (*ReadA
 	// information with the information existing in the deployment plan
 	// has to be defined. Meanwhile, I will comment this section.
 
-	// conf, err := applicationAPIClient.Get("master", input.AppName)
-	// if err != nil {
-	// 	return nil, fmt.Errorf("failed to get app configuration %v", err)
-	// }
+	conf, err := applicationAPIClient.Get("master", input.AppName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get app configuration %v", err)
+	}
 
 	// trust field
-	// trustValue := false
-	// if conf != nil {
-	// 	aux, found := conf.ApplicationConfig["trust"]
-	// 	if found {
-	// 		m := aux.(map[string]any)
-	// 		target, found := m["value"]
-	// 		if found {
-	// 			trustValue = target.(bool)
-	// 		}
-	// 	}
-	// }
+	trustValue := false
+	if conf != nil {
+		aux, found := conf.ApplicationConfig["trust"]
+		if found {
+			m := aux.(map[string]any)
+			target, found := m["value"]
+			if found {
+				trustValue = target.(bool)
+			}
+		}
+	}
 
 	// process expose field
 	// log.Debug().Msg("read application")
@@ -498,12 +498,10 @@ func (c applicationsClient) ReadApplication(input *ReadApplicationInput) (*ReadA
 		Revision: charmURL.Revision,
 		Series:   appInfo.Series,
 		Units:    unitCount,
-		//Trust:    trustValue,
+		Trust:    trustValue,
 		//Expose:   exposed,
 		//Config:   conf.ApplicationConfig,
 	}
-
-	log.Debug().Msgf("ReadApplicationResponse is: %#v", response)
 
 	return response, nil
 }
@@ -558,7 +556,6 @@ func (c applicationsClient) UpdateApplication(input *UpdateApplicationInput) err
 		for k, v := range input.Expose {
 			exposeMap[k] = v.(string)
 		}
-		log.Debug().Msgf("try to update the expose with %#v", exposeMap)
 		err := c.processExpose(applicationAPIClient, input.AppName, exposeMap)
 		if err != nil {
 			log.Error().Err(err).Msg("error when trying to expose")

--- a/internal/juju/applications.go
+++ b/internal/juju/applications.go
@@ -335,7 +335,7 @@ func (c applicationsClient) processExpose(applicationAPIClient *apiapplication.C
 }
 
 func splitCommaDelimitedList(list string) []string {
-	var items []string
+	items := make([]string, 1)
 	for _, token := range strings.Split(list, ",") {
 		token = strings.TrimSpace(token)
 		if len(token) == 0 {

--- a/internal/juju/applications.go
+++ b/internal/juju/applications.go
@@ -302,8 +302,11 @@ func (c applicationsClient) CreateApplication(input *CreateApplicationInput) (*C
 	}, err
 }
 
-// processExpose is a local function that executes an expose request
-// if the
+// processExpose is a local function that executes an expose request.
+// If the exposeConfig argument is nil it simply exits. If not,
+// an expose request is done populating the request arguments with
+// the endpoints, spaces, and cidrs contained in the exposeConfig
+// map.
 func (c applicationsClient) processExpose(applicationAPIClient *apiapplication.Client, applicationName string, exposeConfig map[string]string) error {
 	// nothing to do
 	if exposeConfig == nil {
@@ -444,10 +447,6 @@ func (c applicationsClient) ReadApplication(input *ReadApplicationInput) (*ReadA
 		return nil, fmt.Errorf("failed to parse charm: %v", err)
 	}
 
-	// TODO: (2022-08-12) The strategy to follow to consolidate Juju
-	// information with the information existing in the deployment plan
-	// has to be defined. Meanwhile, I will comment this section.
-
 	conf, err := applicationAPIClient.Get("master", input.AppName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get app configuration %v", err)
@@ -466,6 +465,9 @@ func (c applicationsClient) ReadApplication(input *ReadApplicationInput) (*ReadA
 		}
 	}
 
+	// TODO: (2022-08-12) The strategy to follow to consolidate Juju
+	// information with the information existing in the deployment plan
+	// has to be defined. Meanwhile, I will comment this section.
 	// process expose field
 	// log.Debug().Msg("read application")
 	// var exposed map[string]interface{} = nil

--- a/internal/juju/applications.go
+++ b/internal/juju/applications.go
@@ -445,7 +445,7 @@ func (c applicationsClient) ReadApplication(input *ReadApplicationInput) (*ReadA
 	}
 
 	// TODO: (2022-08-12) The strategy to follow to consolidate Juju
-	// information with the information exsiting in the deployment plan
+	// information with the information existing in the deployment plan
 	// has to be defined. Meanwhile, I will comment this section.
 
 	// conf, err := applicationAPIClient.Get("master", input.AppName)

--- a/internal/juju/applications.go
+++ b/internal/juju/applications.go
@@ -9,9 +9,11 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"strings"
 
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/rpc/params"
+	"github.com/rs/zerolog/log"
 
 	"github.com/juju/charm/v8"
 	charmresources "github.com/juju/charm/v8/resource"
@@ -41,6 +43,8 @@ type CreateApplicationInput struct {
 	CharmRevision   int
 	Units           int
 	Trust           bool
+	Expose          map[string]string
+	Config          map[string]string
 }
 
 type CreateApplicationResponse struct {
@@ -61,7 +65,8 @@ type ReadApplicationResponse struct {
 	Series   string
 	Units    int
 	Trust    bool
-	Config   map[string]interface{}
+	// Config   map[string]interface{}
+	// Expose   map[string]interface{}
 }
 
 type UpdateApplicationInput struct {
@@ -72,6 +77,11 @@ type UpdateApplicationInput struct {
 	Units    *int
 	Revision *int
 	Trust    *bool
+	Expose   map[string]interface{}
+	// Unexpose will be true when the expose
+	// field becomes empty
+	Unexpose bool
+	Config   map[string]interface{}
 	//Series    string // TODO: Unsupported for now
 }
 
@@ -254,7 +264,12 @@ func (c applicationsClient) CreateApplication(input *CreateApplicationInput) (*C
 
 	// TODO: This should probably be set within the schema
 	// For now this is the default required behaviour
-	appConfig := make(map[string]string)
+	var appConfig map[string]string
+	if input.Config != nil {
+		appConfig = input.Config
+	} else {
+		appConfig = make(map[string]string)
+	}
 
 	appConfig["trust"] = fmt.Sprintf("%v", input.Trust)
 
@@ -267,11 +282,68 @@ func (c applicationsClient) CreateApplication(input *CreateApplicationInput) (*C
 		Config:          appConfig,
 		Resources:       resources,
 	})
+
+	if err != nil {
+		// unfortunate error during deployment
+		return &CreateApplicationResponse{
+			AppName:  appName,
+			Revision: *origin.Revision,
+			Series:   series,
+		}, err
+	}
+
+	// If we have managed to deploy something, now we have
+	// to check if we have to expose something
+	err = c.processExpose(applicationAPIClient, input.ApplicationName, input.Expose)
 	return &CreateApplicationResponse{
 		AppName:  appName,
 		Revision: *origin.Revision,
 		Series:   series,
 	}, err
+}
+
+// processExpose is a local function that executes an expose request
+// if the
+func (c applicationsClient) processExpose(applicationAPIClient *apiapplication.Client, applicationName string, exposeConfig map[string]string) error {
+	// nothing to do
+	if exposeConfig == nil {
+		return nil
+	}
+
+	// create one entry with spaces and the CIDRs per endpoint. If no endpoint
+	// use an empty value ("")
+	listEndpoints := splitCommaDelimitedList(exposeConfig["endpoints"])
+	listSpaces := splitCommaDelimitedList(exposeConfig["spaces"])
+	listCIDRs := splitCommaDelimitedList(exposeConfig["cidrs"])
+
+	// build params and send the request
+	if len(listEndpoints) == 0 {
+		listEndpoints = append(listEndpoints, "")
+	}
+
+	requestParams := make(map[string]params.ExposedEndpoint)
+	for _, epName := range listEndpoints {
+		requestParams[epName] = params.ExposedEndpoint{
+			ExposeToSpaces: listSpaces,
+			ExposeToCIDRs:  listCIDRs,
+		}
+	}
+
+	log.Trace().Interface("ExposeParams", requestParams).Msg("call expose API endpoint")
+
+	return applicationAPIClient.Expose(applicationName, requestParams)
+}
+
+func splitCommaDelimitedList(list string) []string {
+	var items []string
+	for _, token := range strings.Split(list, ",") {
+		token = strings.TrimSpace(token)
+		if len(token) == 0 {
+			continue
+		}
+		items = append(items, token)
+	}
+	return items
 }
 
 // processResources is a helper function to process the charm
@@ -372,22 +444,49 @@ func (c applicationsClient) ReadApplication(input *ReadApplicationInput) (*ReadA
 		return nil, fmt.Errorf("failed to parse charm: %v", err)
 	}
 
-	conf, err := applicationAPIClient.Get("master", input.AppName)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get app configuration %v", err)
-	}
+	// conf, err := applicationAPIClient.Get("master", input.AppName)
+	// if err != nil {
+	// 	return nil, fmt.Errorf("failed to get app configuration %v", err)
+	// }
 
-	trustValue := false
-	if conf != nil {
-		aux, found := conf.ApplicationConfig["trust"]
-		if found {
-			m := aux.(map[string]any)
-			target, found := m["value"]
-			if found {
-				trustValue = target.(bool)
-			}
-		}
-	}
+	// trust field
+	// trustValue := false
+	// if conf != nil {
+	// 	aux, found := conf.ApplicationConfig["trust"]
+	// 	if found {
+	// 		m := aux.(map[string]any)
+	// 		target, found := m["value"]
+	// 		if found {
+	// 			trustValue = target.(bool)
+	// 		}
+	// 	}
+	// }
+
+	// process expose field
+	// log.Debug().Msg("read application")
+	// var exposed map[string]interface{} = nil
+	// if appStatus.Exposed {
+	// 	// rebuild
+	// 	log.Debug().Msg("it was previously exposed")
+	// 	exposed = make(map[string]interface{}, 1)
+	// 	endpoints := []string{""}
+	// 	spaces := ""
+	// 	cidrs := ""
+	// 	for epName, value := range appStatus.ExposedEndpoints {
+	// 		if epName != "" {
+	// 			endpoints = append(endpoints, epName)
+	// 		}
+	// 		if len(spaces) == 0 {
+	// 			spaces = strings.Join(value.ExposeToSpaces, ",")
+	// 		}
+	// 		if len(cidrs) == 0 {
+	// 			cidrs = strings.Join(value.ExposeToCIDRs, ",")
+	// 		}
+	// 	}
+	// 	exposed["endpoints"] = strings.Join(endpoints, ",")
+	// 	exposed["spaces"] = spaces
+	// 	exposed["cidrs"] = cidrs
+	// }
 
 	response := &ReadApplicationResponse{
 		Name:     charmURL.Name,
@@ -395,8 +494,12 @@ func (c applicationsClient) ReadApplication(input *ReadApplicationInput) (*ReadA
 		Revision: charmURL.Revision,
 		Series:   appInfo.Series,
 		Units:    unitCount,
-		Trust:    trustValue,
+		//Trust:    trustValue,
+		//Expose:   exposed,
+		//Config:   conf.ApplicationConfig,
 	}
+
+	log.Debug().Msgf("ReadApplicationResponse is: %#v", response)
 
 	return response, nil
 }
@@ -426,11 +529,35 @@ func (c applicationsClient) UpdateApplication(input *UpdateApplicationInput) err
 		return fmt.Errorf("no status returned for application: %s", input.AppName)
 	}
 
+	// process trust
 	if input.Trust != nil {
 		err := applicationAPIClient.SetConfig("master", input.AppName, "", map[string]string{
 			"trust": fmt.Sprintf("%v", *input.Trust),
 		})
 		if err != nil {
+			return err
+		}
+	}
+
+	// process expose
+	if input.Unexpose {
+		// TODO: (2022-08-10) right now we only unexpose all the possible endpoints.
+		// Additional logic must be set up to specify what endpoints
+		// should be unexpose in case this is simply a change, not a
+		// complete removal.
+		if err := applicationAPIClient.Unexpose(input.AppName, nil); err != nil {
+			log.Error().Err(err).Msg("error when trying to unexpose")
+			return err
+		}
+	} else if input.Expose != nil {
+		exposeMap := make(map[string]string)
+		for k, v := range input.Expose {
+			exposeMap[k] = v.(string)
+		}
+		log.Debug().Msgf("try to update the expose with %#v", exposeMap)
+		err := c.processExpose(applicationAPIClient, input.AppName, exposeMap)
+		if err != nil {
+			log.Error().Err(err).Msg("error when trying to expose")
 			return err
 		}
 	}

--- a/internal/juju/applications.go
+++ b/internal/juju/applications.go
@@ -444,6 +444,10 @@ func (c applicationsClient) ReadApplication(input *ReadApplicationInput) (*ReadA
 		return nil, fmt.Errorf("failed to parse charm: %v", err)
 	}
 
+	// TODO: (2022-08-12) The strategy to follow to consolidate Juju
+	// information with the information exsiting in the deployment plan
+	// has to be defined. Meanwhile, I will comment this section.
+
 	// conf, err := applicationAPIClient.Get("master", input.AppName)
 	// if err != nil {
 	// 	return nil, fmt.Errorf("failed to get app configuration %v", err)

--- a/internal/provider/resource_application.go
+++ b/internal/provider/resource_application.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rs/zerolog/log"
 
 	"github.com/juju/terraform-provider-juju/internal/juju"
 )
@@ -43,7 +42,6 @@ func resourceApplication() *schema.Resource {
 				Description: "The name of the charm to be installed from Charmhub.",
 				Type:        schema.TypeList,
 				Required:    true,
-				MaxItems:    1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": {
@@ -84,7 +82,7 @@ func resourceApplication() *schema.Resource {
 				Type:        schema.TypeMap,
 				Optional:    true,
 				DefaultFunc: func() (interface{}, error) {
-					return make(map[string]string), nil
+					return make(map[string]interface{}), nil
 				},
 			},
 			"trust": {
@@ -292,7 +290,6 @@ func resourceApplicationRead(ctx context.Context, d *schema.ResourceData, meta i
 }
 
 func resourceApplicationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Debug().Msg("resourceApplicationUpdate invoked")
 
 	client := meta.(*juju.Client)
 
@@ -321,19 +318,14 @@ func resourceApplicationUpdate(ctx context.Context, d *schema.ResourceData, meta
 	if d.HasChange("expose") {
 		expose, exposeWasSet := d.GetOk("expose")
 		if exposeWasSet {
-			log.Debug().Interface("exposeValue", expose).Msg("expose was set")
 			if expose.([]interface{})[0] == nil {
 				// no params in expose
-				log.Debug().Msg("expose has no params")
 				updateApplicationInput.Expose = make(map[string]interface{})
 			} else {
 				// expose has params
-
-				log.Debug().Interface("setParams", expose).Msg("params are set")
 				updateApplicationInput.Expose = expose.([]interface{})[0].(map[string]interface{})
 			}
 		} else {
-			log.Debug().Msg("expose was not set in a change")
 			// if there is a change and we have no expose, we have
 			// to unexpose
 			updateApplicationInput.Unexpose = true

--- a/internal/provider/resource_application.go
+++ b/internal/provider/resource_application.go
@@ -290,7 +290,6 @@ func resourceApplicationRead(ctx context.Context, d *schema.ResourceData, meta i
 }
 
 func resourceApplicationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-
 	client := meta.(*juju.Client)
 
 	appName := d.Get("name").(string)

--- a/internal/provider/resource_application.go
+++ b/internal/provider/resource_application.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/rs/zerolog/log"
 
 	"github.com/juju/terraform-provider-juju/internal/juju"
 )
@@ -45,7 +46,7 @@ func resourceApplication() *schema.Resource {
 				MaxItems:    1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"name": &schema.Schema{
+						"name": {
 							Description: "The name of the charm",
 							Type:        schema.TypeString,
 							Required:    true,
@@ -82,12 +83,44 @@ func resourceApplication() *schema.Resource {
 				Description: "Application specific configuration.",
 				Type:        schema.TypeMap,
 				Optional:    true,
+				DefaultFunc: func() (interface{}, error) {
+					return make(map[string]string), nil
+				},
 			},
 			"trust": {
 				Description: "Set the trust for the application.",
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     false,
+			},
+			"expose": {
+				Description: "Makes an application publicly available over the network",
+				Type:        schema.TypeList,
+				Optional:    true,
+				Default:     nil,
+				MaxItems:    1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"endpoints": {
+							Description: "Expose only the ports that charms have opened for this comma-delimited list of endpoints",
+							Type:        schema.TypeString,
+							Default:     "",
+							Optional:    true,
+						},
+						"spaces": {
+							Description: "A comma-delimited list of spaces that should be able to access the application ports once exposed.",
+							Type:        schema.TypeString,
+							Default:     "",
+							Optional:    true,
+						},
+						"cidrs": {
+							Description: "A comma-delimited list of CIDRs that should be able to access the application ports once exposed.",
+							Type:        schema.TypeString,
+							Default:     "",
+							Optional:    true,
+						},
+					},
+				},
 			},
 		},
 	}
@@ -109,6 +142,24 @@ func resourceApplicationCreate(ctx context.Context, d *schema.ResourceData, meta
 	series := charm["series"].(string)
 	units := d.Get("units").(int)
 	trust := d.Get("trust").(bool)
+	// populate the config parameter
+	configField := d.Get("config").(map[string]interface{})
+	config := make(map[string]string)
+	for k, v := range configField {
+		config[k] = v.(string)
+	}
+	// if expose is nil, it was not defined
+	var expose map[string]string = nil
+	exposeField, exposeWasSet := d.GetOk("expose")
+	if exposeWasSet {
+		// this was set, by default get no fields there
+		expose = make(map[string]string, 0)
+		aux := exposeField.([]interface{})[0]
+		if aux != nil {
+			expose = aux.(map[string]string)
+		}
+	}
+
 	revision := charm["revision"].(int)
 	if _, exist := d.GetOk("charm.0.revision"); !exist {
 		revision = -1
@@ -122,7 +173,9 @@ func resourceApplicationCreate(ctx context.Context, d *schema.ResourceData, meta
 		CharmRevision:   revision,
 		CharmSeries:     series,
 		Units:           units,
+		Config:          config,
 		Trust:           trust,
+		Expose:          expose,
 	})
 
 	if err != nil {
@@ -213,15 +266,34 @@ func resourceApplicationRead(ctx context.Context, d *schema.ResourceData, meta i
 	if err = d.Set("units", response.Units); err != nil {
 		return diag.FromErr(err)
 	}
+
 	if err = d.Set("trust", response.Trust); err != nil {
 		return diag.FromErr(err)
 	}
 
-	// TODO: Add client function to handle the appropriate JuJu API Facade Endpoint
+	// TODO: (2022-08-12) The information contained in the deployment plan
+	// does not have to be exactly the same returned by Juju.
+	// Operations such as expose or config, will return more
+	// information than the one required for the plan.
+	// Additional logic has to be added here to ignore those
+	// fields returned by Juju not addressed in the deployment
+	// plan.
+
+	// exposeValue := []map[string]interface{}{response.Expose}
+	// if err = d.Set("expose", exposeValue); err != nil {
+	// 	return diag.FromErr(err)
+	// }
+
+	// if err = d.Set("config", response.Config); err != nil {
+	// 	return diag.FromErr(err)
+	// }
+
 	return nil
 }
 
 func resourceApplicationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	log.Debug().Msg("resourceApplicationUpdate invoked")
+
 	client := meta.(*juju.Client)
 
 	appName := d.Get("name").(string)
@@ -246,9 +318,37 @@ func resourceApplicationUpdate(ctx context.Context, d *schema.ResourceData, meta
 		updateApplicationInput.Trust = &trust
 	}
 
+	if d.HasChange("expose") {
+		expose, exposeWasSet := d.GetOk("expose")
+		if exposeWasSet {
+			log.Debug().Interface("exposeValue", expose).Msg("expose was set")
+			if expose.([]interface{})[0] == nil {
+				// no params in expose
+				log.Debug().Msg("expose has no params")
+				updateApplicationInput.Expose = make(map[string]interface{})
+			} else {
+				// expose has params
+
+				log.Debug().Interface("setParams", expose).Msg("params are set")
+				updateApplicationInput.Expose = expose.([]interface{})[0].(map[string]interface{})
+			}
+		} else {
+			log.Debug().Msg("expose was not set in a change")
+			// if there is a change and we have no expose, we have
+			// to unexpose
+			updateApplicationInput.Unexpose = true
+			updateApplicationInput.Expose = nil
+		}
+	}
+
 	if d.HasChange("charm.0.revision") {
 		revision := d.Get("charm.0.revision").(int)
 		updateApplicationInput.Revision = &revision
+	}
+
+	if d.HasChange("config") {
+		config := d.Get("config").(map[string]interface{})
+		updateApplicationInput.Config = config
 	}
 
 	err = client.Applications.UpdateApplication(&updateApplicationInput)


### PR DESCRIPTION
The original juju command `juju expose appname` enables endpoints to be accessible for a given network. This PR adds this field to the application resource, enabling deployments to exposed. 

The additional `expose` parameters mimics the `juju expose` command. For a default behavior, simply add the `expose{}` field as follows.

```tf
terraform {
  required_providers {
    juju = {
      version = "~> 1.0.0"
      source  = "canonical/juju"
    }
  }
}

provider "juju" {}

resource "juju_model" "development" {
  name = "development"
}

resource "juju_application" "grafana" {
  name = "grafana"

  model = juju_model.development.name

  charm {
    name    = "grafana-k8s"
    channel = "latest/edge"
  }
  
  expose {}

  config = {
    juju-external-hostname = "grafana"
  }
```
For a more specific exposure, `endpoints`, `cidrs`, and `spaces` can be set.

```tf
expose {
   endpoints = "endpoint1,endpoint2,endpoint3"
   cidrs = "0.0.0.0,1.2.3.4"
   spaces = "space1, space2"
}
```

This PR will require additional work to be done in order to consolidate situations where the original deployment plan only contains a partial amount of the information returned by the Juju API. For example, when using a default expose Juju sets the `cidrs` field to `0.0.0.0`. This is interpreted by the terraform provider as a change and may trigger an unnecessary update.