### PR TITLE
[JUJU-2885] Update juju to support 2.9.38 version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ Once complete, the initial released version of the provider will allow you to:
 - Manage models,
 - Deploy charms from CharmHub,
 - Manage integrations (previously named "relationships").
-
-There will also be support for importing these existing Juju resources.
+- Manage users
+- Manage credentials
+- Manage SSH keys
 
 ## Requirements
 

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/bflad/tfproviderlint v0.28.1
 	github.com/hashicorp/terraform-plugin-docs v0.13.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.25.0
-	// v2.9.37
-	github.com/juju/juju v0.0.0-20221102165234-51672c0e4243
+	// 2.9.38
+	github.com/juju/juju v0.0.0-20230105012444-6d211be0d72d
 
 )
 
@@ -124,7 +124,7 @@ require (
 	github.com/juju/usso v1.0.1 // indirect
 	github.com/juju/version/v2 v2.0.0 // indirect
 	github.com/juju/webbrowser v1.0.0 // indirect
-	github.com/juju/worker/v3 v3.0.1 // indirect
+	github.com/juju/worker/v3 v3.1.0 // indirect
 	github.com/julienschmidt/httprouter v1.3.0 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
 	github.com/kr/pretty v0.3.1-0.20220829230305-3cd153a126da // indirect

--- a/go.sum
+++ b/go.sum
@@ -630,8 +630,8 @@ github.com/juju/idmclient/v2 v2.0.0 h1:PsGa092JGy6iFNHZCcao+bigVsTyz1C+tHNRdYmKv
 github.com/juju/idmclient/v2 v2.0.0/go.mod h1:EOiFbPmnkqKvCUS/DHpDRWhL7eKF0AJaTvMjIYlIUak=
 github.com/juju/jsonschema v1.0.0 h1:2ScR9hhVdHxft+Te3fnclVx61MmlikHNEOirTGi+hV4=
 github.com/juju/jsonschema v1.0.0/go.mod h1:SlFW+jFtpWX0P4Tb+zTTPR4ufttLrnJIdQPePxVEfkM=
-github.com/juju/juju v0.0.0-20221102165234-51672c0e4243 h1:BL+zEgnN6WNcht7gX9wHfnibQ+u/fmRkv0UpqeWOk9I=
-github.com/juju/juju v0.0.0-20221102165234-51672c0e4243/go.mod h1:1rW/RaZ5EeZAAFYg0CVdgGP0WeVO2hbVYM4Z2ITPUvc=
+github.com/juju/juju v0.0.0-20230105012444-6d211be0d72d h1:M5iLH2O47Nvoqr3Smq0Zzbx/mt/OuKGEONJmzlFwTIc=
+github.com/juju/juju v0.0.0-20230105012444-6d211be0d72d/go.mod h1:fOy3LTxFGxABu9e3tg+a8Fu7NFjy24yZt/IIkgKFLvs=
 github.com/juju/loggo v0.0.0-20170605014607-8232ab8918d9/go.mod h1:vgyd7OREkbtVEN/8IXZe5Ooef3LQePvuBm9UWj6ZL8U=
 github.com/juju/loggo v0.0.0-20200526014432-9ce3a2e09b5e/go.mod h1:vgyd7OREkbtVEN/8IXZe5Ooef3LQePvuBm9UWj6ZL8U=
 github.com/juju/loggo v0.0.0-20210728185423-eebad3a902c4/go.mod h1:NIXFioti1SmKAlKNuUwbMenNdef59IF52+ZzuOmHYkg=
@@ -711,8 +711,8 @@ github.com/juju/version/v2 v2.0.0 h1:0OjCOlgA2UBbB8fSCgd8fmGsntrSbAWXEJil47bQptY
 github.com/juju/version/v2 v2.0.0/go.mod h1:ZeFjNy+UFEWJDDPdzW7Cm9NeU6dsViGaFYhXzycLQrw=
 github.com/juju/webbrowser v1.0.0 h1:JLdmbFtCGY6Qf2jmS6bVaenJFGIFkdF1/BjUm76af78=
 github.com/juju/webbrowser v1.0.0/go.mod h1:RwVlbBcF91Q4vS+iwlkJ6bZTE3EwlrjbYlM3WMVD6Bc=
-github.com/juju/worker/v3 v3.0.1 h1:CSq24xVLBD6SGYs9nadfXrOcvcV0iYqcTgMdrg+ph6k=
-github.com/juju/worker/v3 v3.0.1/go.mod h1:3eE974i5h/HcwNpiLgmqkmqy9GWIjJMtQTTn1ZOZYGM=
+github.com/juju/worker/v3 v3.1.0 h1:rt1yXAGTXYosC4kOcjdlvi0SnISyDtOUj3cKfOtZTLE=
+github.com/juju/worker/v3 v3.1.0/go.mod h1:C7MMHkc7dqghNul0WYnBlFgKPXXSGpJBkgibxqfymII=
 github.com/julienschmidt/httprouter v1.1.1-0.20151013225520-77a895ad01eb/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4dN7jwJOQ1U=


### PR DESCRIPTION

## Description

Update `go.mod` to use juju 2.9.38.

## Type of change

Please mark if proceeds.

- [ ] New resource (a new resource in the schema)
- [ ] Changed resource (changes in an existing resource)
- [ ] Logic changes in resources (the API interaction with Juju has been changed)
- [ ] Test changes (one or several tests have been changed)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Other -> Upgrade juju dependencies.

## Environment

- Juju controller version: 2.9.38
- Terraform version: 1.3

## QA steps

Non required.

# Additional notes

NA
