### PR TITLE
Add Import for Offer (#125)

### DIFF
--- a/docs/resources/offer.md
+++ b/docs/resources/offer.md
@@ -52,4 +52,15 @@ resource "juju_integration" "this" {
 - `id` (String) The ID of this resource.
 - `url` (String) The offer URL.
 
+## Import
 
+Import is supported using the following syntax:
+
+```shell
+# Offers can be imported by using the URL as in the juju show-offers output.
+# Example:
+# $juju show-offer mysql
+# Store            URL             Access  Description                                    Endpoint  Interface  Role
+# mycontroller     admin/db.mysql  admin   MariaDB Server is one of the most ...          mysql     mysql      provider
+$ terraform import juju_offer.db admin/db.mysql
+```

--- a/examples/resources/juju_offer/import.sh
+++ b/examples/resources/juju_offer/import.sh
@@ -1,0 +1,6 @@
+# Offers can be imported by using the URL as in the juju show-offers output.
+# Example:
+# $juju show-offer mysql
+# Store            URL             Access  Description                                    Endpoint  Interface  Role
+# mycontroller     admin/db.mysql  admin   MariaDB Server is one of the most ...          mysql     mysql      provider
+$ terraform import juju_offer.db admin/db.mysql

--- a/internal/provider/resource_offer.go
+++ b/internal/provider/resource_offer.go
@@ -16,7 +16,9 @@ func resourceOffer() *schema.Resource {
 		CreateContext: resourceOfferCreate,
 		ReadContext:   resourceOfferRead,
 		DeleteContext: resourceOfferDelete,
-
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceOfferImporter,
+		},
 		Schema: map[string]*schema.Schema{
 			"model": {
 				Description: "The name of the model to operate in.",
@@ -109,7 +111,7 @@ func resourceOfferRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	var diags diag.Diagnostics
 
 	result, err := client.Offers.ReadOffer(&juju.ReadOfferInput{
-		OfferURL: d.Get("url").(string),
+		OfferURL: d.Id(),
 	})
 	if err != nil {
 		return diag.FromErr(err)
@@ -150,4 +152,8 @@ func resourceOfferDelete(ctx context.Context, d *schema.ResourceData, meta inter
 	d.SetId("")
 
 	return diags
+}
+
+func resourceOfferImporter(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	return []*schema.ResourceData{d}, nil
 }

--- a/internal/provider/resource_offer.go
+++ b/internal/provider/resource_offer.go
@@ -17,7 +17,7 @@ func resourceOffer() *schema.Resource {
 		ReadContext:   resourceOfferRead,
 		DeleteContext: resourceOfferDelete,
 		Importer: &schema.ResourceImporter{
-			StateContext: resourceOfferImporter,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Schema: map[string]*schema.Schema{
 			"model": {
@@ -152,8 +152,4 @@ func resourceOfferDelete(ctx context.Context, d *schema.ResourceData, meta inter
 	d.SetId("")
 
 	return diags
-}
-
-func resourceOfferImporter(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	return []*schema.ResourceData{d}, nil
 }

--- a/internal/provider/resource_offer_test.go
+++ b/internal/provider/resource_offer_test.go
@@ -32,6 +32,11 @@ func TestAcc_ResourceOffer_Basic(t *testing.T) {
 					resource.TestCheckTypeSetElemNestedAttrs("juju_integration.that", "application.*", map[string]string{"name": "", "endpoint": "", "offer_url": fmt.Sprintf("%v/%v.%v", "admin", modelName, "this")}),
 				),
 			},
+			{
+				ImportStateVerify: true,
+				ImportState:       true,
+				ResourceName:      "juju_offer.this",
+			},
 		},
 	})
 }


### PR DESCRIPTION

## Description

Add import for resource Offer (fix #125)

## Type of change

Please mark if proceeds.

- [ ] New resource (a new resource in the schema)
- [X] Changed resource (changes in an existing resource)
- [ ] Logic changes in resources (the API interaction with Juju has been changed)
- [ ] Test changes (one or several tests have been changed)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update
- [ ] Other (describe)

## Environment

- Juju controller version: 2.9.38
- Terraform version: 1.3.8

## QA steps

Manual QA steps should be done to test this PR.

```tf
resource "juju_offer" "db" {
}
```
```bash
# Offers can be imported by using the URL as in the juju show-offers output.
# Example:
# $juju show-offer mysql
# Store            URL             Access  Description                                    Endpoint  Interface  Role
# mycontroller     admin/db.mysql  admin   MariaDB Server is one of the most ...          mysql     mysql      provider
terraform import juju_offer.db admin/db.mysql
```
