### PR TITLE
[JUJU-2356] Additional checks when comparing config values.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,9 +27,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
-        with:
-          go-version-file: "go.mod"
-          cache: true
       - run: go build -v .
 
   generate:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,6 @@ jobs:
         with:
           go-version-file: "go.mod"
           cache: true
-      - run: go mod download
       - run: go build -v .
 
   generate:

--- a/internal/juju/applications.go
+++ b/internal/juju/applications.go
@@ -639,15 +639,18 @@ func (c applicationsClient) UpdateApplication(input *UpdateApplicationInput) err
 	}
 
 	// process configuration
-	var auxConfig map[string]interface{}
+	var auxConfig map[string]string
 	if input.Config != nil {
-		auxConfig = make(map[string]interface{})
+		auxConfig = make(map[string]string)
+		for k, v := range input.Config {
+			auxConfig[k] = ConfigEntryToString(v)
+		}
 	}
 
 	// trust goes inside the config
 	if input.Trust != nil {
 		if auxConfig == nil {
-			auxConfig = make(map[string]interface{})
+			auxConfig = make(map[string]string)
 		}
 		auxConfig["trust"] = fmt.Sprintf("%v", *input.Trust)
 	}

--- a/internal/juju/applications.go
+++ b/internal/juju/applications.go
@@ -55,6 +55,10 @@ func EqualConfigEntries(a interface{}, b interface{}) bool {
 	return a == b
 }
 
+func (ce *ConfigEntry) String() string {
+	return ConfigEntryToString(ce.Value)
+}
+
 // ConfigEntryToString returns the string representation based on
 // the current value.
 func ConfigEntryToString(input interface{}) string {
@@ -516,31 +520,22 @@ func (c applicationsClient) ReadApplication(input *ReadApplicationInput) (*ReadA
 			aux := v.(map[string]interface{})
 			// set if we find the value key and this is not a default
 			// value.
-			// TODO this returns a dictonary with entries using different
-			// type values. Cast the value to the corresponding type.
-			// indicated in the type field"
-			//isDefault, found := aux["source"]
-			//if found && isDefault != "default" {
 			if value, found := aux["value"]; found {
 				conf[k] = ConfigEntry{
 					Value:     value,
 					IsDefault: aux["source"] == "default",
 				}
 			}
-			//}
 		}
 		// repeat the same steps for charm config values
 		for k, v := range returnedConf.CharmConfig {
 			aux := v.(map[string]interface{})
-			// isDefault, found := aux["source"]
-			// if found && isDefault != "default" {
 			if value, found := aux["value"]; found {
 				conf[k] = ConfigEntry{
 					Value:     value,
 					IsDefault: aux["source"] == "default",
 				}
 			}
-			//}
 		}
 	}
 

--- a/internal/juju/applications.go
+++ b/internal/juju/applications.go
@@ -9,6 +9,8 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"reflect"
+	"strconv"
 	"strings"
 
 	"github.com/juju/juju/core/model"
@@ -34,6 +36,40 @@ type applicationsClient struct {
 	ConnectionFactory
 }
 
