### PR TITLE
[JUJU-1969] Fix channel during imports

### DIFF
--- a/internal/provider/resource_application.go
+++ b/internal/provider/resource_application.go
@@ -222,10 +222,6 @@ func resourceApplicationRead(ctx context.Context, d *schema.ResourceData, meta i
 		return nil
 	}
 
-	// TODO: This is a temporary fix to preserve the defined charm channel, as we cannot currently pull this from the API
-	// The if exists statement is also required to allow import to function when no exiting data is in the state
-	// Remove these lines and uncomment under the next TODO
-
 	var charmList map[string]interface{}
 	_, exists := d.GetOk("charm")
 	if exists {
@@ -236,7 +232,7 @@ func resourceApplicationRead(ctx context.Context, d *schema.ResourceData, meta i
 	} else {
 		charmList = map[string]interface{}{
 			"name":     response.Name,
-			"channel":  "latest/stable",
+			"channel":  response.Channel,
 			"revision": response.Revision,
 			"series":   response.Series,
 		}
@@ -245,16 +241,6 @@ func resourceApplicationRead(ctx context.Context, d *schema.ResourceData, meta i
 		return diag.FromErr(err)
 	}
 
-	// TODO: Once we can pull the channel from the API, remove the above and uncomment below
-	//charmList := []map[string]interface{}{
-	//	{
-	//		"name":     response.Name,
-	//		"channel":  response.Channel,
-	//		"revision": response.Revision,
-	//		"series":   response.Series,
-	//	},
-	//}
-	//d.Set("charm", charmList)
 	if err = d.Set("model", modelName); err != nil {
 		return diag.FromErr(err)
 	}

--- a/internal/provider/resource_application.go
+++ b/internal/provider/resource_application.go
@@ -227,6 +227,7 @@ func resourceApplicationRead(ctx context.Context, d *schema.ResourceData, meta i
 	if exists {
 		charmList = d.Get("charm").([]interface{})[0].(map[string]interface{})
 		charmList["name"] = response.Name
+		charmList["channel"] = response.Channel
 		charmList["revision"] = response.Revision
 		charmList["series"] = response.Series
 	} else {


### PR DESCRIPTION
During the import operation the `channel` attribute for charms was ignored. It looks like a hardcoded `latest/stable` value remained there. In this change, we obtain the channel from the response as done with the other fields. This should fix #95.  

Following the example mentioned at #95, you can use these steps for testing.

Compile the terraform provider and make it available as usual. 
```sh
 $ go build
 $ cp terraform-provider-juju <path-to-terraform>/.terraform.d/plugins/registry.terraform.io/juju/juju/0.4.1/linux_amd64/terraform-provider-juju_v0.4.1
 $ cd <path-to-wherever-you-put-the demo.tf>
```


Using microk8s create a model and a redis deployment.

```bash
juju add-model newmodel
juju deploy redis-k8s --channel=edge -m newmodel
```
Use the following terraform plan:
```terraform
terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
       version = "0.4.1"
     }
  }
}

provider "juju" {}

resource "juju_model" "development" {
  name = "newmodel"
}

resource "juju_application" "redis_cache" {
  name  = "redis-cache2"
  model = juju_model.development.name

  charm {
    name    = "redis-k8s"
    channel = "edge"
  }

  units = 1
}
```
Initialize a terraform environment and import the redis application.

```sh
terraform init
terraform import juju_application.redis_cache newmodel:redis-k8
```
Now the plan should not indicate any changes in the channel attribute:
```sh
terraform plan
....
# juju_application.redis_cache must be replaced
-/+ resource "juju_application" "redis_cache" {
      - config = {} -> null
      ~ id     = "newmodel:redis-k8s" -> (known after apply)
      ~ name   = "redis-k8s" -> "redis-cache2" # forces replacement
        # (3 unchanged attributes hidden)

      ~ charm {
            name     = "redis-k8s"
          ~ revision = 19 -> (known after apply)
          ~ series   = "focal" -> (known after apply)
            # (1 unchanged attribute hidden)
        }
    }

  # juju_model.development will be created
  + resource "juju_model" "development" {
      + id   = (known after apply)
      + name = "newmodel"
      + type = (known after apply)

      + cloud {
          + name   = (known after apply)
          + region = (known after apply)
        }
    }
```