### PR TITLE
Remove Application,Machine,Model and Offer from state if it was removed manually

### DIFF
--- a/internal/provider/resource_integration.go
+++ b/internal/provider/resource_integration.go
@@ -128,7 +128,7 @@ func IsIntegrationNotFound(err error) bool {
 	return strings.Contains(err.Error(), "no integrations exist")
 }
 
-func handleIntegrationNotFoundError(err error, d *schema.ResourceData, resource string) diag.Diagnostics {
+func handleIntegrationNotFoundError(err error, d *schema.ResourceData) diag.Diagnostics {
 	if IsIntegrationNotFound(err) {
 		// Integration manually removed
 		d.SetId("")
@@ -160,7 +160,7 @@ func resourceIntegrationRead(ctx context.Context, d *schema.ResourceData, meta i
 
 	response, err := client.Integrations.ReadIntegration(int)
 	if err != nil {
-		return handleIntegrationNotFoundError(err, d, d.Id())
+		return handleIntegrationNotFoundError(err, d)
 	}
 
 	applications := parseApplications(response.Applications)


### PR DESCRIPTION
## Description

This PR does the same as what was done for the Integration resource in the #192 PR. If the resource is removed manually, terraform plan fails with "no integrations exist in specified model". This PR  changes the behavior to remove it from the state instead.

## Type of change

Please mark if proceeds.

- [ ] New resource (a new resource in the schema)
- [ ] Changed resource (changes in an existing resource)
- [ ] Logic changes in resources (the API interaction with Juju has been changed)
- [ ] Test changes (one or several tests have been changed)
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Other (describe)

## Environment

- Juju controller version: 2.9.42
- Terraform version: 1.4.4

## QA steps

Manual QA steps should be done to test this PR.

The same that was reported in issue https://github.com/juju/terraform-provider-juju/issues/186

# Additional notes

It might be worth doing this for all the resources and also creating a specific error for that instead of checking the error message.
