### PR TITLE
[JUJU-3280] Sort placement directive to ensure fair comparisons.

### DIFF
--- a/internal/juju/applications.go
+++ b/internal/juju/applications.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"math"
 	"reflect"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -328,6 +329,8 @@ func (c applicationsClient) CreateApplication(input *CreateApplicationInput) (*C
 		placements = nil
 	} else {
 		placementDirectives := strings.Split(input.Placement, ",")
+		// force this to be sorted
+		sort.Strings(placementDirectives)
 
 		for _, directive := range placementDirectives {
 			appPlacement, err := instance.ParsePlacement(directive)
@@ -536,18 +539,16 @@ func (c applicationsClient) ReadApplication(input *ReadApplicationInput) (*ReadA
 		return nil, fmt.Errorf("no status returned for application: %s", input.AppName)
 	}
 
-	var placementBuilder strings.Builder
+	allocatedMachines := make([]string, 0)
 	placementCount := 0
 	for _, v := range appStatus.Units {
-		placementBuilder.WriteString(v.Machine)
+		allocatedMachines = append(allocatedMachines, v.Machine)
 		placementCount += 1
-		if placementCount != len(appStatus.Units) {
-			// Don't put a comma after the last machine
-			placementBuilder.WriteString(",")
-		}
 	}
+	// sort the list
+	sort.Strings(allocatedMachines)
 
-	placement := placementBuilder.String()
+	placement := strings.Join(allocatedMachines, ",")
 
 	unitCount := len(appStatus.Units)
 


### PR DESCRIPTION

## Description

After the addition of the placement directive, some of the tests are failing due to mismatching comparisons during the import sequence. This PR forces the returned placement string to be sorted  before used (e.g. "0,1,4,10" vs "1,4,10,0").

Fix #168 

## Type of change

Please mark if proceeds.

- [ ] New resource (a new resource in the schema)
- [ ] Changed resource (changes in an existing resource)
- [ ] Logic changes in resources (the API interaction with Juju has been changed)
- [ ] Test changes (one or several tests have been changed)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Other (describe)

## Environment

- Juju controller version: 2.9.42
- Terraform version: 1.3

## QA steps

Run GitHub actions a bunch of times and check that the error is gone.
