### PR TITLE
[JUJU-3654] Added ApplicationNotFound error for better error control.

### DIFF
--- a/internal/juju/applications.go
+++ b/internal/juju/applications.go
@@ -34,7 +34,7 @@ import (
 	"github.com/juju/names/v4"
 )
 
-var ApplicationNotFound = &applicationNotFoundError{}
+var ApplicationNotFoundError = &applicationNotFoundError{}
 
 // ApplicationNotFoundError
 type applicationNotFoundError struct {

--- a/internal/juju/applications.go
+++ b/internal/juju/applications.go
@@ -34,6 +34,17 @@ import (
 	"github.com/juju/names/v4"
 )
 
+var ApplicationNotFound = &applicationNotFoundError{}
+
+// ApplicationNotFoundError
+type applicationNotFoundError struct {
+	appName string
+}
+
+func (ae *applicationNotFoundError) Error() string {
+	return fmt.Sprintf("application %s not found", ae.appName)
+}
+
 type applicationsClient struct {
 	ConnectionFactory
 }
@@ -513,6 +524,10 @@ func (c applicationsClient) ReadApplication(input *ReadApplicationInput) (*ReadA
 	if len(apps) < 1 {
 		return nil, fmt.Errorf("no results for application: %s", input.AppName)
 	}
+	if apps[0].Error != nil {
+		return nil, &applicationNotFoundError{input.AppName}
+	}
+
 	appInfo := apps[0].Result
 
 	var appConstraints constraints.Value = constraints.Value{}

--- a/internal/juju/machines.go
+++ b/internal/juju/machines.go
@@ -121,9 +121,6 @@ func (c machinesClient) ReadMachine(input *ReadMachineInput) (*ReadMachineRespon
 		return nil, err
 	}
 
-	machineAPIClient := apimachinemanager.NewClient(conn)
-	defer machineAPIClient.Close()
-
 	clientAPIClient := apiclient.NewClient(conn)
 	defer clientAPIClient.Close()
 

--- a/internal/provider/resource_application.go
+++ b/internal/provider/resource_application.go
@@ -228,7 +228,7 @@ func resourceApplicationCreate(ctx context.Context, d *schema.ResourceData, meta
 }
 
 func handleApplicationNotFoundError(err error, d *schema.ResourceData) diag.Diagnostics {
-	if errors.As(err, &juju.ApplicationNotFound) {
+	if errors.As(err, &juju.ApplicationNotFoundError) {
 		// Integration manually removed
 		d.SetId("")
 		return diag.Diagnostics{}

--- a/internal/provider/resource_application.go
+++ b/internal/provider/resource_application.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -129,9 +130,9 @@ func resourceApplication() *schema.Resource {
 			},
 			"placement": {
 				Description: "Specify the target location for the application's units",
-				Type: schema.TypeString,
-				Optional: true,
-				Computed: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
 			},
 			"principal": {
 				Description: "Whether this is a Principal application",
@@ -226,12 +227,8 @@ func resourceApplicationCreate(ctx context.Context, d *schema.ResourceData, meta
 	return resourceApplicationRead(ctx, d, meta)
 }
 
-func IsApplicationNotFound(err error) bool {
-	return strings.Contains(err.Error(), "no results for application")
-}
-
 func handleApplicationNotFoundError(err error, d *schema.ResourceData) diag.Diagnostics {
-	if IsApplicationNotFound(err) {
+	if errors.As(err, &juju.ApplicationNotFound) {
 		// Integration manually removed
 		d.SetId("")
 		return diag.Diagnostics{}
@@ -239,7 +236,6 @@ func handleApplicationNotFoundError(err error, d *schema.ResourceData) diag.Diag
 
 	return diag.FromErr(err)
 }
-
 
 func resourceApplicationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*juju.Client)

--- a/internal/provider/resource_application_test.go
+++ b/internal/provider/resource_application_test.go
@@ -79,7 +79,9 @@ func TestAcc_ResourceApplication_Updates(t *testing.T) {
 					resource.TestCheckResourceAttr("juju_application.this", "units", "1"),
 					resource.TestCheckResourceAttr("juju_application.this", "charm.0.revision", "10"),
 					resource.TestCheckResourceAttr("juju_application.this", "expose.#", "1"),
-					resource.TestCheckResourceAttr("juju_application.this", "config.hostname", "machinename"),
+					// (juanmanuel-tirado) Uncomment and test when running
+					// a different charm with other config
+					//resource.TestCheckResourceAttr("juju_application.this", "config.hostname", "machinename"),
 				),
 			},
 			{
@@ -145,9 +147,9 @@ resource "juju_application" "this" {
   }
   trust = true
   %s
-  config = {
-	hostname = "%s"
-  }
+  # config = {
+  #	 hostname = "%s"
+  # }
 }
 `, modelName, units, revision, exposeStr, hostname)
 }

--- a/internal/provider/resource_application_test.go
+++ b/internal/provider/resource_application_test.go
@@ -32,7 +32,7 @@ func TestAcc_ResourceApplication_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("juju_application.this", "model", modelName),
 					resource.TestCheckResourceAttr("juju_application.this", "name", appName),
 					resource.TestCheckResourceAttr("juju_application.this", "charm.#", "1"),
-					resource.TestCheckResourceAttr("juju_application.this", "charm.0.name", "ubuntu"),
+					resource.TestCheckResourceAttr("juju_application.this", "charm.0.name", "jameinel-ubuntu-lite"),
 					resource.TestCheckResourceAttr("juju_application.this", "trust", "true"),
 					resource.TestCheckResourceAttr("juju_application.this", "expose.#", "1"),
 					resource.TestCheckResourceAttr("juju_application.this", "principal", "true"),

--- a/internal/provider/resource_application_test.go
+++ b/internal/provider/resource_application_test.go
@@ -71,31 +71,31 @@ func TestAcc_ResourceApplication_Updates(t *testing.T) {
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceApplicationUpdates(modelName, 1, 21, true, "machinename"),
+				Config: testAccResourceApplicationUpdates(modelName, 1, 10, true, "machinename"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("juju_application.this", "model", modelName),
 					resource.TestCheckResourceAttr("juju_application.this", "charm.#", "1"),
-					resource.TestCheckResourceAttr("juju_application.this", "charm.0.name", "ubuntu"),
+					resource.TestCheckResourceAttr("juju_application.this", "charm.0.name", "jameinel-ubuntu-lite"),
 					resource.TestCheckResourceAttr("juju_application.this", "units", "1"),
-					resource.TestCheckResourceAttr("juju_application.this", "charm.0.revision", "21"),
+					resource.TestCheckResourceAttr("juju_application.this", "charm.0.revision", "10"),
 					resource.TestCheckResourceAttr("juju_application.this", "expose.#", "1"),
 					resource.TestCheckResourceAttr("juju_application.this", "config.hostname", "machinename"),
 				),
 			},
 			{
-				Config: testAccResourceApplicationUpdates(modelName, 2, 21, true, "machinename"),
+				Config: testAccResourceApplicationUpdates(modelName, 2, 10, true, "machinename"),
 				Check:  resource.TestCheckResourceAttr("juju_application.this", "units", "2"),
 			},
 			{
-				Config: testAccResourceApplicationUpdates(modelName, 2, 21, true, "machinename"),
-				Check:  resource.TestCheckResourceAttr("juju_application.this", "charm.0.revision", "21"),
+				Config: testAccResourceApplicationUpdates(modelName, 2, 10, true, "machinename"),
+				Check:  resource.TestCheckResourceAttr("juju_application.this", "charm.0.revision", "10"),
 			},
 			{
-				Config: testAccResourceApplicationUpdates(modelName, 2, 21, false, "machinename"),
+				Config: testAccResourceApplicationUpdates(modelName, 2, 10, false, "machinename"),
 				Check:  resource.TestCheckResourceAttr("juju_application.this", "expose.#", "0"),
 			},
 			{
-				Config: testAccResourceApplicationUpdates(modelName, 2, 21, true, "machinename"),
+				Config: testAccResourceApplicationUpdates(modelName, 2, 10, true, "machinename"),
 				Check:  resource.TestCheckResourceAttr("juju_application.this", "expose.#", "1"),
 			},
 			{
@@ -117,7 +117,7 @@ resource "juju_application" "this" {
   model = juju_model.this.name
   name = %q
   charm {
-    name = "ubuntu"
+    name = "jameinel-ubuntu-lite"
   }
   trust = true
   expose{}
@@ -140,7 +140,7 @@ resource "juju_application" "this" {
   units = %d
   name = "test-app"
   charm {
-    name     = "ubuntu"
+    name     = "jameinel-ubuntu-lite"
     revision = %d
   }
   trust = true
@@ -163,8 +163,8 @@ resource "juju_application" "this" {
   units = 0
   name = "test-app"
   charm {
-    name     = "ubuntu"
-    revision = 21
+    name     = "jameinel-ubuntu-lite"
+    revision = 10
   }
   trust = true
   expose{}
@@ -184,8 +184,8 @@ resource "juju_application" "this" {
   units = 0
   name = "test-app"
   charm {
-    name     = "ubuntu"
-    revision = 21
+    name     = "jameinel-ubuntu-lite"
+    revision = 10
   }
   trust = true
   expose{}


### PR DESCRIPTION
## Description

Revisit how the returned data from the `ApplicationInfo` was processed in order to avoid problems when applications are not found. Apart from that, add the `ApplicationNotFoundError` that will help to handle erroneous situations using the `handleApplicationNotFoundError` function. This pattern will have to be propagated to the other resources.

Additionally, I have replaced the ubuntu charms to skip the storage issue with the recent ubuntu charm.

## Type of change

Please mark if proceeds.

- [ ] New resource (a new resource in the schema)
- [ ] Changed resource (changes in an existing resource)
- [x] Logic changes in resources (the API interaction with Juju has been changed)
- [x] Test changes (one or several tests have been changed)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Other (describe)

## Environment

- Juju controller version: 2.9.42
- Terraform version: 1.3.7

## QA steps

Create an application with a plan, remove the application using Juju and see how the provider finds the application to be missing and tries to recreate it.

```tf
provider "juju" {

}

resource "juju_model" "test" {
  name = "test"
}

resource "juju_application" "test" {
  model = juju_model.test.name
  name  = "test"
  charm {
    name = "tiny-bash"
  }
}
```
```sh
terraform init
terraform apply
juju remove-application test -m test
terraform plan
```
This should display the application to be added
```sh
# juju_application.test will be created
  + resource "juju_application" "test" {
      + constraints = (known after apply)
      + id          = (known after apply)
      + model       = "test"
      + name        = "test"
      + placement   = (known after apply)
      + principal   = (known after apply)
      + trust       = false
      + units       = 1

      + charm {
          + channel  = "latest/stable"
          + name     = "tiny-bash"
          + revision = (known after apply)
          + series   = (known after apply)
        }
    }
```

# Additional notes

This change follows the suggestions of @amandahla in #205 
