### PR TITLE
[JUJU-4009] Add integration test for manual provisioning (add-machine)

### DIFF
--- a/internal/juju/machines.go
+++ b/internal/juju/machines.go
@@ -161,7 +161,6 @@ func (c machinesClient) CreateMachine(input *CreateMachineInput) (*CreateMachine
 
 // manualProvision calls the sshprovisioner.ProvisionMachine on the Juju side to provision an
 // existing machine using ssh_address, public_key and private_key in the CreateMachineInput
-// TODO (cderici): only the ssh scope is supported, include winrm at some point
 func manualProvision(client manual.ProvisioningClientAPI,
 	config *config.Config, sshAddress string, publicKey string,
 	privateKey string) (string, string, error) {

--- a/internal/juju/machines.go
+++ b/internal/juju/machines.go
@@ -155,6 +155,7 @@ func (c machinesClient) CreateMachine(input *CreateMachineInput) (*CreateMachine
 	machines, err := machineAPIClient.AddMachines(addMachineArgs)
 	return &CreateMachineResponse{
 		Machine: machines[0],
+		Series:  input.Series,
 	}, err
 }
 

--- a/internal/provider/main_test.go
+++ b/internal/provider/main_test.go
@@ -5,10 +5,17 @@ package provider
 
 import (
 	"errors"
+	"net"
 	"os"
 	"strings"
 	"testing"
 )
+
+// Env variables to use for various testing purposes
+const TestCloudEnvKey string = "TEST_CLOUD"
+const TestMachineIPEnvKey string = "TEST_ADD_MACHINE_IP"
+const TestSSHPublicKeyFileEnvKey string = "TEST_SSH_PUB_KEY_PATH"
+const TestSSHPrivateKeyFileEnvKey string = "TEST_SSH_PRIV_KEY_PATH"
 
 // CloudTesting is a value indicating the current cloud
 // available for testing
@@ -56,8 +63,23 @@ func TypeTestingCloudFromString(from string) (CloudTesting, error) {
 // for the testing phase.
 var testingCloud CloudTesting
 
+// testAddMachineIP stores the IP address of a manually created machine outside terraform,
+// communicated via the TEST_ADD_MACHINE_IP env variable.
+// That IP will be used in testing the add-machine functionality on terraform via ssh_address.
+var testAddMachineIP = ""
+var testSSHPubKeyPath = ""
+var testSSHPrivKeyPath = ""
+
 func TestMain(m *testing.M) {
-	testCloud := os.Getenv("TEST_CLOUD")
+	testCloud := os.Getenv(TestCloudEnvKey)
+
+	testMachineIP, exist := os.LookupEnv(TestMachineIPEnvKey)
+	// Confirm the validity of the IP address before setting
+	if exist && net.ParseIP(testMachineIP) != nil {
+		testAddMachineIP = testMachineIP
+	}
+	testSSHPubKeyPath = os.Getenv(TestSSHPublicKeyFileEnvKey)
+	testSSHPrivKeyPath = os.Getenv(TestSSHPrivateKeyFileEnvKey)
 
 	var err error
 	testingCloud, err = TypeTestingCloudFromString(testCloud)

--- a/internal/provider/resource_machine.go
+++ b/internal/provider/resource_machine.go
@@ -144,7 +144,9 @@ func resourceMachineCreate(ctx context.Context, d *schema.ResourceData, meta int
 	if err = d.Set("machine_id", response.Machine.Machine); err != nil {
 		return diag.FromErr(err)
 	}
-	d.Set("series", response.Series)
+	if err = d.Set("series", response.Series); err != nil {
+		return diag.FromErr(err)
+	}
 	d.SetId(id)
 	return nil
 }

--- a/internal/provider/resource_machine.go
+++ b/internal/provider/resource_machine.go
@@ -46,11 +46,11 @@ func resourceMachine() *schema.Resource {
 				ConflictsWith: []string{"ssh_address"},
 			},
 			"disks": {
-				Description: "Storage constraints for disks to attach to the machine(s).",
-				Type:        schema.TypeString,
-				Optional:    true,
-				Default:     "",
-				ForceNew:    true,
+				Description:   "Storage constraints for disks to attach to the machine(s).",
+				Type:          schema.TypeString,
+				Optional:      true,
+				Default:       "",
+				ForceNew:      true,
 				ConflictsWith: []string{"ssh_address"},
 			},
 			"series": {
@@ -137,13 +137,14 @@ func resourceMachineCreate(ctx context.Context, d *schema.ResourceData, meta int
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	if response.Machines[0].Error != nil {
+	if response.Machine.Error != nil {
 		return diag.FromErr(err)
 	}
-	id := fmt.Sprintf("%s:%s:%s", modelName, response.Machines[0].Machine, name)
-	if err = d.Set("machine_id", response.Machines[0].Machine); err != nil {
+	id := fmt.Sprintf("%s:%s:%s", modelName, response.Machine.Machine, name)
+	if err = d.Set("machine_id", response.Machine.Machine); err != nil {
 		return diag.FromErr(err)
 	}
+	d.Set("series", response.Series)
 	d.SetId(id)
 	return nil
 }

--- a/internal/provider/resource_machine.go
+++ b/internal/provider/resource_machine.go
@@ -57,6 +57,7 @@ func resourceMachine() *schema.Resource {
 				Description:   "The operating system series to install on the new machine(s).",
 				Type:          schema.TypeString,
 				Optional:      true,
+				Computed:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"ssh_address"},
 			},

--- a/internal/provider/resource_machine_test.go
+++ b/internal/provider/resource_machine_test.go
@@ -52,11 +52,11 @@ func TestAcc_ResourceMachine_AddMachine(t *testing.T) {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
 	if testAddMachineIP == "" {
-		t.Skip(fmt.Sprintf("environment variable %v not setup or invalid for running test", TestMachineIPEnvKey))
+		t.Skipf("environment variable %v not setup or invalid for running test", TestMachineIPEnvKey)
 	}
 	if testSSHPubKeyPath == "" || testSSHPrivKeyPath == "" {
-		t.Skip(fmt.Sprintf("expected environment variables for ssh keys to be set : %v, %v",
-			TestSSHPublicKeyFileEnvKey, TestSSHPrivateKeyFileEnvKey))
+		t.Skipf("expected environment variables for ssh keys to be set : %v, %v",
+			TestSSHPublicKeyFileEnvKey, TestSSHPrivateKeyFileEnvKey)
 	}
 	modelName := acctest.RandomWithPrefix("tf-test-machine-ssh-address")
 	resource.Test(t, resource.TestCase{

--- a/internal/provider/resource_machine_test.go
+++ b/internal/provider/resource_machine_test.go
@@ -73,9 +73,10 @@ func TestAcc_ResourceMachine_AddMachine(t *testing.T) {
 				),
 			},
 			{
-				ImportStateVerify: true,
-				ImportState:       true,
-				ResourceName:      "juju_machine.this_machine",
+				ImportStateVerify:       true,
+				ImportState:             true,
+				ImportStateVerifyIgnore: []string{"ssh_address", "public_key_file", "private_key_file"},
+				ResourceName:            "juju_machine.this_machine",
 			},
 		},
 	})

--- a/internal/provider/resource_machine_test.go
+++ b/internal/provider/resource_machine_test.go
@@ -22,6 +22,7 @@ func TestAcc_ResourceMachine_Basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("juju_machine.this", "model", modelName),
 					resource.TestCheckResourceAttr("juju_machine.this", "name", "this_machine"),
+					resource.TestCheckResourceAttr("juju_machine.this", "series", "focal"),
 				),
 			},
 			{

--- a/internal/provider/resource_machine_test.go
+++ b/internal/provider/resource_machine_test.go
@@ -46,3 +46,53 @@ resource "juju_machine" "this" {
 }
 `, modelName)
 }
+
+func TestAcc_ResourceMachine_AddMachine(t *testing.T) {
+	if testingCloud != LXDCloudTesting {
+		t.Skip(t.Name() + " only runs with LXD")
+	}
+	if testAddMachineIP == "" {
+		t.Errorf("environment variable %v not setup or invalid for running test", TestMachineIPEnvKey)
+	}
+	if testSSHPubKeyPath == "" || testSSHPrivKeyPath == "" {
+		t.Errorf("expected environment variables for ssh keys to be set : %v, %v",
+			TestSSHPublicKeyFileEnvKey, TestSSHPrivateKeyFileEnvKey)
+	}
+	modelName := acctest.RandomWithPrefix("tf-test-machine-ssh-address")
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceMachineAddMachine(modelName, testAddMachineIP, testSSHPubKeyPath, testSSHPrivKeyPath),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("juju_machine.this_machine", "model", modelName),
+					resource.TestCheckResourceAttr("juju_machine.this_machine", "name", "manually_provisioned_machine"),
+					resource.TestCheckResourceAttr("juju_machine.this_machine", "machine_id", "0"),
+				),
+			},
+			{
+				ImportStateVerify: true,
+				ImportState:       true,
+				ResourceName:      "juju_machine.this_machine",
+			},
+		},
+	})
+}
+
+func testAccResourceMachineAddMachine(modelName string, IP string, pubKeyPath string, privKeyPath string) string {
+	return fmt.Sprintf(`
+resource "juju_model" "this_model" {
+	name = %q
+}
+
+resource "juju_machine" "this_machine" {
+	name = "manually_provisioned_machine"
+	model = juju_model.this_model.name
+
+	ssh_address = "ubuntu@%v"
+    public_key_file = %q
+    private_key_file = %q
+}
+`, modelName, IP, pubKeyPath, privKeyPath)
+}

--- a/internal/provider/resource_machine_test.go
+++ b/internal/provider/resource_machine_test.go
@@ -52,11 +52,11 @@ func TestAcc_ResourceMachine_AddMachine(t *testing.T) {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
 	if testAddMachineIP == "" {
-		t.Errorf("environment variable %v not setup or invalid for running test", TestMachineIPEnvKey)
+		t.Skip(fmt.Sprintf("environment variable %v not setup or invalid for running test", TestMachineIPEnvKey))
 	}
 	if testSSHPubKeyPath == "" || testSSHPrivKeyPath == "" {
-		t.Errorf("expected environment variables for ssh keys to be set : %v, %v",
-			TestSSHPublicKeyFileEnvKey, TestSSHPrivateKeyFileEnvKey)
+		t.Skip(fmt.Sprintf("expected environment variables for ssh keys to be set : %v, %v",
+			TestSSHPublicKeyFileEnvKey, TestSSHPrivateKeyFileEnvKey))
 	}
 	modelName := acctest.RandomWithPrefix("tf-test-machine-ssh-address")
 	resource.Test(t, resource.TestCase{


### PR DESCRIPTION
## Description

This is the first step in adding an integration test for manual provisioning. It introduces some scaffolding code for setting up the test, as the test itself requires a somewhat elaborate setup.

The second step will be to create a github action that'll perform the necessary setup (creating a machine on lxd, setting up the ssh keys etc) and run this test.

## Environment

- Juju controller version: 2.9.x
- Terraform version: 0.8.0

## QA steps

Manually running this test will involve some setting up, basically we need the following env variables:

- `TEST_ADD_MACHINE_IP`: the ip address of the machine
- `TEST_SSH_PUB_KEY_PATH`: the path to the public key file
- `TEST_SSH_PRIV_KEY_PATH`: the path to the private key  file

```sh
# we'll create a machine on lxc, so get the container rolling
 $ lxc launch ubuntu:22.04 mtest

# get the IP address of mtest
 $ lxc list | grep mtest
+---------------+---------+----------------------+------+-----------+-----------+
| mtest         | RUNNING | 10.137.32.154 (eth0) |      | CONTAINER | 0         |
+---------------+---------+----------------------+------+-----------+-----------+
```

Now we need some keys to be able to ssh into this machine. If you have some local keys that would be useful, if you don't, then use `ssh-keygen` to generate a pair. Then throw it into the container:

```sh
 $ lxc file push ~/.ssh/id_rsa.pub mtest/home/ubuntu/.ssh/authorized_keys
# you might wanna confirm the keys are working:
 $ ssh -i ~/.ssh/id_rsa ubuntu@10.137.32.154
```

A little note here: for some reason that I've yet to understand, using the juju client keys (i.e. `~/.local/share/juju/ssh/juju_id_rsa.pub`) doesn't work (getting a permission denied error), even though the `ssh -i ~/.local/share/juju/ssh/juju_id_rsa ubuntu@10.137.32.154` works (for some reason we need to call Juju's `LoadClientKeys()` from within terraform provider to make it work, which I don't think is a good idea). (This might be related to my local ssh agent holding the `cloud-city/id_rsa`, so it might work without that running, I need to try it myself)

Now we have a machine that we have access to, so it can be provisioned, let's run the test with the appropriate env vars:

```sh
# go in the directory where the test is (just for convenience for go test)
 $ cd internal/provider/

# set the env variables (doing it in separate lines here for readability, just throw all of these into a single line without exports)
 $ export TEST_SSH_PUB_KEY_PATH=~/.ssh/id_rsa.pub 
 $ export TEST_SSH_PRIV_KEY_PATH=~/.ssh/id_rsa
 $ export TEST_ADD_MACHINE_IP=10.137.32.154
# these are the env variables the github action will need to set to run this integration test (coming in the next PR)

# finally just run the test itself
 $ TF_ACC=1 TEST_CLOUD=lxd  go test ./... -v -test.run TestAcc_ResourceMachine_AddMachine
```

## Notes & Discussion

- Note that the integration test that's added in this PR, the `TestAcc_ResourceMachine_AddMachine`, is currently not running as a part of the CI run below (because it needs an external machine to be set up etc, so it's auto-skipped -- hence the green run), so it needs to be manually ran and QAed. The actual running test in the CI will be in the next PR that'll add the github action which will set up the environment and run the test.