### PR TITLE
[JUJU-1686] Include charm config values when reading Juju app status.

### DIFF
--- a/internal/juju/applications.go
+++ b/internal/juju/applications.go
@@ -479,6 +479,13 @@ func (c applicationsClient) ReadApplication(input *ReadApplicationInput) (*ReadA
 				conf[k] = fmt.Sprintf("%s", value)
 			}
 		}
+		// repeat the same steps for charm config values
+		for k, v := range returnedConf.CharmConfig {
+			aux := v.(map[string]interface{})
+			if value, found := aux["value"]; found {
+				conf[k] = fmt.Sprintf("%s", value)
+			}
+		}
 	}
 
 	// trust field which has to be included into the configuration


### PR DESCRIPTION
When reading the status from an already deployed application, the `CharmConfig` field was ignored. This results in a biased view that may lead terraform to consider unchanged plans to be updated. 

For a manual QA deploy this plan twice and check that no updates are detected. Modify the `site_url` apply again and see how terraform detects changes in the plan. A similar situation can be reached if the value is changed using the Juju CLI.

```
provider "juju" {}

resource "juju_model" "development" {
  name = "indico-test"
}

resource "juju_application" "indico" {
  name  = "indico"
  model = juju_model.development.name

  charm {
    name    = "indico"
    channel = "edge"
  }

  config = {
    site_url = "nothing"
  }
}
```


