### PR TITLE
[JUJU-3863] Process region value in cloud models and force it to be computed

### DIFF
--- a/internal/juju/models.go
+++ b/internal/juju/models.go
@@ -2,6 +2,7 @@ package juju
 
 import (
 	"fmt"
+	"log"
 	"strings"
 	"time"
 
@@ -15,8 +16,6 @@ import (
 	"github.com/juju/juju/api/client/modelmanager"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/names/v4"
-
-	"github.com/rs/zerolog/log"
 )
 
 type modelsClient struct {

--- a/internal/juju/models.go
+++ b/internal/juju/models.go
@@ -2,7 +2,6 @@ package juju
 
 import (
 	"fmt"
-	"log"
 	"strings"
 	"time"
 
@@ -16,6 +15,8 @@ import (
 	"github.com/juju/juju/api/client/modelmanager"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/names/v4"
+
+	"github.com/rs/zerolog/log"
 )
 
 type modelsClient struct {

--- a/internal/provider/resource_model.go
+++ b/internal/provider/resource_model.go
@@ -121,20 +121,25 @@ func resourceModelCreate(ctx context.Context, d *schema.ResourceData, meta inter
 
 	// build an object
 	cloudSectionOutput := make(map[string]interface{})
+	cloudChanged := false
 	// no cloud value was defined, use the response
 	if cloudNameInput == "" {
 		cloudSectionOutput["name"] = response.ModelInfo.Cloud
+		cloudChanged = true
 	}
 	if cloudRegionInput == "" {
 		cloudSectionOutput["region"] = response.ModelInfo.CloudRegion
+		cloudChanged = true
 	}
 
 	// TODO: Should config track all key=value or just those explicitly set?
 
-	// Compute the cloud value
-	err = d.Set("cloud", []any{cloudSectionOutput})
-	if err != nil {
-		return diag.FromErr(err)
+	// Set the cloud value if required
+	if cloudChanged {
+		err = d.Set("cloud", []any{cloudSectionOutput})
+		if err != nil {
+			return diag.FromErr(err)
+		}
 	}
 
 	d.SetId(response.ModelInfo.UUID)

--- a/internal/provider/resource_model.go
+++ b/internal/provider/resource_model.go
@@ -50,6 +50,7 @@ func resourceModel() *schema.Resource {
 							Description: "The region of the cloud",
 							Type:        schema.TypeString,
 							Optional:    true,
+							Computed:    true,
 						},
 					},
 				},
@@ -110,10 +111,30 @@ func resourceModelCreate(ctx context.Context, d *schema.ResourceData, meta inter
 		return diag.FromErr(err)
 	}
 
-	// TODO: If cloud is blank, we should set it to the default (returned in modelInfo)
+	// compute the cloud information required
+	var cloudNameInput, cloudRegionInput string = "", ""
+	for _, c := range cloud {
+		cloudEntry := c.(map[string]interface{})
+		cloudNameInput = cloudEntry["name"].(string)
+		cloudRegionInput = cloudEntry["region"].(string)
+	}
+
+	// build an object
+	cloudSectionOutput := make(map[string]interface{})
+	// no cloud value was defined, use the response
+	if cloudNameInput == "" {
+		cloudSectionOutput["name"] = response.ModelInfo.Cloud
+	}
+	if cloudRegionInput == "" {
+		cloudSectionOutput["region"] = response.ModelInfo.CloudRegion
+	}
+
 	// TODO: Should config track all key=value or just those explicitly set?
 
 	d.SetId(response.ModelInfo.UUID)
+
+	// Compute the cloud value
+	d.Set("cloud", []any{cloudSectionOutput})
 
 	return diags
 }
@@ -151,6 +172,7 @@ func resourceModelRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	if err := d.Set("name", response.ModelInfo.Name); err != nil {
 		return diag.FromErr(err)
 	}
+
 	if err := d.Set("cloud", cloudList); err != nil {
 		return diag.FromErr(err)
 	}

--- a/internal/provider/resource_model.go
+++ b/internal/provider/resource_model.go
@@ -131,10 +131,13 @@ func resourceModelCreate(ctx context.Context, d *schema.ResourceData, meta inter
 
 	// TODO: Should config track all key=value or just those explicitly set?
 
-	d.SetId(response.ModelInfo.UUID)
-
 	// Compute the cloud value
-	d.Set("cloud", []any{cloudSectionOutput})
+	err = d.Set("cloud", []any{cloudSectionOutput})
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(response.ModelInfo.UUID)
 
 	return diags
 }


### PR DESCRIPTION

## Description

The `region` parameter in the `cloud` section from the `resource_model` should be computed by the provider when empty. In this manner, something like:

```tf
resource "juju_model" "terraform" {
  name = "terraform"
  cloud {
    name   = "localhost"
  }
}
```

will automatically set the `region` value to be `localhost` which is the default value returned by the Juju provider.

Fix #209 



## Type of change

Please mark if proceeds.

- [ ] New resource (a new resource in the schema)
- [x] Changed resource (changes in an existing resource)
- [ ] Logic changes in resources (the API interaction with Juju has been changed)
- [ ] Test changes (one or several tests have been changed)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Other (describe)

## Environment

- Juju controller version: 2.9.42
- Terraform version: 1.36

## QA steps

Try to apply the plan described in #209 twice. No new values are detected now.

```tf
terraform {
  required_providers {
    juju = {
      version = "~> 0.7.0"
      source  = "juju/juju"
    }
  }
}


provider "juju" {}

resource "juju_model" "terraform" {
  name = "terraform"

  cloud {
    name   = "localhost"
  }
}
```

```sh
terraform init
terraform apply --auto-approve
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the
following symbols:
  + create

Terraform will perform the following actions:

  # juju_model.terraform will be created
  + resource "juju_model" "terraform" {
      + credential = (known after apply)
      + id         = (known after apply)
      + name       = "terraform"
      + type       = (known after apply)

      + cloud {
          + name   = "localhost"
          + region = (known after apply)
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.
juju_model.terraform: Creating...
juju_model.terraform: Creation complete after 6s [id=77a75e5b-1236-48b5-8564-6c234f36767e]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
terraform apply --auto-approve
juju_model.terraform: Refreshing state... [id=77a75e5b-1236-48b5-8564-6c234f36767e]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are
needed.

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```
