### PR TITLE
[JUJU-1938] Ignore similar config values when reading config.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 )
 
 require (
-	github.com/juju/charm/v9 v9.0.0-20220131034618-d197db1afa3d
+	github.com/juju/charm/v8 v8.0.6
 	github.com/juju/errors v1.0.0
 	github.com/rs/zerolog v1.28.0
 )
@@ -78,7 +78,6 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/juju/ansiterm v1.0.0 // indirect
-	github.com/juju/charm/v8 v8.0.6 // indirect
 	github.com/juju/charmrepo/v6 v6.0.3 // indirect
 	github.com/juju/clock v1.0.2 // indirect
 	github.com/juju/cmd/v3 v3.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -474,8 +474,6 @@ github.com/juju/ansiterm v1.0.0/go.mod h1:PyXUpnI3olx3bsPcHt98FGPX/KCFZ1Fi+hw1XL
 github.com/juju/blobstore/v2 v2.0.0 h1:pYXYE7m/RL73EfuwWMQZNuG60jXlL+OsI1qVOM86nwk=
 github.com/juju/charm/v8 v8.0.6 h1:fTm1Kn3JHNVbdsetPas1icMy+MUoCHrpfEW5eqWKlTY=
 github.com/juju/charm/v8 v8.0.6/go.mod h1:tZ0JfWOdv11qu4Gm5lPD0KHBeuVUH2vbrKFyYS6JUAw=
-github.com/juju/charm/v9 v9.0.0-20220131034618-d197db1afa3d h1:Rwsglg4pj1EJUTqUMs1gXQ5z5p3NcSVZbMGXjq2CDuw=
-github.com/juju/charm/v9 v9.0.0-20220131034618-d197db1afa3d/go.mod h1:5mxM1pDiccCU+kHnNhd0wRr4Py2wVrKpxpXTMlTTwi8=
 github.com/juju/charmrepo/v6 v6.0.3 h1:gSdJk0Hc+g3nktVzrs86/YtKIbD9ClOXZ7WpvxYNeCE=
 github.com/juju/charmrepo/v6 v6.0.3/go.mod h1:3bgmJGGixQ205agoj0oFYvCj+VTzDxSQhR20QmUxJJI=
 github.com/juju/clock v0.0.0-20190205081909-9c5c9712527c/go.mod h1:nD0vlnrUjcjJhqN5WuCWZyzfd5AHZAC9/ajvbSx69xA=

--- a/internal/juju/applications.go
+++ b/internal/juju/applications.go
@@ -469,6 +469,10 @@ func (c applicationsClient) ReadApplication(input *ReadApplicationInput) (*ReadA
 	conf := make(map[string]string, 0)
 	if returnedConf.ApplicationConfig != nil {
 		for k, v := range returnedConf.ApplicationConfig {
+			// skip the trust value. We have an independent field for that
+			if k == "trust" {
+				continue
+			}
 			// The API returns the configuration entries as interfaces
 			// In the terraform plan we introduce strings...
 			// so we force this conversion

--- a/internal/juju/client.go
+++ b/internal/juju/client.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/connector"
+	"github.com/rs/zerolog/log"
 )
 
 const (
@@ -73,8 +74,8 @@ func (cf *ConnectionFactory) GetConnection(model *string) (api.Connection, error
 
 	conn, err := connr.Connect()
 	if err != nil {
+		log.Error().Err(err).Msg("connection not established")
 		return nil, err
 	}
-
 	return conn, nil
 }

--- a/internal/provider/resource_application.go
+++ b/internal/provider/resource_application.go
@@ -265,10 +265,10 @@ func resourceApplicationRead(ctx context.Context, d *schema.ResourceData, meta i
 		return diag.FromErr(err)
 	}
 
-	// config will contain a long map with many fields this plan
-	// may not be aware of. We focus on those config entries that
-	// are not the default value. If they are known in the previous
-	// status they will be ignored.
+	// We focus on those config entries that
+	// are not the default value. If the value was the same
+	// we ignore it. If no changes were made, jump to the
+	// next step.
 	previousConfig := d.Get("config").(map[string]interface{})
 	// update the values from the previous config
 	changes := false

--- a/main.go
+++ b/main.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"flag"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 	"github.com/juju/terraform-provider-juju/internal/provider"
+	"github.com/rs/zerolog"
 )
 
 // Run "go generate" to format example terraform files and generate the docs for the registry/website
@@ -30,6 +32,10 @@ func main() {
 
 	flag.BoolVar(&debugMode, "debug", false, "set to true to run the provider with support for debuggers like delve")
 	flag.Parse()
+
+	if debugMode {
+		zerolog.SetGlobalLevel(zerolog.DebugLevel)
+	}
 
 	opts := &plugin.ServeOpts{
 		ProviderFunc: provider.New(version),


### PR DESCRIPTION
When reading an existing application now:
* Ignore configuration elements with `default` values. They are not relevant.
* Ignore configuration values similar to the already existing entries. If the read entry differs, this value will overwrite the existing value in the plan.

This Fixes #96 

Follow a similar scenario to the one described in #96.

1. Prepare a plan
```terraform
provider "juju" {}

resource "juju_model" "test" {
  name = "test"
}

resource "juju_application" "indico" {
  name  = "indico"
  model = juju_model.test.name

  charm {
    name = "indico"
  }

  config = {
    indico_no_reply_email = "test@example.com"
  }
}
```
2. Create the corresponding environment in Juju 2.9.37
```bash
juju bootstrap localhost controllertest
juju add-model test
juju deploy indico --config indico_no_reply_email="test@example.com"
```
3. Run terraform
```bash
terraform init --plugin-dir=/whereveryourpluginsare/ -upgrade
terraform import juju_application.indico test:indico
```
4. Check that the formed plan does not show any changes in the configuration
```bash
Terraform will perform the following actions:

  # juju_application.indico will be updated in-place
  ~ resource "juju_application" "indico" {
        id     = "test:indico"
        name   = "indico"
        # (4 unchanged attributes hidden)

      ~ charm {
          ~ channel  = "stable" -> "latest/stable"
            name     = "indico"
            # (2 unchanged attributes hidden)
        }
    }

  # juju_model.test will be created
  + resource "juju_model" "test" {
      + id   = (known after apply)
      + name = "test"
      + type = (known after apply)

      + cloud {
          + name   = (known after apply)
          + region = (known after apply)
        }
    }

Plan: 1 to add, 1 to change, 0 to destroy.
```
Notice that only the channel will be modified to be latest/stable.

5. (Additional) Update the configuration using the `juju` cli and refresh 
```bash
juju config indico indico_no_reply_email="otheremail@example.com"
terraform plan
....
# juju_application.indico will be updated in-place
  ~ resource "juju_application" "indico" {
      ~ config = {
          ~ "indico_no_reply_email" = "otheremail@example.com" -> "test@example.com"
        }
        id     = "test:indico"
        name   = "indico"
        # (3 unchanged attributes hidden)

      ~ charm {
          ~ channel  = "stable" -> "latest/stable"
            name     = "indico"
            # (2 unchanged attributes hidden)
        }
    }

  # juju_model.test will be created
  + resource "juju_model" "test" {
      + id   = (known after apply)
      + name = "test"
      + type = (known after apply)

      + cloud {
          + name   = (known after apply)
          + region = (known after apply)
        }
    }

Plan: 1 to add, 1 to change, 0 to destroy.
```