### PR TITLE
[JUJU-1598] update application configuration

### DIFF
--- a/internal/juju/applications.go
+++ b/internal/juju/applications.go
@@ -461,7 +461,11 @@ func (c applicationsClient) ReadApplication(input *ReadApplicationInput) (*ReadA
 			// The API returns the configuration entries as interfaces
 			// In the terraform plan we introduce strings...
 			// so we force this conversion
-			conf[k] = v.(map[string]interface{})["value"].(string)
+			aux := v.(map[string]interface{})
+			// set if we find the value key
+			if value := aux["value"]; value != nil {
+				conf[k] = fmt.Sprintf("%s", value)
+			}
 		}
 	}
 

--- a/internal/provider/resource_application.go
+++ b/internal/provider/resource_application.go
@@ -147,14 +147,14 @@ func resourceApplicationCreate(ctx context.Context, d *schema.ResourceData, meta
 		config[k] = v.(string)
 	}
 	// if expose is nil, it was not defined
-	var expose map[string]string = nil
+	var expose map[string]interface{} = nil
 	exposeField, exposeWasSet := d.GetOk("expose")
 	if exposeWasSet {
 		// this was set, by default get no fields there
-		expose = make(map[string]string, 0)
+		expose = make(map[string]interface{}, 0)
 		aux := exposeField.([]interface{})[0]
 		if aux != nil {
-			expose = aux.(map[string]string)
+			expose = aux.(map[string]interface{})
 		}
 	}
 


### PR DESCRIPTION
With this PR the provider reads the current application config and expose parameters from Juju and sets the status accordingly. This may help in the future to inform users about situations where the Juju status does not match terraform plans, enabling users to detect inconsistencies between plans and the current status.

For some QA, apply a plan with some config parameters, modify them using the Juju CLI and apply again the plan. During the update process the mismatch between Juju and terraform will be notified. For example, run a `grafana-k8s` like this:

```
terraform {
  required_providers {
    juju = {
      version = "~> 1.0.0"
      source  = "canonical/juju"
    }
  }
}

provider "juju" {}

resource "juju_model" "development" {
  name = "development"
}

resource "juju_application" "grafana" {
  name = "grafana"

  model = juju_model.development.name

  charm {
    name    = "grafana-k8s"
    channel = "latest/edge"
  }
  expose {}
  config = {
    juju-external-hostname = "grafana"
    juju-application-path  = "/grafana123"
  }
  trust = true
}
```

Modify one of the config params using the Juju CLI:
```
juju config grafana juju-application-path="/ihavebeenchanged"
```
Apply the plan again and check that the provider realizes of the changes to the current status.
```
terraform apply
...
Terraform will perform the following actions:

  # juju_application.grafana will be updated in-place
  ~ resource "juju_application" "grafana" {
      ~ config = {
          ~ "juju-application-path"  = "/ihavebeenchanged" -> "/grafana123"
            # (1 unchanged element hidden)
        }
        id     = "development:grafana"
        name   = "grafana"
        # (3 unchanged attributes hidden)

        # (2 unchanged blocks hidden)
    }
...
```

After running, check that `juju config grafana` indicates `/grafana123` to be the value for `juju-application-path` instead of `/ihavebeenchanged`. 

Similar tests can be done with `expose{}`.
