### PR TITLE
Adds reference to Juju provider in Terraform docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ go mod tidy
 
 Then commit the changes to `go.mod` and `go.sum`.
 
+## Using the Provider
+
+Please, refer to the [Terraform docs for the Juju provider](https://registry.terraform.io/providers/juju/juju/latest/docs).
+
 ## Developing the Provider
 
 If you wish to work on the provider, you'll first need [Go](http://www.golang.org) installed on your machine (see [Requirements](#requirements) above).


### PR DESCRIPTION
Hi guys, I was trying to use the Juju Provider but I didn't find any docs/examples about its use. I think it'd be handy to have them linked in the README. Let me know what you think.

Thanks for doing this, it's gonna be pretty useful for us (Telco team) 😁