### PR TITLE
[JUJU-2651] Upload artifacts when the use case is not tested

### DIFF
--- a/.github/workflows/test_new_candidates.yml
+++ b/.github/workflows/test_new_candidates.yml
@@ -45,8 +45,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ env.juju_track }}
+          if_no_artifact_found: ignore
+          workflow_conclusion: success
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: dawidd6/action-download-artifact@v2
         id: download_artifact
         with:
           name: ${{ env.id }}

--- a/.github/workflows/test_new_candidates.yml
+++ b/.github/workflows/test_new_candidates.yml
@@ -36,7 +36,7 @@ jobs:
           channel=$(echo ${{ matrix.juju_track }}/${{ matrix.juju_risk }})
           echo "Target channel is $channel"
           echo "channel=$channel" >> $GITHUB_ENV
-          id=$(echo ${{ matrix.juju_track }}-${{ matrix.juju_risk }}-${{ matrix. terraform }})
+          id=$(echo ${{ github.sha }}-${{ matrix.juju_track }}-${{ matrix.juju_risk }}-${{ matrix. terraform }})
           echo "Target id is $id"
           echo "id=$id" >> $GITHUB_ENV
       - name: Download artifact
@@ -103,11 +103,12 @@ jobs:
           juju show-controller | yq .$CONTROLLER.details.ca-cert >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
       - name: Run integration tests
+        id: test
         env:
           TF_ACC: "1"
         run: go test -v -cover ./internal/provider/
         timeout-minutes: 30   
-      - if: ${{ env.next-test != 'NA' }}
+      - if: success()
         uses: actions/upload-artifact@v3
         with:
           name: ${{ env.id }}

--- a/.github/workflows/test_new_candidates.yml
+++ b/.github/workflows/test_new_candidates.yml
@@ -45,13 +45,13 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ env.juju_track }}
-          if_no_artifact_found: ignore
-          workflow_conclusion: success
       - name: Download artifact
         uses: dawidd6/action-download-artifact@v2
         id: download_artifact
         with:
           name: ${{ env.id }}
+          if_no_artifact_found: ignore
+          workflow_conclusion: success
       - name: Check latest juju version tested
         # If we could not find the artifact, it means
         # that we have not tested successfully this item.

--- a/.github/workflows/test_new_candidates.yml
+++ b/.github/workflows/test_new_candidates.yml
@@ -53,16 +53,12 @@ jobs:
           if_no_artifact_found: ignore
           workflow_conclusion: success
       - name: Check latest juju version tested
-        # If we could not find the artifact, it means
-        # that we have not tested successfully this item.
-        continue-on-error: true
-        if: failure()
         shell: bash
         run: |
           candidate=$(snap info juju | grep ${{ env.channel }} | awk '{print $2}')
           last_tested=NA
-          if [ -f ${{ env.channel }} ]; then
-            last_tested=$(cat ${{ env.channel }})
+          if [ -f ${{ env.id }} ]; then
+            last_tested=$(cat ${{ env.id }})
           fi
           echo "Last tested was $last_tested"
           echo "Latest juju version found is $candidate"
@@ -80,21 +76,25 @@ jobs:
           echo "next-test=$next_test" >> $GITHUB_ENV
           echo "$next_test" > ~/${{ env.id }}
       - name: Setup go
+        if: ${{ env.next-test != 'NA' }}
         uses: actions/setup-go@v3
         with:
           go-version-file: "go.mod"
           cache: true
       - name: Install terraform
+        if: ${{ env.next-test != 'NA' }}
         uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: ${{ matrix.terraform }}
           terraform_wrapper: false
       - name: Install target juju
+        if: ${{ env.next-test != 'NA' }}
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: lxd
           juju-channel: ${{ env.channel }}
       - name: "Set environment to configure provider"
+        if: ${{ env.next-test != 'NA' }}
         run: |
           CONTROLLER=$(juju whoami --format yaml | yq .controller)
 
@@ -105,14 +105,14 @@ jobs:
           juju show-controller | yq .$CONTROLLER.details.ca-cert >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
       - name: Run integration tests
+        if: ${{ env.next-test != 'NA' }}
         id: test
         env:
           TF_ACC: "1"
         run: go test -timeout 30m -v -cover ./internal/provider/
         timeout-minutes: 30   
       - uses: actions/upload-artifact@v3
-        # if everything worked, we upload the artifact
-        if: success()
+        if: ${{ env.next-test != 'NA' }}
         with:
           name: ${{ env.id }}
           path: "~/${{ env.id }}"

