### PR TITLE
[JUJU-2575] Downgrade juju to 2.9.37

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/bflad/tfproviderlint v0.28.1
 	github.com/hashicorp/terraform-plugin-docs v0.13.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.1
-	// v2.9.38
-	github.com/juju/juju v0.0.0-20230105012444-6d211be0d72d
+	// v2.9.37
+	github.com/juju/juju v0.0.0-20221102165234-51672c0e4243
 
 )
 

--- a/go.sum
+++ b/go.sum
@@ -509,8 +509,8 @@ github.com/juju/idmclient/v2 v2.0.0 h1:PsGa092JGy6iFNHZCcao+bigVsTyz1C+tHNRdYmKv
 github.com/juju/idmclient/v2 v2.0.0/go.mod h1:EOiFbPmnkqKvCUS/DHpDRWhL7eKF0AJaTvMjIYlIUak=
 github.com/juju/jsonschema v1.0.0 h1:2ScR9hhVdHxft+Te3fnclVx61MmlikHNEOirTGi+hV4=
 github.com/juju/jsonschema v1.0.0/go.mod h1:SlFW+jFtpWX0P4Tb+zTTPR4ufttLrnJIdQPePxVEfkM=
-github.com/juju/juju v0.0.0-20230105012444-6d211be0d72d h1:M5iLH2O47Nvoqr3Smq0Zzbx/mt/OuKGEONJmzlFwTIc=
-github.com/juju/juju v0.0.0-20230105012444-6d211be0d72d/go.mod h1:fOy3LTxFGxABu9e3tg+a8Fu7NFjy24yZt/IIkgKFLvs=
+github.com/juju/juju v0.0.0-20221102165234-51672c0e4243 h1:BL+zEgnN6WNcht7gX9wHfnibQ+u/fmRkv0UpqeWOk9I=
+github.com/juju/juju v0.0.0-20221102165234-51672c0e4243/go.mod h1:1rW/RaZ5EeZAAFYg0CVdgGP0WeVO2hbVYM4Z2ITPUvc=
 github.com/juju/loggo v0.0.0-20170605014607-8232ab8918d9/go.mod h1:vgyd7OREkbtVEN/8IXZe5Ooef3LQePvuBm9UWj6ZL8U=
 github.com/juju/loggo v0.0.0-20200526014432-9ce3a2e09b5e/go.mod h1:vgyd7OREkbtVEN/8IXZe5Ooef3LQePvuBm9UWj6ZL8U=
 github.com/juju/loggo v0.0.0-20210728185423-eebad3a902c4/go.mod h1:NIXFioti1SmKAlKNuUwbMenNdef59IF52+ZzuOmHYkg=


### PR DESCRIPTION
As observed in [PR131](https://github.com/juju/terraform-provider-juju/pull/131#pullrequestreview-1269898941), there are potential problems with juju 2.9.38. Until this is fixed, we downgrade Juju to 2.9.37