### PR TITLE
docs(user): Use namespaced resource

### DIFF
--- a/examples/resources/juju_users/import.sh
+++ b/examples/resources/juju_users/import.sh
@@ -1,2 +1,2 @@
-# Users can be imported using the user name
-$ terraform import juju_user.dev-user dev-user
+# Users can be imported using the user:<user name> syntax
+$ terraform import juju_user.dev-user user:dev-user


### PR DESCRIPTION

## Description

The `juju_user` resource supports importing users via `user:<user name>`, however the documentation does not include the `user:` prefix, this PR fixes that.

## Type of change

Please mark if proceeds.

- [ ] New resource (a new resource in the schema)
- [ ] Changed resource (changes in an existing resource)
- [ ] Logic changes in resources (the API interaction with Juju has been changed)
- [ ] Test changes (one or several tests have been changed)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [X] Other (describe) - update `import.sh` example for `juju_users`

## Environment

- Juju controller version: n/a
- Terraform version: n/a

## QA steps

The change relates to documentation, importing a user is tested in the automated tests of the resource.

# Additional notes

n/a
