### PR TITLE
Support managing users

### DIFF
--- a/examples/resources/juju_users/import.sh
+++ b/examples/resources/juju_users/import.sh
@@ -1,0 +1,2 @@
+# Users can be imported using the user name
+$ terraform import juju_user.dev-user dev-user

--- a/examples/resources/juju_users/resource.tf
+++ b/examples/resources/juju_users/resource.tf
@@ -1,0 +1,5 @@
+resource "juju_user" "this" {
+  name         = "dev-user"
+  display_name = format("%s - terraform managed", "dev-user")
+  password     = var.password
+}

--- a/internal/juju/client.go
+++ b/internal/juju/client.go
@@ -29,6 +29,7 @@ type Client struct {
 	Applications applicationsClient
 	Integrations integrationsClient
 	Offers       offersClient
+	Users        usersClient
 }
 
 type ConnectionFactory struct {

--- a/internal/juju/client.go
+++ b/internal/juju/client.go
@@ -46,6 +46,7 @@ func NewClient(config Configuration) (*Client, error) {
 		Applications: *newApplicationClient(cf),
 		Integrations: *newIntegrationsClient(cf),
 		Offers:       *newOffersClient(cf),
+		Users:        *newUsersClient(cf),
 	}, nil
 }
 

--- a/internal/juju/users.go
+++ b/internal/juju/users.go
@@ -2,9 +2,6 @@ package juju
 
 import (
 	"fmt"
-	"strings"
-
-	"github.com/juju/juju/api"
 
 	"github.com/juju/juju/api/client/usermanager"
 	"github.com/juju/juju/rpc/params"
@@ -50,10 +47,6 @@ func newUsersClient(cf ConnectionFactory) *usersClient {
 	return &usersClient{
 		ConnectionFactory: cf,
 	}
-}
-
-func (c *usersClient) getCurrentUser(conn api.Connection) string {
-	return strings.TrimPrefix(conn.AuthTag().String(), PrefixUser)
 }
 
 func (c *usersClient) CreateUser(input CreateUserInput) (*CreateUserResponse, error) {

--- a/internal/juju/users.go
+++ b/internal/juju/users.go
@@ -1,0 +1,138 @@
+package juju
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/juju/juju/api"
+
+	"github.com/juju/juju/api/client/usermanager"
+	"github.com/juju/juju/rpc/params"
+	"github.com/juju/names/v4"
+)
+
+type usersClient struct {
+	ConnectionFactory
+}
+
+type CreateUserInput struct {
+	Name        string
+	DisplayName string
+	Model       string
+	Password    string
+}
+
+type CreateUserResponse struct {
+	UserTag names.UserTag
+	Secret  []byte
+}
+
+type ReadUserInput struct {
+	Name string
+}
+
+type ReadUserResponse struct {
+	UserInfo params.UserInfo
+}
+
+type UpdateUserInput struct {
+	Name        string
+	DisplayName string
+	User        string
+	Password    string
+}
+
+type DestroyUserInput struct {
+	Name string
+}
+
+func newUsersClient(cf ConnectionFactory) *usersClient {
+	return &usersClient{
+		ConnectionFactory: cf,
+	}
+}
+
+func (c *usersClient) getCurrentUser(conn api.Connection) string {
+	return strings.TrimPrefix(conn.AuthTag().String(), PrefixUser)
+}
+
+func (c *usersClient) CreateUser(input CreateUserInput) (*CreateUserResponse, error) {
+	conn, err := c.GetConnection(nil)
+	if err != nil {
+		return nil, err
+	}
+
+	client := usermanager.NewClient(conn)
+	defer client.Close()
+
+	userTag, userSecret, err := client.AddUser(input.Name, input.DisplayName, input.Password)
+	if err != nil {
+		return nil, err
+	}
+
+	return &CreateUserResponse{UserTag: userTag, Secret: userSecret}, nil
+}
+
+func (c *usersClient) ReadUser(name string) (*ReadUserResponse, error) {
+	usermanagerConn, err := c.GetConnection(nil)
+	if err != nil {
+		return nil, err
+	}
+
+	usermanagerClient := usermanager.NewClient(usermanagerConn)
+	defer usermanagerClient.Close()
+
+	users, err := usermanagerClient.UserInfo([]string{name}, false) //don't list disabled users
+	if err != nil {
+		return nil, err
+	}
+
+	if len(users) > 1 {
+		return nil, fmt.Errorf("more than one user returned for user name: %s", name)
+	}
+	if len(users) < 1 {
+		return nil, fmt.Errorf("no user returned for user name: %s", name)
+	}
+
+	userInfo := users[0]
+
+	return &ReadUserResponse{
+		UserInfo: userInfo,
+	}, nil
+}
+
+func (c *usersClient) UpdateUser(input UpdateUserInput) error {
+	conn, err := c.GetConnection(nil)
+	if err != nil {
+		return err
+	}
+
+	client := usermanager.NewClient(conn)
+	defer client.Close()
+
+	if input.Password != "" {
+		err = client.SetPassword(input.Name, input.Password)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *usersClient) DestroyUser(input DestroyUserInput) error {
+	conn, err := c.GetConnection(nil)
+	if err != nil {
+		return err
+	}
+
+	client := usermanager.NewClient(conn)
+	defer client.Close()
+
+	err = client.RemoveUser(input.Name)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -58,6 +58,7 @@ func New(version string) func() *schema.Provider {
 			},
 			ResourcesMap: map[string]*schema.Resource{
 				"juju_model":       resourceModel(),
+				"juju_user":        resourceUser(),
 				"juju_application": resourceApplication(),
 				"juju_integration": resourceIntegration(),
 				"juju_offer":       resourceOffer(),

--- a/internal/provider/resource_user.go
+++ b/internal/provider/resource_user.go
@@ -22,7 +22,7 @@ func resourceUser() *schema.Resource {
 		UpdateContext: resourceUserUpdate,
 		DeleteContext: resourceUserDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/internal/provider/resource_user.go
+++ b/internal/provider/resource_user.go
@@ -9,9 +9,8 @@ import (
 )
 
 // The User resource maps to a juju user that is operated via
-// `juju add-user [--model <modelname>]`, `juju remove-user`
-// Display name and model are optional. If no model is given,
-// the user is granted global (login) permissions.
+// `juju add-user`, `juju remove-user`
+// Display name is optional.
 func resourceUser() *schema.Resource {
 	return &schema.Resource{
 		// This description is used by the documentation generator and the language server.

--- a/internal/provider/resource_user.go
+++ b/internal/provider/resource_user.go
@@ -37,11 +37,6 @@ func resourceUser() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 			},
-			"model": {
-				Description: "The model to be assigned to the user",
-				Type:        schema.TypeString,
-				Optional:    true,
-			},
 			"password": {
 				Description: "The password to be assigned to the user",
 				Type:        schema.TypeString,
@@ -58,13 +53,11 @@ func resourceUserCreate(ctx context.Context, d *schema.ResourceData, meta interf
 
 	name := d.Get("name").(string)
 	displayName := d.Get("display_name").(string)
-	model := d.Get("model").(string)
 	password := d.Get("password").(string)
 
 	_, err := client.Users.CreateUser(juju.CreateUserInput{
 		Name:        name,
 		DisplayName: displayName,
-		Model:       model,
 		Password:    password,
 	})
 	if err != nil {

--- a/internal/provider/resource_user.go
+++ b/internal/provider/resource_user.go
@@ -2,6 +2,8 @@ package provider
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -63,7 +65,7 @@ func resourceUserCreate(ctx context.Context, d *schema.ResourceData, meta interf
 		return diag.FromErr(err)
 	}
 
-	d.SetId(name)
+	d.SetId(fmt.Sprintf("user-%s", name))
 
 	return diags
 }
@@ -73,7 +75,8 @@ func resourceUserRead(ctx context.Context, d *schema.ResourceData, meta interfac
 
 	var diags diag.Diagnostics
 
-	name := d.Id()
+	id := strings.Split(d.Id(), "-")
+	name := id[1]
 	response, err := client.Users.ReadUser(name)
 	if err != nil {
 		return diag.FromErr(err)
@@ -108,8 +111,10 @@ func resourceUserUpdate(ctx context.Context, d *schema.ResourceData, meta interf
 		return diags
 	}
 
+	id := strings.Split(d.Id(), "-")
+	name := id[1]
 	err = client.Users.UpdateUser(juju.UpdateUserInput{
-		Name:     d.Id(),
+		Name:     name,
 		Password: newPassword,
 	})
 	if err != nil {
@@ -126,7 +131,8 @@ func resourceUserDelete(ctx context.Context, d *schema.ResourceData, meta interf
 
 	var diags diag.Diagnostics
 
-	name := d.Id()
+	id := strings.Split(d.Id(), "-")
+	name := id[1]
 
 	err := client.Users.DestroyUser(juju.DestroyUserInput{
 		Name: name,

--- a/internal/provider/resource_user.go
+++ b/internal/provider/resource_user.go
@@ -65,7 +65,7 @@ func resourceUserCreate(ctx context.Context, d *schema.ResourceData, meta interf
 		return diag.FromErr(err)
 	}
 
-	d.SetId(fmt.Sprintf("user-%s", name))
+	d.SetId(fmt.Sprintf("user:%s", name))
 
 	return diags
 }
@@ -75,7 +75,7 @@ func resourceUserRead(ctx context.Context, d *schema.ResourceData, meta interfac
 
 	var diags diag.Diagnostics
 
-	id := strings.Split(d.Id(), "-")
+	id := strings.Split(d.Id(), ":")
 	name := id[1]
 	response, err := client.Users.ReadUser(name)
 	if err != nil {
@@ -111,7 +111,7 @@ func resourceUserUpdate(ctx context.Context, d *schema.ResourceData, meta interf
 		return diags
 	}
 
-	id := strings.Split(d.Id(), "-")
+	id := strings.Split(d.Id(), ":")
 	name := id[1]
 	err = client.Users.UpdateUser(juju.UpdateUserInput{
 		Name:     name,
@@ -131,7 +131,7 @@ func resourceUserDelete(ctx context.Context, d *schema.ResourceData, meta interf
 
 	var diags diag.Diagnostics
 
-	id := strings.Split(d.Id(), "-")
+	id := strings.Split(d.Id(), ":")
 	name := id[1]
 
 	err := client.Users.DestroyUser(juju.DestroyUserInput{

--- a/internal/provider/resource_user.go
+++ b/internal/provider/resource_user.go
@@ -1,0 +1,169 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/juju/terraform-provider-juju/internal/juju"
+)
+
+// The User resource maps to a juju user that is operated via
+// `juju add-user [--model <modelname>]`, `juju remove-user`
+// Display name and model are optional. If no model is given,
+// the user is granted global (login) permissions.
+func resourceUser() *schema.Resource {
+	return &schema.Resource{
+		// This description is used by the documentation generator and the language server.
+		Description: "A resource that represent a Juju User.",
+
+		CreateContext: resourceUserCreate,
+		ReadContext:   resourceUserRead,
+		UpdateContext: resourceUserUpdate,
+		DeleteContext: resourceUserDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceUserImporter,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Description: "The name to be assigned to the user",
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+			},
+			"display_name": {
+				Description: "The display name to be assigned to the user",
+				Type:        schema.TypeString,
+				Optional:    true,
+			},
+			"model": {
+				Description: "The model to be assigned to the user",
+				Type:        schema.TypeString,
+				Optional:    true,
+			},
+			"password": {
+				Description: "The password to be assigned to the user",
+				Type:        schema.TypeString,
+				Required:    true,
+			},
+		},
+	}
+}
+
+func resourceUserCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*juju.Client)
+
+	var diags diag.Diagnostics
+
+	name := d.Get("name").(string)
+	displayName := d.Get("display_name").(string)
+	model := d.Get("model").(string)
+	password := d.Get("password").(string)
+
+	_, err := client.Users.CreateUser(juju.CreateUserInput{
+		Name:        name,
+		DisplayName: displayName,
+		Model:       model,
+		Password:    password,
+	})
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(name)
+
+	return diags
+}
+
+func resourceUserRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*juju.Client)
+
+	var diags diag.Diagnostics
+
+	name := d.Id()
+	response, err := client.Users.ReadUser(name)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := d.Set("name", response.UserInfo.Username); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("display_name", response.UserInfo.DisplayName); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return diags
+}
+
+func resourceUserUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*juju.Client)
+
+	var diags diag.Diagnostics
+	anyChange := false
+
+	var newDisplayName string
+
+	var err error
+
+	if d.HasChange("display_name") {
+		anyChange = true
+		newDisplayName = d.Get("display_name").(string)
+	}
+
+	if !anyChange {
+		return diags
+	}
+
+	err = client.Users.UpdateUser(juju.UpdateUserInput{
+		Name:        d.Id(),
+		DisplayName: newDisplayName,
+	})
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return diags
+}
+
+// Juju refers to user deletion as "destroy" so we call the Destroy function of our client here rather than delete
+// This function remains named Delete for parity across the provider and to stick within terraform naming conventions
+func resourceUserDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*juju.Client)
+
+	var diags diag.Diagnostics
+
+	name := d.Id()
+
+	err := client.Users.DestroyUser(juju.DestroyUserInput{
+		Name: name,
+	})
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId("")
+
+	return diags
+}
+
+func resourceUserImporter(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	client := meta.(*juju.Client)
+
+	//d.Id() here is the last argument passed to the `terraform import juju_model.RESOURCE_NAME USER_NAME` command
+	//because we import based on model name we load it into `modelName` here for clarity
+	name := d.Id()
+
+	user, err := client.Users.ReadUser(name)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = d.Set("name", user.UserInfo.Username); err != nil {
+		return nil, err
+	}
+	d.SetId(user.UserInfo.Username)
+
+	return []*schema.ResourceData{d}, nil
+}

--- a/internal/provider/resource_user.go
+++ b/internal/provider/resource_user.go
@@ -96,13 +96,13 @@ func resourceUserUpdate(ctx context.Context, d *schema.ResourceData, meta interf
 	var diags diag.Diagnostics
 	anyChange := false
 
-	var newDisplayName string
+	var newPassword string
 
 	var err error
 
-	if d.HasChange("display_name") {
+	if d.HasChange("password") {
 		anyChange = true
-		newDisplayName = d.Get("display_name").(string)
+		newPassword = d.Get("password").(string)
 	}
 
 	if !anyChange {
@@ -110,8 +110,8 @@ func resourceUserUpdate(ctx context.Context, d *schema.ResourceData, meta interf
 	}
 
 	err = client.Users.UpdateUser(juju.UpdateUserInput{
-		Name:        d.Id(),
-		DisplayName: newDisplayName,
+		Name:     d.Id(),
+		Password: newPassword,
 	})
 	if err != nil {
 		return diag.FromErr(err)

--- a/internal/provider/resource_user.go
+++ b/internal/provider/resource_user.go
@@ -22,7 +22,7 @@ func resourceUser() *schema.Resource {
 		UpdateContext: resourceUserUpdate,
 		DeleteContext: resourceUserDelete,
 		Importer: &schema.ResourceImporter{
-			StateContext: resourceUserImporter,
+			State: schema.ImportStatePassthrough,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -146,24 +146,4 @@ func resourceUserDelete(ctx context.Context, d *schema.ResourceData, meta interf
 	d.SetId("")
 
 	return diags
-}
-
-func resourceUserImporter(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	client := meta.(*juju.Client)
-
-	//d.Id() here is the last argument passed to the `terraform import juju_model.RESOURCE_NAME USER_NAME` command
-	//because we import based on model name we load it into `modelName` here for clarity
-	name := d.Id()
-
-	user, err := client.Users.ReadUser(name)
-	if err != nil {
-		return nil, err
-	}
-
-	if err = d.Set("name", user.UserInfo.Username); err != nil {
-		return nil, err
-	}
-	d.SetId(user.UserInfo.Username)
-
-	return []*schema.ResourceData{d}, nil
 }

--- a/internal/provider/resource_user_test.go
+++ b/internal/provider/resource_user_test.go
@@ -1,0 +1,46 @@
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAcc_ResourceUser_Basic(t *testing.T) {
+	userName := "tftestuser"
+	userPassword := acctest.RandomWithPrefix("tf-test-user")
+
+	resourceName := "juju_user.user"
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceUser(t, userName, userPassword),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", userName),
+				),
+			},
+			{
+				ImportStateVerify: true,
+				ImportState:       true,
+				ImportStateVerifyIgnore: []string{
+					"config.%",
+					"config.logging-config"},
+				ImportStateId: userName,
+				ResourceName:  resourceName,
+			},
+		},
+	})
+}
+
+func testAccResourceUser(t *testing.T, userName, userPassword string) string {
+	return fmt.Sprintf(`
+resource "juju_user" "user" {
+  name = %q
+  password = %q
+
+}`, userName, userPassword)
+}

--- a/internal/provider/resource_user_test.go
+++ b/internal/provider/resource_user_test.go
@@ -27,7 +27,7 @@ func TestAcc_ResourceUser_Basic(t *testing.T) {
 				ImportStateVerify:       true,
 				ImportState:             true,
 				ImportStateVerifyIgnore: []string{"password"},
-				ImportStateId:           userName,
+				ImportStateId:           fmt.Sprintf("user:%s", userName),
 				ResourceName:            resourceName,
 			},
 		},

--- a/internal/provider/resource_user_test.go
+++ b/internal/provider/resource_user_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestAcc_ResourceUser_Basic(t *testing.T) {
-	userName := "tftestuser"
+	userName := acctest.RandomWithPrefix("tfuser")
 	userPassword := acctest.RandomWithPrefix("tf-test-user")
 
 	resourceName := "juju_user.user"
@@ -24,13 +24,11 @@ func TestAcc_ResourceUser_Basic(t *testing.T) {
 				),
 			},
 			{
-				ImportStateVerify: true,
-				ImportState:       true,
-				ImportStateVerifyIgnore: []string{
-					"config.%",
-					"config.logging-config"},
-				ImportStateId: userName,
-				ResourceName:  resourceName,
+				ImportStateVerify:       true,
+				ImportState:             true,
+				ImportStateVerifyIgnore: []string{"password"},
+				ImportStateId:           userName,
+				ResourceName:            resourceName,
 			},
 		},
 	})


### PR DESCRIPTION
This is a PR that enables managing users (`add`, `remove`). It closes #143. It updates on a password change only as changing the `display name` does not correspond to a juju API call. To be consistent with the juju CLI, it won't manipulate model access here, that would be done with `grant`ing additional permission in #144 .