### PR TITLE
Add capability to set application constraints

### DIFF
--- a/docs/resources/application.md
+++ b/docs/resources/application.md
@@ -44,6 +44,7 @@ resource "juju_application" "this" {
 ### Optional
 
 - `config` (Map of String) Application specific configuration.
+- `constraints` (String) Constraints imposed on this application.
 - `expose` (Block List, Max: 1) Makes an application publicly available over the network (see [below for nested schema](#nestedblock--expose))
 - `name` (String) A custom name for the application deployment. If empty, uses the charm's name.
 - `trust` (Boolean) Set the trust for the application.
@@ -52,6 +53,7 @@ resource "juju_application" "this" {
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+- `principal` (Boolean) Whether this is a Principal application
 
 <a id="nestedblock--charm"></a>
 ### Nested Schema for `charm`


### PR DESCRIPTION
In the same vein as work previously done to enable the setting of model constraints (see issue #109 / PR #118), this commit introduces the capability to set constraints on individual applications.

This requires the addition of a read-only attribute, "principal". This attribute reflects whether the application is principal or not (i.e. subordinate), which is used to avoid errors when trying to get or set constraints for subordinates.

As this is a read-only value which is depended on by a user-configurable value, the Create and Update functions have been updated to trigger a Read action immediately after running, ensuring that all values are accurate.