### PR TITLE
Update ssh_key import example

### DIFF
--- a/docs/resources/ssh_key.md
+++ b/docs/resources/ssh_key.md
@@ -36,6 +36,6 @@ resource "juju_ssh_key" "mykey" {
 Import is supported using the following syntax:
 
 ```shell
-# Keys can be imported with the username of the key
-$ terraform import juju_ssh_key.dev-user dev-user
+# Keys can be imported with the name of the model and the username of the key
+$ terraform import juju_ssh_key.dev-user ssh_key:development:dev-user
 ```

--- a/examples/resources/juju_ssh_key/import.sh
+++ b/examples/resources/juju_ssh_key/import.sh
@@ -1,2 +1,2 @@
-# Keys can be imported with the username of the key
-$ terraform import juju_ssh_key.dev-user dev-user
+# Keys can be imported with the name of the model and the username of the key
+$ terraform import juju_ssh_key.dev-user ssh_key:development:dev-user


### PR DESCRIPTION
## Description

This PR resolves #171 by updating the documented example for importing an SSH key resource.

## Type of change

Please mark if proceeds.

- [ ] New resource (a new resource in the schema)
- [ ] Changed resource (changes in an existing resource)
- [ ] Logic changes in resources (the API interaction with Juju has been changed)
- [ ] Test changes (one or several tests have been changed)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Other (documentation update)

## Environment

- Juju controller version: 2.9.42
- Terraform version: 1.4.0

## QA steps

1. Attempt to import a `juju_ssh_key` resource using previous example
2. Attempt to import a `juju_ssh_key` resource using updated example