+// ConfigEntry is an auxiliar struct to
+// keep information about juju config entries.
+// Specially, we want to know if they have the
+// default value.
+type ConfigEntry struct {
+	Value     interface{}
+	IsDefault bool
+}
+
+// EqualConfigEntries compare two juju configuration entries.
+// If both entries share the same type, otherwise they are
+// considered to be different.
+func EqualConfigEntries(a interface{}, b interface{}) bool {
+	if reflect.TypeOf(a) != reflect.TypeOf(b) {
+		return false
+	}
+	return a == b
+}
+
+// ConfigEntryToString returns the string representation based on
+// the current value.
+func ConfigEntryToString(input interface{}) string {
+	switch input.(type) {
+	case bool:
+		return strconv.FormatBool(input.(bool))
+	case int64:
+		return strconv.FormatInt(input.(int64), 10)
+	case float64:
+		return strconv.FormatFloat(input.(float64), 'f', 0, 64)
+	default:
+		return input.(string)
+	}
+}
+
 type CreateApplicationInput struct {
 	ApplicationName string
 	ModelUUID       string
@@ -44,7 +80,7 @@ type CreateApplicationInput struct {
 	Units           int
 	Trust           bool
 	Expose          map[string]interface{}
-	Config          map[string]string
+	Config          map[string]interface{}
 }
 
 type CreateApplicationResponse struct {
@@ -65,7 +101,7 @@ type ReadApplicationResponse struct {
 	Series   string
 	Units    int
 	Trust    bool
-	Config   map[string]string
+	Config   map[string]ConfigEntry
 	Expose   map[string]interface{}
 }
 
@@ -80,7 +116,7 @@ type UpdateApplicationInput struct {
 	Expose   map[string]interface{}
 	// Unexpose indicates what endpoints to unexpose
 	Unexpose []string
-	Config   map[string]string
+	Config   map[string]interface{}
 	//Series    string // TODO: Unsupported for now
 }
 
@@ -261,13 +297,16 @@ func (c applicationsClient) CreateApplication(input *CreateApplicationInput) (*C
 		return nil, err
 	}
 
-	// TODO: This should probably be set within the schema
-	// For now this is the default required behaviour
+	// The deploy API endpoint expects string values for the
+	// constraints.
 	var appConfig map[string]string
-	if input.Config != nil {
-		appConfig = input.Config
-	} else {
+	if input.Config == nil {
 		appConfig = make(map[string]string)
+	} else {
+		appConfig = make(map[string]string, len(input.Config))
+		for k, v := range input.Config {
+			appConfig[k] = ConfigEntryToString(v)
+		}
 	}
 
 	appConfig["trust"] = fmt.Sprintf("%v", input.Trust)
@@ -466,7 +505,7 @@ func (c applicationsClient) ReadApplication(input *ReadApplicationInput) (*ReadA
 		return nil, fmt.Errorf("failed to get app configuration %v", err)
 	}
 
-	conf := make(map[string]string, 0)
+	conf := make(map[string]ConfigEntry, 0)
 	if returnedConf.ApplicationConfig != nil {
 		for k, v := range returnedConf.ApplicationConfig {
 			// skip the trust value. We have an independent field for that
@@ -474,30 +513,34 @@ func (c applicationsClient) ReadApplication(input *ReadApplicationInput) (*ReadA
 				continue
 			}
 			// The API returns the configuration entries as interfaces
-			// In the terraform plan we introduce strings...
-			// so we force this conversion
 			aux := v.(map[string]interface{})
 			// set if we find the value key and this is not a default
 			// value.
 			// TODO this returns a dictonary with entries using different
 			// type values. Cast the value to the corresponding type.
 			// indicated in the type field"
-			isDefault, found := aux["source"]
-			if found && isDefault != "default" {
-				if value, found := aux["value"]; found {
-					conf[k] = fmt.Sprintf("%s", value)
+			//isDefault, found := aux["source"]
+			//if found && isDefault != "default" {
+			if value, found := aux["value"]; found {
+				conf[k] = ConfigEntry{
+					Value:     value,
+					IsDefault: aux["source"] == "default",
 				}
 			}
+			//}
 		}
 		// repeat the same steps for charm config values
 		for k, v := range returnedConf.CharmConfig {
 			aux := v.(map[string]interface{})
-			isDefault, found := aux["source"]
-			if found && isDefault != "default" {
-				if value, found := aux["value"]; found {
-					conf[k] = fmt.Sprintf("%s", value)
+			// isDefault, found := aux["source"]
+			// if found && isDefault != "default" {
+			if value, found := aux["value"]; found {
+				conf[k] = ConfigEntry{
+					Value:     value,
+					IsDefault: aux["source"] == "default",
 				}
 			}
+			//}
 		}
 	}
 
@@ -601,12 +644,15 @@ func (c applicationsClient) UpdateApplication(input *UpdateApplicationInput) err
 	}
 
 	// process configuration
-	auxConfig := input.Config
+	var auxConfig map[string]interface{}
+	if input.Config != nil {
+		auxConfig = make(map[string]interface{})
+	}
 
 	// trust goes inside the config
 	if input.Trust != nil {
 		if auxConfig == nil {
-			auxConfig = make(map[string]string)
+			auxConfig = make(map[string]interface{})
 		}
 		auxConfig["trust"] = fmt.Sprintf("%v", *input.Trust)
 	}
@@ -630,10 +676,6 @@ func (c applicationsClient) UpdateApplication(input *UpdateApplicationInput) err
 	// expose endpoints if required
 	if input.Expose != nil {
 		log.Trace().Interface("endpoints", input.Unexpose).Msg("Expose endpoints")
-		// exposeMap := make(map[string]string)
-		// for k, v := range input.Expose {
-		// 	exposeMap[k] = v.(string)
-		// }
 		err := c.processExpose(applicationAPIClient, input.AppName, input.Expose)
 		if err != nil {
 			log.Error().Err(err).Msg("error when trying to expose")

--- a/internal/juju/applications.go
+++ b/internal/juju/applications.go
@@ -62,13 +62,13 @@ func (ce *ConfigEntry) String() string {
 // ConfigEntryToString returns the string representation based on
 // the current value.
 func ConfigEntryToString(input interface{}) string {
-	switch input.(type) {
+	switch t := input.(type) {
 	case bool:
-		return strconv.FormatBool(input.(bool))
+		return strconv.FormatBool(t)
 	case int64:
-		return strconv.FormatInt(input.(int64), 10)
+		return strconv.FormatInt(t, 10)
 	case float64:
-		return strconv.FormatFloat(input.(float64), 'f', 0, 64)
+		return strconv.FormatFloat(t, 'f', 0, 64)
 	default:
 		return input.(string)
 	}

--- a/internal/provider/resource_application.go
+++ b/internal/provider/resource_application.go
@@ -275,18 +275,18 @@ func resourceApplicationRead(ctx context.Context, d *schema.ResourceData, meta i
 	// known previously
 	// update the values from the previous config
 	changes := false
-
+	// log.Debug().Msgf("--> Previous config was %s", previousConfig)
 	for k, v := range response.Config {
 		// Add if the value has changed from the previous state
 		if previousValue, found := previousConfig[k]; found {
 			if !juju.EqualConfigEntries(v, previousValue) {
 				// remember that this terraform schema type only accepts strings
-				previousConfig[k] = juju.ConfigEntryToString(v)
+				previousConfig[k] = v.String()
 				changes = true
 			}
 		} else if !v.IsDefault {
 			// Add if the value is not default
-			previousConfig[k] = juju.ConfigEntryToString(v)
+			previousConfig[k] = v.String()
 			changes = true
 		}
 
@@ -346,11 +346,10 @@ func resourceApplicationUpdate(ctx context.Context, d *schema.ResourceData, meta
 		oldConfig, newConfig := d.GetChange("config")
 		oldConfigMap := oldConfig.(map[string]interface{})
 		newConfigMap := newConfig.(map[string]interface{})
-		//updateApplicationInput.Config = make(map[string]string, len(config))
 		for k, v := range newConfigMap {
 			// we've lost the type of the config value. We compare the string
 			// values.
-			if !juju.EqualConfigEntries(oldConfigMap[k], v) {
+			if !juju.EqualConfigEntries(oldConfigMap[k], v.(juju.ConfigEntry)) {
 				if updateApplicationInput.Config == nil {
 					// initialize just in case
 					updateApplicationInput.Config = make(map[string]interface{})

--- a/internal/provider/resource_application.go
+++ b/internal/provider/resource_application.go
@@ -289,7 +289,6 @@ func resourceApplicationRead(ctx context.Context, d *schema.ResourceData, meta i
 			previousConfig[k] = v.String()
 			changes = true
 		}
-
 	}
 	// we only set changes if there is any difference between
 	// the previous and the current config values


### PR DESCRIPTION
Due to a limitation in the terraform schema definition, we can only use strings for configuration values. This limits us to treat everything as a string when the configuration values in Juju can have several types (int, bool, float, string). Additional, conversion has to be done between the terraform schema values and the values returned from Juju to ensure that we are comparing the same data type (e.g.: string vs string, int vs int, etc.)

Fix #121 

## QA
Add a model and deploy `ngingx` with some configuration parameters.
```bash
juju add-model nginx-test
juju deploy nginx-ingress-integrator --config limit-rps=10 --config service-hostname="myhostname" --config rewrite-enabled=false
```

Import the model and deployment into the following plan:

```terraform
provider "juju" {}

resource "juju_model" "development" {
  name = "nginx-test"
}

resource "juju_application" "nginx" {
  name = "nginx-ingress-integrator"
  model = juju_model.development.name

  charm {
    name = "nginx-ingress-integrator"
  }

  config = {
    limit-rps = 10
    service-hostname = "myhostname"
    rewrite-enabled = false
  }
}
```
```bash
terraform import juju_model.development nginx-test
terraform import juju_application.nginx nginx-test:nginx-ingress-integrator
```
The terraform plan should not display any change regarding configuration values. Additionally, modify the three configuration parameters, refresh and check they are planned to be modified.

```bash
juju config nginx-ingress-integrator limit-rps=33 service-hostname=changedhostname rewrite-enabled=true
terraform refresh
terraform plan
```
