### PR TITLE
Add via option to integrations

### DIFF
--- a/docs/resources/integration.md
+++ b/docs/resources/integration.md
@@ -14,6 +14,7 @@ A resource that represents a Juju Integration.
 ```terraform
 resource "juju_integration" "this" {
   model = juju_model.development.name
+  via = "10.0.0.0/24,10.0.1.0/24"
 
   application {
     name     = juju_application.wordpress.name
@@ -35,6 +36,9 @@ resource "juju_integration" "this" {
 - `application` (Block Set, Min: 2, Max: 2) The two applications to integrate. (see [below for nested schema](#nestedblock--application))
 - `model` (String) The name of the model to operate in.
 
+### Optional:
+- `via` (String) A comma-delimited list of CIDRs that can be used when traffic will egress the requiring side of the relation with a modified network address. See [Juju Cross-Model Integrations](https://juju.is/docs/olm/manage-cross-model-integrations) for more details.
+
 ### Read-Only
 
 - `id` (String) The ID of this resource.
@@ -55,6 +59,7 @@ When creating this resource the `offer_url` property will show `(known after app
   + resource "juju_integration" "this" {
       + id    = (known after apply)
       + model = "this"
+      + via   = "10.0.0.0/24,10.0.1.0/24"
 
       + application {
           + endpoint  = (known after apply)

--- a/docs/resources/integration.md
+++ b/docs/resources/integration.md
@@ -14,7 +14,7 @@ A resource that represents a Juju Integration.
 ```terraform
 resource "juju_integration" "this" {
   model = juju_model.development.name
-  via = "10.0.0.0/24,10.0.1.0/24"
+  via   = "10.0.0.0/24,10.0.1.0/24"
 
   application {
     name     = juju_application.wordpress.name
@@ -36,8 +36,9 @@ resource "juju_integration" "this" {
 - `application` (Block Set, Min: 2, Max: 2) The two applications to integrate. (see [below for nested schema](#nestedblock--application))
 - `model` (String) The name of the model to operate in.
 
-### Optional:
-- `via` (String) A comma-delimited list of CIDRs that can be used when traffic will egress the requiring side of the relation with a modified network address. See [Juju Cross-Model Integrations](https://juju.is/docs/olm/manage-cross-model-integrations) for more details.
+### Optional
+
+- `via` (String) A comma separated list of CIDRs for outbound traffic
 
 ### Read-Only
 

--- a/examples/resources/juju_integration/resource.tf
+++ b/examples/resources/juju_integration/resource.tf
@@ -1,5 +1,6 @@
 resource "juju_integration" "this" {
   model = juju_model.development.name
+  via   = "10.0.0.0/24,10.0.1.0/24"
 
   application {
     name     = juju_application.wordpress.name

--- a/internal/juju/integrations.go
+++ b/internal/juju/integrations.go
@@ -1,5 +1,5 @@
-//In comments and in code we refer to integrations which are known in juju 2.x as relations.
-//calls to the upstream juju client currently reference relations
+// In comments and in code we refer to integrations which are known in juju 2.x as relations.
+// calls to the upstream juju client currently reference relations
 package juju
 
 import (
@@ -31,6 +31,7 @@ type Offer struct {
 type IntegrationInput struct {
 	ModelUUID string
 	Endpoints []string
+	ViaCIDRs  string
 }
 
 type CreateIntegrationResponse struct {
@@ -50,6 +51,7 @@ type UpdateIntegrationInput struct {
 	ID           string
 	Endpoints    []string
 	OldEndpoints []string
+	ViaCIDRs     string
 }
 
 func newIntegrationsClient(cf ConnectionFactory) *integrationsClient {
@@ -67,9 +69,10 @@ func (c integrationsClient) CreateIntegration(input *IntegrationInput) (*CreateI
 	client := apiapplication.NewClient(conn)
 	defer client.Close()
 
+	listViaCIDRs := splitCommaDelimitedList(input.ViaCIDRs)
 	response, err := client.AddRelation(
 		input.Endpoints,
-		[]string(nil),
+		listViaCIDRs,
 	)
 	if err != nil {
 		return nil, err
@@ -156,9 +159,10 @@ func (c integrationsClient) UpdateIntegration(input *UpdateIntegrationInput) (*U
 	client := apiapplication.NewClient(conn)
 	defer client.Close()
 
+	listViaCIDRs := splitCommaDelimitedList(input.ViaCIDRs)
 	response, err := client.AddRelation(
 		input.Endpoints,
-		[]string(nil),
+		listViaCIDRs,
 	)
 	if err != nil {
 		return nil, err
@@ -231,7 +235,7 @@ func getStatus(conn api.Connection) (*params.FullStatus, error) {
 	return status, nil
 }
 
-//This function takes remote applications and endpoint status and combines them into a more usable format to return to the provider
+// This function takes remote applications and endpoint status and combines them into a more usable format to return to the provider
 func parseApplications(remoteApplications map[string]params.RemoteApplicationStatus, src interface{}) []Application {
 	applications := make([]Application, 0, 2)
 

--- a/internal/provider/resource_integration.go
+++ b/internal/provider/resource_integration.go
@@ -33,7 +33,7 @@ func resourceIntegration() *schema.Resource {
 			"via": {
 				Description: "A comma separated list of CIDRs for outbound traffic",
 				Type:        schema.TypeString,
-				Required:    false,
+				Optional:    true,
 			},
 			"application": {
 				Description: "The two applications to integrate.",

--- a/internal/provider/resource_integration.go
+++ b/internal/provider/resource_integration.go
@@ -10,7 +10,7 @@ import (
 	"github.com/juju/terraform-provider-juju/internal/juju"
 )
 
-//Currently offers are handled as a part of the integration resource in order to have parity with the CLI. An alternative considered was to create a resource specifically for managing cross model integrations.
+// Currently offers are handled as a part of the integration resource in order to have parity with the CLI. An alternative considered was to create a resource specifically for managing cross model integrations.
 func resourceIntegration() *schema.Resource {
 	return &schema.Resource{
 		Description: "A resource that represents a Juju Integration.",
@@ -29,6 +29,11 @@ func resourceIntegration() *schema.Resource {
 				Description: "The name of the model to operate in.",
 				Type:        schema.TypeString,
 				Required:    true,
+			},
+			"via": {
+				Description: "A comma separated list of CIDRs for outbound traffic",
+				Type:        schema.TypeString,
+				Required:    false,
 			},
 			"application": {
 				Description: "The two applications to integrate.",
@@ -97,9 +102,11 @@ func resourceIntegrationCreate(ctx context.Context, d *schema.ResourceData, meta
 		endpoints = append(endpoints, offerResponse.SAASName)
 	}
 
+	viaCIDRs := d.Get("via").(string)
 	response, err := client.Integrations.CreateIntegration(&juju.IntegrationInput{
 		ModelUUID: modelUUID,
 		Endpoints: endpoints,
+		ViaCIDRs:  viaCIDRs,
 	})
 	if err != nil {
 		return diag.FromErr(err)
@@ -209,11 +216,13 @@ func resourceIntegrationUpdate(ctx context.Context, d *schema.ResourceData, meta
 		}
 	}
 
+	viaCIDRs := d.Get("via").(string)
 	input := &juju.UpdateIntegrationInput{
 		ModelUUID:    modelUUID,
 		ID:           d.Id(),
 		Endpoints:    endpoints,
 		OldEndpoints: oldEndpoints,
+		ViaCIDRs:     viaCIDRs,
 	}
 
 	response, err := client.Integrations.UpdateIntegration(input)
@@ -297,8 +306,8 @@ func generateID(modelName string, apps []juju.Application) string {
 	return id
 }
 
-//This function can be used to parse the terraform data into usable juju endpoints
-//it also does some sanity checks on inputs and returns user friendly errors
+// This function can be used to parse the terraform data into usable juju endpoints
+// it also does some sanity checks on inputs and returns user friendly errors
 func parseEndpoints(apps []interface{}) (endpoints []string, offer *string, err error) {
 	for _, app := range apps {
 		if app == nil {

--- a/internal/provider/resource_integration_test.go
+++ b/internal/provider/resource_integration_test.go
@@ -98,3 +98,76 @@ resource "juju_integration" "this" {
 }
 `, modelName, integrationName)
 }
+
+func TestAcc_ResourceIntegrationWithViaCIDRs(t *testing.T) {
+	srcModelName := acctest.RandomWithPrefix("tf-test-integration")
+	dstModelName := acctest.RandomWithPrefix("tf-test-integration-dst")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		CheckDestroy:      testAccCheckIntegrationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceIntegrationWithVia(srcModelName, dstModelName, "127.0.0.1/32,127.0.0.3/32"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("juju_integration.this", "model", srcModelName),
+					resource.TestCheckResourceAttr("juju_integration.this", "id", fmt.Sprintf("%v:%v:%v", srcModelName, "that:db", "this:db")),
+					resource.TestCheckResourceAttr("juju_integration.this", "application.#", "2"),
+					resource.TestCheckTypeSetElemNestedAttrs("juju_integration.this", "application.*", map[string]string{"name": "this", "endpoint": "db"}),
+				),
+			},
+		},
+	})
+}
+
+func testAccResourceIntegrationWithVia(srcModelName string, dstModelName string, viaCIDRs string) string {
+	return fmt.Sprintf(`
+resource "juju_model" "this" {
+	name = %q
+}
+
+resource "juju_model" "that" {
+	name = %q
+}
+
+resource "juju_application" "this" {
+	model = juju_model.this.name
+	name  = "this" 
+	
+	charm {
+		name = "hello-juju"
+		series = "focal"
+	}
+}
+
+resource "juju_application" "that" {
+	model = juju_model.that.name
+	name  = "that"
+
+	charm {
+		name = "postgresql"
+		series = "focal"
+	}
+}
+
+resource "juju_offer" "that" {
+	model            = juju_model.that.name
+	application_name = juju_application.that.name
+	endpoint         = "db"
+}
+
+resource "juju_integration" "this" {
+	model = juju_model.this.name
+	via = %q
+
+	application {
+		name = juju_application.this.name
+	}
+
+	application {
+		offer_url = juju_offer.that.url
+	}
+}
+`, srcModelName, dstModelName, viaCIDRs)
+}

--- a/templates/resources/integration.md.tmpl
+++ b/templates/resources/integration.md.tmpl
@@ -24,6 +24,7 @@ When creating this resource the `offer_url` property will show `(known after app
   + resource "juju_integration" "this" {
       + id    = (known after apply)
       + model = "this"
+      + via   = "10.0.0.0/24,10.0.1.0/24"
 
       + application {
           + endpoint  = (known after apply)


### PR DESCRIPTION
Hi,

In this PR I've attempted to add the --via option normally used in the `juju relate` command. This allows for communicating across models or even across controllers with cross-model relations where firewall rules/egress is involved. Also somewhat addresses #119.

I kept the implementation similar to that used in the `expose` block so that a comma-delimited string is passed in and this is split up in the Juju module rather than the provider module.

I've added a test but I'm unfamiliar with the testing framework, so if you could please take a look at perhaps improving the test it would be appreciated. The test creates 2 models, an offer and then relates with the offer much like resource_offer_test.go. I did it in this way to test the via option since it is really only useful with applications in separate models, though it could be tested against apps in the same model. Much like the test in resource_offer_test, it takes a long while to run (5 minutes on my machine).
 