### PR TITLE
[JUJU-3792] Revisit tests on Microk8s.

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,6 +1,9 @@
-default: testacc
+default: testlxd
 
-# Run acceptance tests
-.PHONY: testacc
-testacc:
-	TF_ACC=1 go test ./... -v $(TESTARGS) -timeout 120m
+.PHONY: testslxd
+testlxd:
+	TF_ACC=1 TEST_CLOUD=lxd go test ./... -v $(TESTARGS) -timeout 120m
+
+.PHONY: testmicrok8s
+testmicrok8s:
+	TF_ACC=1 TEST_CLOUD=microk8s go test ./... -v $(TESTARGS) -timeout 120m

--- a/internal/juju/applications.go
+++ b/internal/juju/applications.go
@@ -565,7 +565,7 @@ func (c applicationsClient) ReadApplication(input *ReadApplicationInput) (*ReadA
 
 	placement := strings.Join(allocatedMachines, ",")
 
-	unitCount := len(appStatus.Units)
+	unitCount := appStatus.Scale
 
 	// NOTE: we are assuming that this charm comes from CharmHub
 	charmURL, err := charm.ParseURL(appStatus.Charm)

--- a/internal/juju/applications.go
+++ b/internal/juju/applications.go
@@ -565,7 +565,7 @@ func (c applicationsClient) ReadApplication(input *ReadApplicationInput) (*ReadA
 
 	placement := strings.Join(allocatedMachines, ",")
 
-	unitCount := appStatus.Scale
+	unitCount := len(appStatus.Units)
 
 	// NOTE: we are assuming that this charm comes from CharmHub
 	charmURL, err := charm.ParseURL(appStatus.Charm)

--- a/internal/juju/applications.go
+++ b/internal/juju/applications.go
@@ -110,6 +110,7 @@ type CreateApplicationResponse struct {
 
 type ReadApplicationInput struct {
 	ModelUUID string
+	ModelType string
 	AppName   string
 }
 
@@ -566,6 +567,10 @@ func (c applicationsClient) ReadApplication(input *ReadApplicationInput) (*ReadA
 	placement := strings.Join(allocatedMachines, ",")
 
 	unitCount := len(appStatus.Units)
+	// if we have a CAAS we use scale instead of units length
+	if input.ModelType == model.CAAS.String() {
+		unitCount = appStatus.Scale
+	}
 
 	// NOTE: we are assuming that this charm comes from CharmHub
 	charmURL, err := charm.ParseURL(appStatus.Charm)

--- a/internal/provider/main_test.go
+++ b/internal/provider/main_test.go
@@ -20,6 +20,27 @@ const LXDCloudTesting CloudTesting = "lxd"
 // MicroK8sTesting
 const MicroK8sTesting CloudTesting = "microk8s"
 
+func (ct CloudTesting) String() string {
+	return string(ct)
+}
+
+// CloudName returns the cloud name as displayed
+// when using `juju list-clouds`. For example,
+// a controller can be bootstrapped with an lxd type.
+// However, that's the controller type, the cloud name
+// would be localhost
+func (ct CloudTesting) CloudName() string {
+	// Right now, we're only testing two cases and
+	// a switch could be unnecessary. However,
+	// this can be useful in the future.
+	switch ct {
+	case LXDCloudTesting:
+		return "localhost"
+	default:
+		return ct.String()
+	}
+}
+
 func TypeTestingCloudFromString(from string) (CloudTesting, error) {
 	switch strings.ToLower(from) {
 	case string(LXDCloudTesting):

--- a/internal/provider/resource_access_model_test.go
+++ b/internal/provider/resource_access_model_test.go
@@ -32,6 +32,12 @@ func TestAcc_ResourceAccessModel_Basic(t *testing.T) {
 				ExpectError: regexp.MustCompile("Error running pre-apply refresh.*"),
 			},
 			{
+				// (juanmanuel-tirado) For some reason beyond my understanding,
+				// this test fails no microk8s on GitHub. If passes in local
+				// environments with no additional configurations...
+				SkipFunc: func() (bool, error) {
+					return testingCloud != LXDCloudTesting, nil
+				},
 				Config: testAccResourceAccessModel(t, userName, userPassword, modelName, access),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "access", access),
@@ -40,6 +46,9 @@ func TestAcc_ResourceAccessModel_Basic(t *testing.T) {
 				),
 			},
 			{
+				SkipFunc: func() (bool, error) {
+					return testingCloud != LXDCloudTesting, nil
+				},
 				ImportStateVerify: true,
 				ImportState:       true,
 				ImportStateId:     fmt.Sprintf("%s:%s:%s", modelName, access, userName),

--- a/internal/provider/resource_access_model_test.go
+++ b/internal/provider/resource_access_model_test.go
@@ -13,9 +13,9 @@ func TestAcc_ResourceAccessModel_Basic(t *testing.T) {
 	// (juanmanuel-tirado) This test fails when using microk8s but
 	// only in github actions. I could not reproduce this issue
 	// locally.
-	if testingCloud != LXDCloudTesting {
-		t.Skip(t.Name() + " only runs with LXD")
-	}
+	// if testingCloud != LXDCloudTesting {
+	// 	t.Skip(t.Name() + " only runs with LXD")
+	// }
 	userName := acctest.RandomWithPrefix("tfuser")
 	userPassword := acctest.RandomWithPrefix("tf-test-user")
 	modelName := "testing"

--- a/internal/provider/resource_access_model_test.go
+++ b/internal/provider/resource_access_model_test.go
@@ -10,12 +10,6 @@ import (
 )
 
 func TestAcc_ResourceAccessModel_Basic(t *testing.T) {
-	// (juanmanuel-tirado) This test fails when using microk8s but
-	// only in github actions. I could not reproduce this issue
-	// locally.
-	// if testingCloud != LXDCloudTesting {
-	// 	t.Skip(t.Name() + " only runs with LXD")
-	// }
 	userName := acctest.RandomWithPrefix("tfuser")
 	userPassword := acctest.RandomWithPrefix("tf-test-user")
 	modelName := "testing"

--- a/internal/provider/resource_application.go
+++ b/internal/provider/resource_application.go
@@ -250,13 +250,15 @@ func resourceApplicationRead(ctx context.Context, d *schema.ResourceData, meta i
 	}
 
 	modelName, appName := id[0], id[1]
-	modelUUID, err := client.Models.ResolveModelUUID(modelName)
+
+	modelInfo, err := client.Models.GetModelByName(modelName)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
 	response, err := client.Applications.ReadApplication(&juju.ReadApplicationInput{
-		ModelUUID: modelUUID,
+		ModelUUID: modelInfo.UUID,
+		ModelType: modelInfo.Type,
 		AppName:   appName,
 	})
 	if err != nil {

--- a/internal/provider/resource_application_test.go
+++ b/internal/provider/resource_application_test.go
@@ -84,7 +84,10 @@ func TestAcc_ResourceApplication_Basic(t *testing.T) {
 
 func TestAcc_ResourceApplication_Updates(t *testing.T) {
 	modelName := acctest.RandomWithPrefix("tf-test-application")
-
+	appName := "jameinel-ubuntu-lite"
+	if testingCloud != LXDCloudTesting {
+		appName = "hello-kubecon"
+	}
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
@@ -94,7 +97,7 @@ func TestAcc_ResourceApplication_Updates(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("juju_application.this", "model", modelName),
 					resource.TestCheckResourceAttr("juju_application.this", "charm.#", "1"),
-					resource.TestCheckResourceAttr("juju_application.this", "charm.0.name", "jameinel-ubuntu-lite"),
+					resource.TestCheckResourceAttr("juju_application.this", "charm.0.name", appName),
 					resource.TestCheckResourceAttr("juju_application.this", "units", "1"),
 					resource.TestCheckResourceAttr("juju_application.this", "charm.0.revision", "10"),
 					resource.TestCheckResourceAttr("juju_application.this", "expose.#", "1"),
@@ -131,6 +134,23 @@ func TestAcc_ResourceApplication_Updates(t *testing.T) {
 	})
 }
 
+func TestAcc_Simple(t *testing.T) {
+	modelName := acctest.RandomWithPrefix("tf-test-application")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceApplicationUpdates(modelName, 2, 10, true, "machinename"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("juju_application.this", "units", "2"),
+				),
+			},
+		},
+	})
+}
+
 func testAccResourceApplicationBasic(modelName, appInvalidName string) string {
 	if testingCloud == LXDCloudTesting {
 		return fmt.Sprintf(`
@@ -156,7 +176,7 @@ func testAccResourceApplicationBasic(modelName, appInvalidName string) string {
 		}
 		
 		resource "juju_application" "this" {
-		  model = juju_model.this.name
+		  model = jameinel-ubuntu-lite
 		  name = %q
 		  charm {
 			name = "jameinel-ubuntu-lite"
@@ -209,15 +229,13 @@ func testAccResourceApplicationUpdates(modelName string, units int, revision int
 		  units = %d
 		  name = "test-app"
 		  charm {
-			name     = "jameinel-ubuntu-lite"
+			name     = "hello-kubecon"
 			revision = %d
 		  }
 		  trust = true
 		  %s
-		  # config = {
-		  #	 hostname = "%s"
-		  # }
 		  config = {
+		  	# hostname = "%s"
 			juju-external-hostname="myhostname"
 		  }
 		}

--- a/internal/provider/resource_application_test.go
+++ b/internal/provider/resource_application_test.go
@@ -11,9 +11,6 @@ import (
 )
 
 func TestAcc_ResourceApplication_Basic(t *testing.T) {
-	if testingCloud != LXDCloudTesting {
-		t.Skip(t.Name() + " only runs with LXD")
-	}
 
 	modelName := acctest.RandomWithPrefix("tf-test-application")
 	appName := "test-app"
@@ -43,6 +40,10 @@ func TestAcc_ResourceApplication_Basic(t *testing.T) {
 				),
 			},
 			{
+				SkipFunc: func() (bool, error) {
+					// cores constraint is not valid in K8s
+					return testingCloud != LXDCloudTesting, nil
+				},
 				Config: testAccResourceApplicationConstraints(t, modelName, "arch=amd64 cores=1 mem=4096M"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("juju_application.this", "model", modelName),
@@ -50,6 +51,21 @@ func TestAcc_ResourceApplication_Basic(t *testing.T) {
 				),
 			},
 			{
+				// specific constraints for k8s
+				SkipFunc: func() (bool, error) {
+					return testingCloud != MicroK8sTesting, nil
+				},
+				Config: testAccResourceApplicationConstraints(t, modelName, "arch=amd64 mem=4096M"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("juju_application.this", "model", modelName),
+					resource.TestCheckResourceAttr("juju_application.this", "constraints", "arch=amd64 mem=4096M"),
+				),
+			},
+			{
+				SkipFunc: func() (bool, error) {
+					// skip if we are not in lxd environment
+					return testingCloud != LXDCloudTesting, nil
+				},
 				Config: testAccResourceApplicationConstraintsSubordinate(t, modelName, "arch=amd64 cores=1 mem=4096M"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("juju_application.this", "model", modelName),
@@ -68,9 +84,6 @@ func TestAcc_ResourceApplication_Basic(t *testing.T) {
 }
 
 func TestAcc_ResourceApplication_Updates(t *testing.T) {
-	if testingCloud != LXDCloudTesting {
-		t.Skip(t.Name() + " only runs with LXD")
-	}
 
 	modelName := acctest.RandomWithPrefix("tf-test-application")
 
@@ -92,47 +105,69 @@ func TestAcc_ResourceApplication_Updates(t *testing.T) {
 					//resource.TestCheckResourceAttr("juju_application.this", "config.hostname", "machinename"),
 				),
 			},
-			{
-				Config: testAccResourceApplicationUpdates(modelName, 2, 10, true, "machinename"),
-				Check:  resource.TestCheckResourceAttr("juju_application.this", "units", "2"),
-			},
+			// {
+			// 	Config: testAccResourceApplicationUpdates(modelName, 2, 10, true, "machinename"),
+			// 	Check:  resource.TestCheckResourceAttr("juju_application.this", "units", "2"),
+			// },
 			{
 				Config: testAccResourceApplicationUpdates(modelName, 2, 10, true, "machinename"),
 				Check:  resource.TestCheckResourceAttr("juju_application.this", "charm.0.revision", "10"),
 			},
-			{
-				Config: testAccResourceApplicationUpdates(modelName, 2, 10, false, "machinename"),
-				Check:  resource.TestCheckResourceAttr("juju_application.this", "expose.#", "0"),
-			},
-			{
-				Config: testAccResourceApplicationUpdates(modelName, 2, 10, true, "machinename"),
-				Check:  resource.TestCheckResourceAttr("juju_application.this", "expose.#", "1"),
-			},
-			{
-				ImportStateVerify: true,
-				ImportState:       true,
-				ResourceName:      "juju_application.this",
-			},
+			// {
+			// 	Config: testAccResourceApplicationUpdates(modelName, 2, 10, false, "machinename"),
+			// 	Check:  resource.TestCheckResourceAttr("juju_application.this", "expose.#", "0"),
+			// },
+			// {
+			// 	Config: testAccResourceApplicationUpdates(modelName, 2, 10, true, "machinename"),
+			// 	Check:  resource.TestCheckResourceAttr("juju_application.this", "expose.#", "1"),
+			// },
+			// {
+			// 	ImportStateVerify: true,
+			// 	ImportState:       true,
+			// 	ResourceName:      "juju_application.this",
+			// },
 		},
 	})
 }
 
 func testAccResourceApplicationBasic(modelName, appInvalidName string) string {
-	return fmt.Sprintf(`
-resource "juju_model" "this" {
-  name = %q
-}
-
-resource "juju_application" "this" {
-  model = juju_model.this.name
-  name = %q
-  charm {
-    name = "jameinel-ubuntu-lite"
-  }
-  trust = true
-  expose{}
-}
-`, modelName, appInvalidName)
+	if testingCloud == LXDCloudTesting {
+		return fmt.Sprintf(`
+		resource "juju_model" "this" {
+		  name = %q
+		}
+		
+		resource "juju_application" "this" {
+		  model = juju_model.this.name
+		  name = %q
+		  charm {
+			name = "jameinel-ubuntu-lite"
+		  }
+		  trust = true
+		  expose{}
+		}
+		`, modelName, appInvalidName)
+	} else {
+		// if we have a K8s deployment we need the machine hostname
+		return fmt.Sprintf(`
+		resource "juju_model" "this" {
+		  name = %q
+		}
+		
+		resource "juju_application" "this" {
+		  model = juju_model.this.name
+		  name = %q
+		  charm {
+			name = "jameinel-ubuntu-lite"
+		  }
+		  trust = true
+		  expose{}
+		  config = {
+			juju-external-hostname="myhostname"
+		  }
+		}
+		`, modelName, appInvalidName)
+	}
 }
 
 func testAccResourceApplicationUpdates(modelName string, units int, revision int, expose bool, hostname string) string {
@@ -140,30 +175,62 @@ func testAccResourceApplicationUpdates(modelName string, units int, revision int
 	if !expose {
 		exposeStr = ""
 	}
-	return fmt.Sprintf(`
-resource "juju_model" "this" {
-  name = %q
+
+	if testingCloud == LXDCloudTesting {
+		return fmt.Sprintf(`
+		resource "juju_model" "this" {
+		  name = %q
+		}
+		
+		resource "juju_application" "this" {
+		  model = juju_model.this.name
+		  units = %d
+		  name = "test-app"
+		  charm {
+			name     = "jameinel-ubuntu-lite"
+			revision = %d
+		  }
+		  trust = true
+		  %s
+		  # config = {
+		  #	 hostname = "%s"
+		  # }
+		}
+		`, modelName, units, revision, exposeStr, hostname)
+	} else {
+		return fmt.Sprintf(`
+		resource "juju_model" "this" {
+		  name = %q
+		}
+		
+		resource "juju_application" "this" {
+		  model = juju_model.this.name
+		  units = %d
+		  name = "test-app"
+		  charm {
+			name     = "jameinel-ubuntu-lite"
+			revision = %d
+		  }
+		  trust = true
+		  %s
+		  # config = {
+		  #	 hostname = "%s"
+		  # }
+		  config = {
+			juju-external-hostname="myhostname"
+		  }
+		}
+		`, modelName, units, revision, exposeStr, hostname)
+	}
+
 }
 
-resource "juju_application" "this" {
-  model = juju_model.this.name
-  units = %d
-  name = "test-app"
-  charm {
-    name     = "jameinel-ubuntu-lite"
-    revision = %d
-  }
-  trust = true
-  %s
-  # config = {
-  #	 hostname = "%s"
-  # }
-}
-`, modelName, units, revision, exposeStr, hostname)
-}
-
+// testAccResourceApplicationConstraints will return two set for constraint
+// applications. The version to be used in K8s sets the juju-external-hostname
+// because we set the expose parameter.
 func testAccResourceApplicationConstraints(t *testing.T, modelName string, constraints string) string {
-	return fmt.Sprintf(`
+	if testingCloud == LXDCloudTesting {
+		return fmt.Sprintf(`
 resource "juju_model" "this" {
   name = %q
 }
@@ -176,11 +243,34 @@ resource "juju_application" "this" {
     name     = "jameinel-ubuntu-lite"
     revision = 10
   }
-  trust = true
+  
+  trust = true 
   expose{}
   constraints = "%s"
 }
 `, modelName, constraints)
+	} else {
+		return fmt.Sprintf(`
+resource "juju_model" "this" {
+  name = %q
+}
+
+resource "juju_application" "this" {
+  model = juju_model.this.name
+  name = "test-app"
+  charm {
+    name     = "jameinel-ubuntu-lite"
+	revision = 10
+  }
+  trust = true
+  expose{}
+  constraints = "%s"
+  config = {
+    juju-external-hostname="myhostname"
+  }
+}
+`, modelName, constraints)
+	}
 }
 
 func testAccResourceApplicationConstraintsSubordinate(t *testing.T, modelName string, constraints string) string {
@@ -203,13 +293,13 @@ resource "juju_application" "this" {
 }
 
 resource "juju_application" "subordinate" {
-	model = juju_model.this.name
-	units = 0
-	name = "test-subordinate"
-	charm {
-		name = "nrpe"
-		revision = 96
-	}
+  model = juju_model.this.name
+  units = 0
+  name = "test-subordinate"
+  charm {
+    name = "nrpe"
+    revision = 96
+    }
 } 
 `, modelName, constraints)
 }

--- a/internal/provider/resource_application_test.go
+++ b/internal/provider/resource_application_test.go
@@ -203,7 +203,7 @@ func testAccResourceApplicationUpdates(modelName string, units int, revision int
 		
 		resource "juju_application" "this" {
 		  model = juju_model.this.name
-		  units = %d
+		  # units = %d
 		  name = "test-app"
 		  charm {
 			name     = "jameinel-ubuntu-lite"

--- a/internal/provider/resource_application_test.go
+++ b/internal/provider/resource_application_test.go
@@ -103,27 +103,30 @@ func TestAcc_ResourceApplication_Updates(t *testing.T) {
 					//resource.TestCheckResourceAttr("juju_application.this", "config.hostname", "machinename"),
 				),
 			},
-			// {
-			// 	Config: testAccResourceApplicationUpdates(modelName, 2, 10, true, "machinename"),
-			// 	Check:  resource.TestCheckResourceAttr("juju_application.this", "units", "2"),
-			// },
+			{
+				SkipFunc: func() (bool, error) {
+					return testingCloud != LXDCloudTesting, nil
+				},
+				Config: testAccResourceApplicationUpdates(modelName, 2, 10, true, "machinename"),
+				Check:  resource.TestCheckResourceAttr("juju_application.this", "units", "2"),
+			},
 			{
 				Config: testAccResourceApplicationUpdates(modelName, 2, 10, true, "machinename"),
 				Check:  resource.TestCheckResourceAttr("juju_application.this", "charm.0.revision", "10"),
 			},
-			// {
-			// 	Config: testAccResourceApplicationUpdates(modelName, 2, 10, false, "machinename"),
-			// 	Check:  resource.TestCheckResourceAttr("juju_application.this", "expose.#", "0"),
-			// },
-			// {
-			// 	Config: testAccResourceApplicationUpdates(modelName, 2, 10, true, "machinename"),
-			// 	Check:  resource.TestCheckResourceAttr("juju_application.this", "expose.#", "1"),
-			// },
-			// {
-			// 	ImportStateVerify: true,
-			// 	ImportState:       true,
-			// 	ResourceName:      "juju_application.this",
-			// },
+			{
+				Config: testAccResourceApplicationUpdates(modelName, 2, 10, false, "machinename"),
+				Check:  resource.TestCheckResourceAttr("juju_application.this", "expose.#", "0"),
+			},
+			{
+				Config: testAccResourceApplicationUpdates(modelName, 2, 10, true, "machinename"),
+				Check:  resource.TestCheckResourceAttr("juju_application.this", "expose.#", "1"),
+			},
+			{
+				ImportStateVerify: true,
+				ImportState:       true,
+				ResourceName:      "juju_application.this",
+			},
 		},
 	})
 }
@@ -203,7 +206,7 @@ func testAccResourceApplicationUpdates(modelName string, units int, revision int
 		
 		resource "juju_application" "this" {
 		  model = juju_model.this.name
-		  # units = %d
+		  units = %d
 		  name = "test-app"
 		  charm {
 			name     = "jameinel-ubuntu-lite"

--- a/internal/provider/resource_application_test.go
+++ b/internal/provider/resource_application_test.go
@@ -176,7 +176,7 @@ func testAccResourceApplicationBasic(modelName, appInvalidName string) string {
 		}
 		
 		resource "juju_application" "this" {
-		  model = jameinel-ubuntu-lite
+		  model = juju_model.this.name
 		  name = %q
 		  charm {
 			name = "jameinel-ubuntu-lite"

--- a/internal/provider/resource_application_test.go
+++ b/internal/provider/resource_application_test.go
@@ -11,7 +11,6 @@ import (
 )
 
 func TestAcc_ResourceApplication_Basic(t *testing.T) {
-
 	modelName := acctest.RandomWithPrefix("tf-test-application")
 	appName := "test-app"
 	appInvalidName := "test_app"
@@ -84,7 +83,6 @@ func TestAcc_ResourceApplication_Basic(t *testing.T) {
 }
 
 func TestAcc_ResourceApplication_Updates(t *testing.T) {
-
 	modelName := acctest.RandomWithPrefix("tf-test-application")
 
 	resource.Test(t, resource.TestCase{
@@ -222,7 +220,6 @@ func testAccResourceApplicationUpdates(modelName string, units int, revision int
 		}
 		`, modelName, units, revision, exposeStr, hostname)
 	}
-
 }
 
 // testAccResourceApplicationConstraints will return two set for constraint

--- a/internal/provider/resource_model_test.go
+++ b/internal/provider/resource_model_test.go
@@ -15,7 +15,6 @@ import (
 )
 
 func TestAcc_ResourceModel_Basic(t *testing.T) {
-
 	modelName := acctest.RandomWithPrefix("tf-test-model")
 	modelInvalidName := acctest.RandomWithPrefix("tf_test_model")
 	logLevelInfo := "INFO"


### PR DESCRIPTION
## Description

Revisit tests to run on Microk8s to ensure we are testing all the available features in both microk8s and lxd.


## Type of change

Please mark if proceeds.

- [ ] New resource (a new resource in the schema)
- [ ] Changed resource (changes in an existing resource)
- [ ] Logic changes in resources (the API interaction with Juju has been changed)
- [x] Test changes (one or several tests have been changed)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Other (describe)

## Environment

- Juju controller version: 2.9.43
- Terraform version: 1.36

## QA steps

GitHub actions should run as expected.

# Additional notes

I found a bug when updating the number of units for a Microk8s deployment. I added code to distinguish between lxd and k8s deployments to use the number of units or the value of the `scale` variable. This fixes the issue.

There is an ongoing issue when running `TestAcc_ResourceAccessModel_Basic` using microk8s on GitHub. I cannot find the reason for the problem. This works in local testing environments. To move this forward, I have skipped two of the subtests there. This will require further investigation. 
