### PR TITLE
[JUJU-2639] Fix error when setting model constraints.

### DIFF
--- a/internal/juju/models.go
+++ b/internal/juju/models.go
@@ -2,6 +2,7 @@ package juju
 
 import (
 	"fmt"
+	"log"
 	"strings"
 	"time"
 
@@ -14,8 +15,6 @@ import (
 	"github.com/juju/juju/api/client/modelmanager"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/names/v4"
-
-	"github.com/rs/zerolog/log"
 )
 
 type modelsClient struct {

--- a/internal/juju/models.go
+++ b/internal/juju/models.go
@@ -18,14 +18,6 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-const (
-	// WaitModelTimeout set the maximum time for models to be set up
-	WaitModelTimeout = time.Minute * 10
-	// WaitModelInterval sets the time to wait between model status
-	// requests
-	WaitModelInterval = time.Second * 5
-)
-
 type modelsClient struct {
 	ConnectionFactory
 }

--- a/internal/juju/models.go
+++ b/internal/juju/models.go
@@ -170,7 +170,7 @@ func (c *modelsClient) CreateModel(input CreateModelInput) (*CreateModelResponse
 	}
 
 	// we have to set constraints ...
-	// stablish a new connection with the target model and set constraints
+	// establish a new connection with the created model through the modelconfig api to set constraints
 	connModel, err := c.GetConnection(&modelInfo.UUID)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This PR fixes #109 

Erroneously during the model creation the model config client was establishing a connection with the controller instead of the new model.

## QA
Bootstrap a controller and run the following plan.
```

provider "juju" {}

resource "juju_model" "development" {
  name = "development"

  constraints = "mem=1024M"
}

resource "juju_application" "ubuntu" {
  name = "ubuntu"

  model = juju_model.development.name

  charm {
    name = "ubuntu"
  }
}
```
Next, check that the model constraints are correct.
```
juju model-constraints -m development
mem=1024M
```