### PR TITLE
[JUJU-2125] Set model constraints

### DIFF
--- a/docs/resources/model.md
+++ b/docs/resources/model.md
@@ -39,7 +39,8 @@ resource "juju_model" "this" {
 ### Optional
 
 - `cloud` (Block List, Max: 1) JuJu Cloud where the model will operate (see [below for nested schema](#nestedblock--cloud))
-- `config` (Map of String) Override default model configuration.
+- `config` (Map of String) Override default model configuration
+- `constraints` (String) Constraints imposed to this model
 
 ### Read-Only
 

--- a/internal/juju/models.go
+++ b/internal/juju/models.go
@@ -177,7 +177,6 @@ func (c *modelsClient) CreateModel(input CreateModelInput) (*CreateModelResponse
 	}
 
 	return &CreateModelResponse{ModelInfo: modelInfo}, nil
-
 }
 
 func (c *modelsClient) ReadModel(uuid string) (*ReadModelResponse, error) {

--- a/internal/provider/resource_model_test.go
+++ b/internal/provider/resource_model_test.go
@@ -39,7 +39,7 @@ func TestAcc_ResourceModel_Basic(t *testing.T) {
 			{
 				Config: testAccConstraintsModel(t, modelName, "cores=1 mem=1G"),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "constraints", "cores=1 mem=1G"),
+					resource.TestCheckResourceAttr(resourceName, "constraints", "cores=1 mem=1024M"),
 				),
 			},
 			{

--- a/internal/provider/resource_model_test.go
+++ b/internal/provider/resource_model_test.go
@@ -37,6 +37,12 @@ func TestAcc_ResourceModel_Basic(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccConstraintsModel(t, modelName, "cores=1 mem=1G"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "constraints", "cores=1 mem=1G"),
+				),
+			},
+			{
 				ImportStateVerify: true,
 				ImportState:       true,
 				ImportStateVerifyIgnore: []string{
@@ -140,4 +146,18 @@ resource "juju_model" "model" {
     logging-config = "<root>=%s"
   }
 }`, modelName, logLevel)
+}
+
+func testAccConstraintsModel(t *testing.T, modelName string, constraints string) string {
+	return fmt.Sprintf(`
+resource "juju_model" "model" {
+  name = %q
+
+  cloud {
+   name   = "localhost"
+   region = "localhost"
+  }
+
+  constraints = "%s"
+}`, modelName, constraints)
 }

--- a/internal/provider/resource_model_test.go
+++ b/internal/provider/resource_model_test.go
@@ -37,7 +37,7 @@ func TestAcc_ResourceModel_Basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccConstraintsModel(t, modelName, "cores=1 mem=1G"),
+				Config: testAccConstraintsModel(t, modelName, "cores=1 mem=1024M"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "constraints", "cores=1 mem=1024M"),
 				),


### PR DESCRIPTION
Support for model constraints as requested in #109. 

An additional `constraints` field has been added to the model resources. The string is similar to the one expected by the Juju CLI (see [here](https://juju.is/docs/olm/set-constraints-for-a-model#heading--set-constraints-for-the-initial-controller-and-default-models)).

For the QA, apply a plan with some constraints like this:

```terraform
provider "juju" {}

resource "juju_model" "development" {
  name        = "newmodel2"
  constraints = "cores=2 mem=1G"
}

resource "juju_application" "hello" {
  name  = "hello-kubecon"
  model = juju_model.development.name

  charm {
    name = "hello-kubecon"
  }
}
```
After `terraform apply` you should get the corresponding constraints with juju.
```bash
juju get-model-constraints -m newmodel2
cores=2 mem=1024M
```