### PR TITLE
[JUJU-1695] Take out -go 1.16 from canary test workflow

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -27,7 +27,6 @@ jobs:
           go-version-file: "go.mod"
           cache: true
       - run: go get -v -u github.com/juju/juju@${{ steps.get_release.outputs.release }}
-      - run: go mod tidy -go 1.16
       - run: go mod tidy -go 1.18
       - run: go build -v .
 
@@ -74,7 +73,6 @@ jobs:
           juju show-controller | yq .$CONTROLLER.details.ca-cert >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
       - run: go get -v -u github.com/juju/juju@${{ steps.get_release.outputs.release }}
-      - run: go mod tidy -go 1.16
       - run: go mod tidy -go 1.18
       - env:
           TF_ACC: "1"


### PR DESCRIPTION
This removes the [failing](https://github.com/juju/terraform-provider-juju/actions/runs/3065040212/jobs/4948740355) `- run: go mod tidy -go 1.16` from canary test workflow. 

The error in the canary tests itself seems to be related to the `grpc`, and updating that might be a solution,

```
go: google.golang.org/grpc/naming@v0.0.0-00010101000000-000000000000: invalid version: unknown revision 000000000000
```

however, we seem to have `go 1.18` specific code, as the `go build` is failing for me locally after (successfully) running `go mod tidy -go 1.16`:

```
 $ go mod tidy -go 1.16
 $ go build
# github.com/juju/terraform-provider-juju/internal/juju
internal/juju/applications.go:496:25: undeclared name: any (requires version go1.18 or later)
```

Note that this doesn't officially "drop support" for `1.16` (though looking at the error above we might have done that already). As far as the terraform sdk is concerned, I couldn't find any document that suggest that we have to be supporting `go 1.16` ([the provider scaffolding code](https://github.com/hashicorp/terraform-provider-scaffolding-framework) requires `go 1.18+`), however, there might be an internal/external integration that I'm not aware of.