### PR TITLE
Add go mod replace for grpc/naming from juju & lxd

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -212,3 +212,8 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect
 	sigs.k8s.io/yaml v1.2.0 // indirect
 )
+
+// This is copied from the go.mod file in github.com/lxc/lxd
+// It is needed to avoid this error when running go list -m
+// go: google.golang.org/grpc/naming@v0.0.0-00010101000000-000000000000: invalid version: unknown revision 000000000000
+replace google.golang.org/grpc/naming => google.golang.org/grpc v1.29.1


### PR DESCRIPTION
This is apparently a known issue that I hit recently after accidentally cleaned all my go modules and invalidated all my caches on Goland. Trying to figure out, I found that https://github.com/juju/juju/pull/14268 was adding it to [juju's go.mod as well](https://github.com/juju/juju/blob/05a2b7cb56036eea2b0b53bfbf5acbcef0199c46/go.mod#L303) to fix the infamous

```
go: google.golang.org/grpc/naming@v0.0.0-00010101000000-000000000000: invalid version: unknown revision 000000000000
```

error. I have no idea why is this error is happening and why is this replacement works, but it does fix everything quite nicely.