### PR TITLE
Escape angle brackets in application markdown doc

### DIFF
--- a/docs/resources/application.md
+++ b/docs/resources/application.md
@@ -62,7 +62,7 @@ Required:
 
 Optional:
 
-- `channel` (String) The channel to use when deploying a charm. Specified as <track>/<risk>/<branch>.
+- `channel` (String) The channel to use when deploying a charm. Specified as \<track>/\<risk>/\<branch>.
 - `revision` (Number) The revision of the charm to deploy.
 - `series` (String) The series on which to deploy.
 

--- a/internal/provider/resource_application.go
+++ b/internal/provider/resource_application.go
@@ -51,7 +51,7 @@ func resourceApplication() *schema.Resource {
 							ForceNew:    true,
 						},
 						"channel": {
-							Description: "The channel to use when deploying a charm. Specified as <track>/<risk>/<branch>.",
+							Description: "The channel to use when deploying a charm. Specified as \\<track>/\\<risk>/\\<branch>.",
 							Type:        schema.TypeString,
 							Default:     "latest/stable",
 							Optional:    true,


### PR DESCRIPTION
Currently, the documentation for application -> charm -> channel is generated as `...Specified as <track>/<risk>/<branch>.`. When rendered[1], this produces `...Specified as //.`.

With the proposed change, this is correctly rendered as `...Specified as <track>/<risk>/<branch>`.

This can be verified using the terraform doc-preview[2] tool.

[1] https://registry.terraform.io/providers/juju/juju/latest/docs/resources/application#channel
[2] https://registry.terraform.io/tools/doc-preview