### PR TITLE
[JUJU-1966] Replace tiny-bash for ubuntu.

### DIFF
--- a/.github/actions/setup-juju/action.yaml
+++ b/.github/actions/setup-juju/action.yaml
@@ -21,7 +21,7 @@ runs:
       # language=bash
       run: |
         set -euxo pipefail
-        sudo snap install juju --classic
+        sudo snap install juju --channel=2.9/stable --classic
         lxc network set lxdbr0 ipv6.address none
     - name: bootstrap
       shell: bash

--- a/internal/provider/resource_application_test.go
+++ b/internal/provider/resource_application_test.go
@@ -89,7 +89,7 @@ resource "juju_application" "this" {
   model = juju_model.this.name
   name = "test-app"
   charm {
-    name = "tiny-bash"
+    name = "ubuntu"
   }
   trust = true
   expose{}

--- a/internal/provider/resource_application_test.go
+++ b/internal/provider/resource_application_test.go
@@ -22,7 +22,7 @@ func TestAcc_ResourceApplication_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("juju_application.this", "model", modelName),
 					resource.TestCheckResourceAttr("juju_application.this", "name", "test-app"),
 					resource.TestCheckResourceAttr("juju_application.this", "charm.#", "1"),
-					resource.TestCheckResourceAttr("juju_application.this", "charm.0.name", "tiny-bash"),
+					resource.TestCheckResourceAttr("juju_application.this", "charm.0.name", "ubuntu"),
 					resource.TestCheckResourceAttr("juju_application.this", "trust", "true"),
 					resource.TestCheckResourceAttr("juju_application.this", "expose.#", "1"),
 				),

--- a/internal/provider/resource_application_test.go
+++ b/internal/provider/resource_application_test.go
@@ -44,30 +44,30 @@ func TestAcc_ResourceApplication_Updates(t *testing.T) {
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceApplicationUpdates(modelName, 1, 19, true),
+				Config: testAccResourceApplicationUpdates(modelName, 1, 21, true),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("juju_application.this", "model", modelName),
 					resource.TestCheckResourceAttr("juju_application.this", "charm.#", "1"),
 					resource.TestCheckResourceAttr("juju_application.this", "charm.0.name", "ubuntu"),
 					resource.TestCheckResourceAttr("juju_application.this", "units", "1"),
-					resource.TestCheckResourceAttr("juju_application.this", "charm.0.revision", "19"),
+					resource.TestCheckResourceAttr("juju_application.this", "charm.0.revision", "21"),
 					resource.TestCheckResourceAttr("juju_application.this", "expose.#", "1"),
 				),
 			},
 			{
-				Config: testAccResourceApplicationUpdates(modelName, 2, 19, true),
+				Config: testAccResourceApplicationUpdates(modelName, 2, 21, true),
 				Check:  resource.TestCheckResourceAttr("juju_application.this", "units", "2"),
 			},
 			{
-				Config: testAccResourceApplicationUpdates(modelName, 2, 20, true),
-				Check:  resource.TestCheckResourceAttr("juju_application.this", "charm.0.revision", "20"),
+				Config: testAccResourceApplicationUpdates(modelName, 2, 21, true),
+				Check:  resource.TestCheckResourceAttr("juju_application.this", "charm.0.revision", "21"),
 			},
 			{
-				Config: testAccResourceApplicationUpdates(modelName, 2, 20, false),
+				Config: testAccResourceApplicationUpdates(modelName, 2, 21, false),
 				Check:  resource.TestCheckResourceAttr("juju_application.this", "expose.#", "0"),
 			},
 			{
-				Config: testAccResourceApplicationUpdates(modelName, 2, 20, true),
+				Config: testAccResourceApplicationUpdates(modelName, 2, 21, true),
 				Check:  resource.TestCheckResourceAttr("juju_application.this", "expose.#", "1"),
 			},
 			{

--- a/internal/provider/resource_integration_test.go
+++ b/internal/provider/resource_integration_test.go
@@ -60,6 +60,7 @@ resource "juju_application" "one" {
 	
 	charm {
 		name = "hello-juju"
+		series = "focal"
 	}
 }
 
@@ -69,6 +70,7 @@ resource "juju_application" "two" {
 
 	charm {
 		name = "postgresql"
+		series = "focal"
 	}
 }
 
@@ -78,6 +80,7 @@ resource "juju_application" "three" {
 
 	charm {
 		name = "postgresql"
+		series = "focal"
 	}
 }
 

--- a/internal/provider/resource_offer_test.go
+++ b/internal/provider/resource_offer_test.go
@@ -48,6 +48,7 @@ resource "juju_application" "this" {
 
 	charm {
 		name = "postgresql"
+		series = "focal"
 	}
 }
 
@@ -71,6 +72,7 @@ resource "juju_application" "this" {
 
 	charm {
 		name = "postgresql"
+		series = "focal"
 	}
 }
 
@@ -90,6 +92,7 @@ resource "juju_application" "that" {
 
 	charm {
 		name = "hello-juju"
+		series = "focal"
 	}
 }
 


### PR DESCRIPTION
Some of the charms used for testing do not have support for modern series. Main changes here:
* Replace tiny-bash by ubuntu
* Set series to focus for those charms not supporting Jammy
* Set the installed Juju snap package to 2.9/latest