### PR TITLE
[JUJU-3315] Force "stable" channel to be "latest/stable" when reading apps.

### DIFF
--- a/internal/juju/applications.go
+++ b/internal/juju/applications.go
@@ -637,18 +637,9 @@ func (c applicationsClient) ReadApplication(input *ReadApplicationInput) (*ReadA
 		exposed["cidrs"] = cidrs
 	}
 
-	// (juanmanuel-tirado) In certain scenarios depending on how
-	// charms are uploaded to CharmHub, Juju may register the
-	// latest/stable channel as stable. We check this case here
-	// and force it to be latest/stable
-	normalizedChannel := appInfo.Channel
-	if normalizedChannel == "stable" {
-		normalizedChannel = "latest/stable"
-	}
-
 	response := &ReadApplicationResponse{
 		Name:        charmURL.Name,
-		Channel:     normalizedChannel,
+		Channel:     appInfo.Channel,
 		Revision:    charmURL.Revision,
 		Series:      appInfo.Series,
 		Units:       unitCount,

--- a/internal/juju/applications.go
+++ b/internal/juju/applications.go
@@ -637,9 +637,18 @@ func (c applicationsClient) ReadApplication(input *ReadApplicationInput) (*ReadA
 		exposed["cidrs"] = cidrs
 	}
 
+	// (juanmanuel-tirado) In certain scenarios depending on how
+	// charms are uploaded to CharmHub, Juju may register the
+	// latest/stable channel as stable. We check this case here
+	// and force it to be latest/stable
+	normalizedChannel := appInfo.Channel
+	if normalizedChannel == "stable" {
+		normalizedChannel = "latest/stable"
+	}
+
 	response := &ReadApplicationResponse{
 		Name:        charmURL.Name,
-		Channel:     appStatus.CharmChannel,
+		Channel:     normalizedChannel,
 		Revision:    charmURL.Revision,
 		Series:      appInfo.Series,
 		Units:       unitCount,

--- a/internal/provider/resource_application.go
+++ b/internal/provider/resource_application.go
@@ -129,9 +129,9 @@ func resourceApplication() *schema.Resource {
 			},
 			"placement": {
 				Description: "Specify the target location for the application's units",
-				Type: schema.TypeString,
-				Optional: true,
-				Computed: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
 			},
 			"principal": {
 				Description: "Whether this is a Principal application",

--- a/internal/provider/resource_application.go
+++ b/internal/provider/resource_application.go
@@ -53,8 +53,8 @@ func resourceApplication() *schema.Resource {
 						"channel": {
 							Description: "The channel to use when deploying a charm. Specified as \\<track>/\\<risk>/\\<branch>.",
 							Type:        schema.TypeString,
-							Default:     "latest/stable",
 							Optional:    true,
+							Computed:    true,
 						},
 						"revision": {
 							Description: "The revision of the charm to deploy.",
@@ -155,6 +155,10 @@ func resourceApplicationCreate(ctx context.Context, d *schema.ResourceData, meta
 	charm := d.Get("charm").([]interface{})[0].(map[string]interface{})
 	charmName := charm["name"].(string)
 	channel := charm["channel"].(string)
+	if channel == "" {
+		// if no channel was set we will request the stable by default
+		channel = "stable"
+	}
 	series := charm["series"].(string)
 	units := d.Get("units").(int)
 	trust := d.Get("trust").(bool)


### PR DESCRIPTION
## Description

Depending on how a charm is uploaded to CharmHub, Juju may resolve the channel to be `stable` instead of `latest/stable`. This leads to awkward situations where Terraform things the state has changed as reported in #113. This PR forces the `stable` channel to be replaced by `latest/stable` when reading applications. 

Fix #113.

## Type of change

Please mark if proceeds.

- [ ] New resource (a new resource in the schema)
- [ ] Changed resource (changes in an existing resource)
- [ ] Logic changes in resources (the API interaction with Juju has been changed)
- [ ] Test changes (one or several tests have been changed)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Other (describe)

## Environment

- Juju controller version: 2.9.42
- Terraform version: 1.4.6

## QA steps

The steps reported in #113 are no longer valid to reproduce this issue after the last changes in the postgresql-k8s charm. A similar scenario can be reproduced using the github-runner charm.

Deploy the github-runner charm

```sh
juju bootstrap microk8s datest
juju add-model ghrunner
juju deploy github-runner ghrunner
```
Create a plan and import the model and the application

```tf
terraform {
  required_providers {
    juju = {
      source  = "juju/juju"
      version = "1.0.0"
    }
  }
}

provider "juju" {}

resource "juju_model" "ghrunner" {
  name = "ghrunnertest"
}

resource "juju_application" "ghrunner" {
  name  = "ghrunner"
  model = juju_model.ghrunner.name

  charm {
    name = "github-runner"
  }

  units = 1
}
```

```sh
terraform init -plugin-dir=<wherever your compiled providers are>
terraform import juju_model.ghrunner ghrunner
terraform import terraform import juju_application.ghrunner ghrunner:ghrunner
```
Terraform should not detect any changes
```sh
terraform plan

juju_model.ghrunner: Refreshing state... [id=08552cd9-4e03-40d5-8a3a-3d6f09faee7f]
juju_application.ghrunner: Refreshing state... [id=ghrunner:ghrunner]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
```

If the same steps are done with the 0.6.0 controller, Terraform finds changes to be done.
```sh
terraform plan
juju_model.ghrunner: Refreshing state... [id=08552cd9-4e03-40d5-8a3a-3d6f09faee7f]
juju_application.ghrunner: Refreshing state... [id=ghrunner:ghrunner]

Terraform used the selected providers to generate the following execution plan.
Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # juju_application.ghrunner will be updated in-place
  ~ resource "juju_application" "ghrunner" {
        id          = "ghrunner:ghrunner"
        name        = "ghrunner"
        # (5 unchanged attributes hidden)

      ~ charm {
          ~ channel  = "stable" -> "latest/stable"
            name     = "github-runner"
            # (2 unchanged attributes hidden)
        }
    }

Plan: 0 to add, 1 to change, 0 to destroy.

```
