### PR TITLE
docs: bump version to ~>0.4.0 in example

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -40,7 +40,7 @@ Terraform 0.13 and later:
 terraform {
   required_providers {
     juju = {
-      version = "~> 0.3.1"
+      version = "~> 0.5.0"
       source  = "juju/juju"
     }
   }


### PR DESCRIPTION
## Description

Update docs to use the 0.4.X version.

## Type of change
- [X] Other (describe)