### PR TITLE
Support models removed outside the plan.

### DIFF
--- a/internal/provider/resource_application.go
+++ b/internal/provider/resource_application.go
@@ -233,7 +233,7 @@ func resourceApplicationCreate(ctx context.Context, d *schema.ResourceData, meta
 
 func handleApplicationNotFoundError(err error, d *schema.ResourceData) diag.Diagnostics {
 	if errors.As(err, &juju.ApplicationNotFoundError) {
-		// Integration manually removed
+		// Application manually removed
 		d.SetId("")
 		return diag.Diagnostics{}
 	}

--- a/internal/provider/resource_model.go
+++ b/internal/provider/resource_model.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -147,12 +148,8 @@ func resourceModelCreate(ctx context.Context, d *schema.ResourceData, meta inter
 	return diags
 }
 
-func IsModelNotFound(err error) bool {
-	return strings.Contains(err.Error(), "model not found")
-}
-
 func handleModelNotFoundError(err error, d *schema.ResourceData) diag.Diagnostics {
-	if IsModelNotFound(err) {
+	if errors.As(err, &juju.ModelNotFoundError) {
 		// Model manually removed
 		d.SetId("")
 		return diag.Diagnostics{}


### PR DESCRIPTION

## Description

When a model is removed manually, the terraform plan should recover and detect this situation. Added a specific error type to be processed.

Fix #222 

## Type of change

Please mark if proceeds.

- [ ] New resource (a new resource in the schema)
- [ ] Changed resource (changes in an existing resource)
- [x] Logic changes in resources (the API interaction with Juju has been changed)
- [ ] Test changes (one or several tests have been changed)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Other (describe)

## Environment

- Juju controller version: 3.2.0
- Terraform version: 1.3

## QA steps

Follow the steps described in #222 

