### PR TITLE
Update SSH key parsing

### DIFF
--- a/internal/provider/resource_ssh_key.go
+++ b/internal/provider/resource_ssh_key.go
@@ -54,7 +54,7 @@ func sshKeyCreate(ctx context.Context, d *schema.ResourceData, meta interface{})
 
 	payload := d.Get("payload").(string)
 
-	user := getUserFromSSHKey(payload)
+	user := utils.GetUserFromSSHKey(payload)
 	if user == "" {
 		return diag.Errorf("malformed SSH key, user not found")
 	}
@@ -184,15 +184,4 @@ func sshKeyDelete(ctx context.Context, d *schema.ResourceData, meta interface{})
 	d.SetId("")
 
 	return diags
-}
-
-// getUserFromSSHKey returns the user of the key
-// returning the string after the = symbol
-func getUserFromSSHKey(key string) string {
-	end := strings.LastIndex(key, "=")
-	if end < 0 {
-		return ""
-	}
-	user := key[end+2:]
-	return user
 }

--- a/internal/provider/resource_ssh_key_test.go
+++ b/internal/provider/resource_ssh_key_test.go
@@ -35,6 +35,24 @@ func TestAcc_ResourceSSHKey_Basic(t *testing.T) {
 	})
 }
 
+func TestAcc_ResourceSSHKey_ED25519(t *testing.T) {
+	modelName := acctest.RandomWithPrefix("tf-test-sshkey")
+	sshKey1 := `ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAID3gjJTJtYZU55HTUr+hu0JF9p152yiC9czJi9nKojuW jimmy@somewhere`
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceSSHKey(modelName, sshKey1),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("juju_ssh_key.this", "model", modelName),
+					resource.TestCheckResourceAttr("juju_ssh_key.this", "payload", sshKey1)),
+			},
+		},
+	})
+}
+
 func testAccResourceSSHKey(modelName string, sshKey string) string {
 	return fmt.Sprintf(`
 resource "juju_model" "this" {

--- a/internal/utils/sshkeys.go
+++ b/internal/utils/sshkeys.go
@@ -3,15 +3,15 @@ package utils
 import "strings"
 
 // GetUserFromSSHKey returns the user of the key
-// returning the string after the "=" character
 func GetUserFromSSHKey(key string) string {
-	end := strings.LastIndex(key, "=")
-	if end < 0 {
+	// The key is broken down into component values.
+	// components[0] is the type of key (e.g. ssh-rsa)
+	// components[1] is the key string itself
+	// components[2] is the key's comment field (e.g. user@server)
+	components := strings.Fields(key)
+	if len(components) < 3 {
 		return ""
+	} else {
+		return components[2]
 	}
-	if (end + 2) >= len(key) {
-		return ""
-	}
-	user := key[end+2:]
-	return user
 }


### PR DESCRIPTION
## Description

Resolves #173

- Remove function `getUserFromSSHKey` in `resource_ssh_key.go`
  - Update remaining reference to instead use `utils.GetUserFromSSHKey`, per other existing references.
- Update function `utils.GetUserFromSSHKey` to split the key string on whitespaces and return the third component (comment / user string)
- Updated tests to validate ED25519 format keys were now working, along
  with RSA keys.

## Type of change

Please mark if proceeds.

- [ ] New resource (a new resource in the schema)
- [ ] Changed resource (changes in an existing resource)
- [ ] Logic changes in resources (the API interaction with Juju has been changed)
- [x] Test changes (one or several tests have been changed)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Other (describe)

## Environment

- Juju controller version: 2.9.42
- Terraform version: 1.4.0

## QA steps

An additional test has been added to test resolution of #173, and the pre-existing tests for RSA keys still return the results they did previously.

# Additional notes
Per notes in #167 there appears to be a bug causing inconsistent results in some tests due to placement order not being preserved.  Tests have all run and passed locally:
```
jsimpso@kif:~/code/terraform-provider-juju$ make testacc
TF_ACC=1 go test ./... -v  -timeout 120m
?       github.com/juju/terraform-provider-juju [no test files]
?       github.com/juju/terraform-provider-juju/internal/juju   [no test files]
?       github.com/juju/terraform-provider-juju/internal/utils  [no test files]
=== RUN   TestAcc_DataSourceModel
--- PASS: TestAcc_DataSourceModel (3.73s)
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProviderConfigure
--- PASS: TestProviderConfigure (0.02s)
=== RUN   TestProviderConfigureUsernameFromEnv
--- PASS: TestProviderConfigureUsernameFromEnv (0.02s)
=== RUN   TestProviderConfigurePasswordFromEnv
--- PASS: TestProviderConfigurePasswordFromEnv (0.02s)
=== RUN   TestProviderConfigureAddresses
--- PASS: TestProviderConfigureAddresses (0.02s)
=== RUN   TestProviderConfigurex509FromEnv
--- PASS: TestProviderConfigurex509FromEnv (0.02s)
=== RUN   TestProviderConfigurex509InvalidFromEnv
--- PASS: TestProviderConfigurex509InvalidFromEnv (0.01s)
=== RUN   TestAcc_ResourceAccessModel_Basic
--- PASS: TestAcc_ResourceAccessModel_Basic (4.13s)
=== RUN   TestAcc_ResourceApplication_Basic
{"level":"trace","time":"2023-03-15T14:46:03+08:00","message":"call expose application [test-app]"}
--- PASS: TestAcc_ResourceApplication_Basic (19.85s)
=== RUN   TestAcc_ResourceApplication_Updates
{"level":"trace","time":"2023-03-15T14:46:21+08:00","message":"call expose application [test-app]"}
{"level":"trace","endpoints":[""],"time":"2023-03-15T14:46:28+08:00","message":"Unexposing endpoints"}
{"level":"trace","endpoints":[],"time":"2023-03-15T14:46:32+08:00","message":"Expose endpoints"}
{"level":"trace","time":"2023-03-15T14:46:32+08:00","message":"call expose application [test-app]"}
--- PASS: TestAcc_ResourceApplication_Updates (21.96s)
=== RUN   TestAcc_ResourceCredential_Basic
--- PASS: TestAcc_ResourceCredential_Basic (4.14s)
=== RUN   TestAcc_ResourceIntegration
--- PASS: TestAcc_ResourceIntegration (30.93s)
=== RUN   TestAcc_ResourceIntegrationWithViaCIDRs
--- PASS: TestAcc_ResourceIntegrationWithViaCIDRs (336.53s)
=== RUN   TestAcc_ResourceMachine_Basic
--- PASS: TestAcc_ResourceMachine_Basic (6.54s)
=== RUN   TestAcc_ResourceModel_Basic
--- PASS: TestAcc_ResourceModel_Basic (11.19s)
=== RUN   TestAcc_ResourceModel_UnsetConfig
--- PASS: TestAcc_ResourceModel_UnsetConfig (6.55s)
=== RUN   TestAcc_ResourceOffer_Basic
--- PASS: TestAcc_ResourceOffer_Basic (341.44s)
=== RUN   TestAcc_ResourceSSHKey_Basic
{"level":"warn","time":"2023-03-15T14:58:59+08:00","message":"ssh key from user jimmy@somewhere is the last one and will not be removed"}
--- PASS: TestAcc_ResourceSSHKey_Basic (6.97s)
=== RUN   TestAcc_ResourceSSHKey_ED25519
{"level":"warn","time":"2023-03-15T14:59:04+08:00","message":"ssh key from user jimmy@somewhere is the last one and will not be removed"}
--- PASS: TestAcc_ResourceSSHKey_ED25519 (5.47s)
=== RUN   TestAcc_ResourceUser_Basic
--- PASS: TestAcc_ResourceUser_Basic (1.72s)
PASS
ok      github.com/juju/terraform-provider-juju/internal/provider       (cached)
```