--- a/.github/workflows/test_new_candidates.yml
+++ b/.github/workflows/test_new_candidates.yml
@@ -25,12 +25,12 @@ jobs:
           - "2.9"
         juju_risk:
           - "candidate"
-          - "edge"
+          # - "edge"
         terraform:
           - "0.15"
           - "1.0"
-          - "1.1"
-          - "1.2"
+          # - "1.1"
+          # - "1.2"
 
     steps:
       - name: Set channel and artifact id
@@ -38,17 +38,23 @@ jobs:
           channel=$(echo ${{ matrix.juju_track }}/${{ matrix.juju_risk }})
           echo "Target channel is $channel"
           echo "channel=$channel" >> $GITHUB_ENV
-          id=$(echo ${{ github.sha }}-${{ matrix.juju_track }}-${{ matrix.juju_risk }}-${{ matrix. terraform }})
+          id=$(echo ${{ github.sha }}-${{ matrix.juju_track }}-${{ matrix.juju_risk }}-${{ matrix.terraform }})
           echo "Target id is $id"
           echo "id=$id" >> $GITHUB_ENV
+      - name: Checkout branch
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ env.juju_track }}
       - name: Download artifact
-        uses: dawidd6/action-download-artifact@v2
+        uses: actions/download-artifact@v3
         id: download_artifact
         with:
-          workflow_conclusion: success
           name: ${{ env.id }}
-          if_no_artifact_found: ignore
       - name: Check latest juju version tested
+        # If we could not find the artifact, it means
+        # that we have not tested successfully this item.
+        continue-on-error: true
+        if: failure()
         shell: bash
         run: |
           candidate=$(snap info juju | grep ${{ env.channel }} | awk '{print $2}')
@@ -71,13 +77,7 @@ jobs:
           fi
           echo "next-test=$next_test" >> $GITHUB_ENV
           echo "$next_test" > ~/${{ env.id }}
-      - name: Checkout branch
-        if: ${{ env.next-test != 'NA' }}
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ env.juju_track }}
       - name: Setup go
-        if: ${{ env.next-test != 'NA' }}
         uses: actions/setup-go@v3
         with:
           go-version-file: "go.mod"
@@ -88,13 +88,11 @@ jobs:
           terraform_version: ${{ matrix.terraform }}
           terraform_wrapper: false
       - name: Install target juju
-        if: ${{ env.next-test != 'NA' }}
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: lxd
           juju-channel: ${{ env.channel }}
       - name: "Set environment to configure provider"
-        # language=bash
         run: |
           CONTROLLER=$(juju whoami --format yaml | yq .controller)
 
@@ -110,8 +108,9 @@ jobs:
           TF_ACC: "1"
         run: go test -timeout 30m -v -cover ./internal/provider/
         timeout-minutes: 30   
-      - if: success()
-        uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v3
+        # if everything worked, we upload the artifact
+        if: success()
         with:
           name: ${{ env.id }}
           path: "~/${{ env.id }}"

--- a/.github/workflows/test_new_candidates.yml
+++ b/.github/workflows/test_new_candidates.yml
@@ -3,6 +3,8 @@ name: Test new juju candidates
 on:
   schedule:
     - cron: "0 0 * * *"  # Run at 12AM UTC, every day
+  pull_request:
+    
 
 
 # Testing only needs permissions to read the repository contents.

--- a/.github/workflows/test_new_candidates.yml
+++ b/.github/workflows/test_new_candidates.yml
@@ -3,9 +3,6 @@ name: Test new juju candidates
 on:
   schedule:
     - cron: "0 0 * * *"  # Run at 12AM UTC, every day
-  pull_request:
-    
-
 
 # Testing only needs permissions to read the repository contents.
 permissions:
@@ -29,9 +26,8 @@ jobs:
         terraform:
           - "0.15"
           - "1.0"
-          # - "1.1"
-          # - "1.2"
-
+          - "1.1"
+          - "1.2"
     steps:
       - name: Set channel and artifact id
         run: |

--- a/.github/workflows/test_new_candidates.yml
+++ b/.github/workflows/test_new_candidates.yml
@@ -108,7 +108,7 @@ jobs:
         id: test
         env:
           TF_ACC: "1"
-        run: go test -v -cover ./internal/provider/
+        run: go test -timeout 30m -v -cover ./internal/provider/
         timeout-minutes: 30   
       - if: success()
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
When a deployment scenario has already been tested, we have to upload the artifact for the next running. Otherwise, we rerun tests unnecessarily.

Additionally, we extend the proof id to include the commit sha.