### PR TITLE
[JUJU-4010] Github action for add machine integration test

### DIFF
--- a/.github/workflows/test_add_machine.yml
+++ b/.github/workflows/test_add_machine.yml
@@ -92,15 +92,16 @@ jobs:
           export TEST_ADD_MACHINE_IP=$(/snap/bin/lxc list mtest --format=json | jq -r '.[0].state.network.eth0.addresses[] | select(.family == "inet").address')
           export TEST_SSH_PUB_KEY_PATH=$(pwd)/test-add-machine.pub
           export TEST_SSH_PRIV_KEY_PATH=$(pwd)/test-add-machine
+          echo "Testing with machine at $TEST_ADD_MACHINE_IP with keys $TEST_SSH_PUB_KEY_PATH and $TEST_SSH_PRIV_KEY_PATH"
 
-          # put the ssh public key into the container
+          echo "Pushing the ssh public key at $TEST_SSH_PUB_KEY_PATH into the container"
           /snap/bin/lxc file push $TEST_SSH_PUB_KEY_PATH mtest/home/ubuntu/.ssh/authorized_keys
 
-          # add the host fingerprint to known_hosts to avoid the host key verification prompt
+          # to avoid the host key verification prompt
+          echo "adding the host fingerprint to known_hosts"
           ssh-keyscan $TEST_ADD_MACHINE_IP >> ~/.ssh/known_hosts
 
-          # go run the test
-          echo "Testing with machine at $TEST_ADD_MACHINE_IP with keys $TEST_SSH_PUB_KEY_PATH and $TEST_SSH_PRIV_KEY_PATH"
+          echo "Running the test"
           cd ./internal/provider/
           go test ./... -timeout 30m -v -test.run TestAcc_ResourceMachine_AddMachine
         timeout-minutes: 40

--- a/.github/workflows/test_add_machine.yml
+++ b/.github/workflows/test_add_machine.yml
@@ -95,6 +95,10 @@ jobs:
           echo "Testing with machine at $TEST_ADD_MACHINE_IP with keys $TEST_SSH_PUB_KEY_PATH and $TEST_SSH_PRIV_KEY_PATH"
 
           echo "Pushing the ssh public key at $TEST_SSH_PUB_KEY_PATH into the container"
+          echo "Waiting on the container to be up and ready to receive the ssh public key file"
+          while [[ -z $(lxc list --format=json | jq -r '.[] | select(.state.status == "Running") | .name' | grep mtest) ]]; do sleep 1; done
+          # Running status doesn't mean the network interface is up, so wait another 10 seconds
+          sleep 10
           /snap/bin/lxc file push $TEST_SSH_PUB_KEY_PATH mtest/home/ubuntu/.ssh/authorized_keys
 
           # to avoid the host key verification prompt

--- a/.github/workflows/test_add_machine.yml
+++ b/.github/workflows/test_add_machine.yml
@@ -86,6 +86,8 @@ jobs:
         run: |
           # generate a key pair and set the env variables
           ssh-keygen -t rsa -N "" -f ./test-add-machine
+          ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no
+
           echo $(/snap/bin/lxc list mtest --format=json | jq -r '.[0].state.network.eth0.addresses[]')
           export TEST_ADD_MACHINE_IP=$(/snap/bin/lxc list mtest --format=json | jq -r '.[0].state.network.eth0.addresses[] | select(.family == "inet").address')
           export TEST_SSH_PUB_KEY_PATH=$(pwd)/test-add-machine.pub

--- a/.github/workflows/test_add_machine.yml
+++ b/.github/workflows/test_add_machine.yml
@@ -36,6 +36,8 @@ jobs:
     name: Add Machine
     needs: build
     runs-on: ubuntu-latest
+    env:
+      ACTIONS_ALLOW_IPV6: false
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test_add_machine.yml
+++ b/.github/workflows/test_add_machine.yml
@@ -78,7 +78,13 @@ jobs:
           echo "EOF" >> $GITHUB_ENV
       - run: go mod download
       - name: Create a new machine on lxd
-        run: /snap/bin/lxc launch ubuntu:22.04 mtest
+        run: |
+          /snap/bin/lxc launch ubuntu:22.04 mtest
+          echo "Waiting on the container to be up and ready"
+          while [[ -z $(lxc list --format=json | jq -r '.[] | select(.state.status == "Running") | .name' | grep mtest) ]]; do sleep 1; done
+          # Running status doesn't mean the network interface is up, so wait another 10 seconds
+          sleep 10
+          echo "Container for test is ready"
       - name: Final setup and test
         env:
           TF_ACC: "1"
@@ -95,10 +101,6 @@ jobs:
           echo "Testing with machine at $TEST_ADD_MACHINE_IP with keys $TEST_SSH_PUB_KEY_PATH and $TEST_SSH_PRIV_KEY_PATH"
 
           echo "Pushing the ssh public key at $TEST_SSH_PUB_KEY_PATH into the container"
-          echo "Waiting on the container to be up and ready to receive the ssh public key file"
-          while [[ -z $(lxc list --format=json | jq -r '.[] | select(.state.status == "Running") | .name' | grep mtest) ]]; do sleep 1; done
-          # Running status doesn't mean the network interface is up, so wait another 10 seconds
-          sleep 10
           /snap/bin/lxc file push $TEST_SSH_PUB_KEY_PATH mtest/home/ubuntu/.ssh/authorized_keys
 
           # to avoid the host key verification prompt

--- a/.github/workflows/test_add_machine.yml
+++ b/.github/workflows/test_add_machine.yml
@@ -77,12 +77,14 @@ jobs:
       - run: go mod download
       - name: Create a new machine on lxd
         run: lxc launch ubuntu:22.04 mtest
-      - env:
+      - name: Final setup and test
+        env:
           TF_ACC: "1"
           TEST_CLOUD: ${{ matrix.cloud }}
         run: |
           # generate a key pair and set the env variables
           ssh-keygen -t rsa -N "" -f ./test-add-machine
+          echo $(lxc list mtest --format=json | jq -r '.[0].state.network.eth0.addresses[]')
           export TEST_ADD_MACHINE_IP=$(lxc list mtest --format=json | jq -r '.[0].state.network.eth0.addresses[] | select(.family == "inet").address')
           export TEST_SSH_PUB_KEY_PATH=$(pwd)/test-add-machine.pub
           export TEST_SSH_PRIV_KEY_PATH=$(pwd)/test-add-machine

--- a/.github/workflows/test_add_machine.yml
+++ b/.github/workflows/test_add_machine.yml
@@ -105,6 +105,7 @@ jobs:
 
           # to avoid the host key verification prompt
           echo "adding the host fingerprint to known_hosts"
+          mkdir -p ~/.ssh
           ssh-keyscan $TEST_ADD_MACHINE_IP >> ~/.ssh/known_hosts
 
           echo "Running the test"

--- a/.github/workflows/test_add_machine.yml
+++ b/.github/workflows/test_add_machine.yml
@@ -78,14 +78,15 @@ jobs:
       - name: Create a new machine on lxd
         run: lxc launch ubuntu:22.04 mtest
       - env:
-          TEST_ADD_MACHINE_IP: $(lxc list mtest --format=json | jq -r '.[0].state.network.eth0.addresses[0].address')
           TF_ACC: "1"
           TEST_CLOUD: ${{ matrix.cloud }}
         run: |
           # generate a key pair and set the env variables
           ssh-keygen -t rsa -N "" -f ./test-add-machine
+          export TEST_ADD_MACHINE_IP=$(lxc list mtest --format=json | jq -r '.[0].state.network.eth0.addresses[0].address')
           export TEST_SSH_PUB_KEY_PATH=$(pwd)/test-add-machine.pub
           export TEST_SSH_PRIV_KEY_PATH=$(pwd)/test-add-machine
+          echo "Testing with machine at $TEST_ADD_MACHINE_IP with keys $TEST_SSH_PUB_KEY_PATH and $TEST_SSH_PRIV_KEY_PATH"
           cd ./internal/provider/
           go test ./... -timeout 30m -v -test.run TestAcc_ResourceMachine_AddMachine
         timeout-minutes: 40

--- a/.github/workflows/test_add_machine.yml
+++ b/.github/workflows/test_add_machine.yml
@@ -1,0 +1,91 @@
+# Terraform Provider testing workflow using different terraform versions
+# on lxd. This action is specifically for testing manual provision.
+# It sets up an external machine and adds it into the Juju model using
+# terraform.
+name: Manual machine provision
+
+on:
+  pull_request:
+    paths-ignore:
+      - "README.md"
+      - "project-docs/**"
+  push:
+    branches:
+      - "main"
+    paths-ignore:
+      - "README.md"
+      - "project-docs/**"
+
+# Testing only needs permissions to read the repository contents.
+permissions:
+  contents: read
+
+jobs:
+  # Ensure project builds before running testing matrix
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+      - run: go build -v .
+
+  # Run acceptance tests in a matrix with Terraform CLI versions
+  test:
+    name: Integration
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Only on lxd
+        cloud:
+          - "lxd"
+        terraform:
+          - "1.3.*"
+          - "1.4.*"
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: "go.mod"
+          cache: true
+      # set up terraform
+      - uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: ${{ matrix.terraform }}
+          terraform_wrapper: false
+      # set up snap, lxd, tox, Juju, bootstrap a controller, etc.
+      - name: Setup operator environment
+        uses: charmed-kubernetes/actions-operator@main
+        with:
+          provider: ${{ matrix.cloud }}
+          juju-channel: 2.9/stable
+      - name: "Set environment to configure provider"
+        # language=bash
+        run: |
+          CONTROLLER=$(juju whoami --format yaml | yq .controller)
+
+          echo "JUJU_CONTROLLER_ADDRESSES=$(juju show-controller | yq .$CONTROLLER.details.api-endpoints | yq -r '. | join(",")')" >> $GITHUB_ENV
+          echo "JUJU_USERNAME=$(juju show-controller | yq .$CONTROLLER.account.user)"  >> $GITHUB_ENV
+          echo "JUJU_PASSWORD=$(cat ~/.local/share/juju/accounts.yaml | yq .controllers.$CONTROLLER.password)"  >> $GITHUB_ENV
+          echo "JUJU_CA_CERT<<EOF" >> $GITHUB_ENV
+          juju show-controller | yq .$CONTROLLER.details.ca-cert >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+      - run: go mod download
+      - name: Create a new machine on lxd
+        run: lxc launch ubuntu:22.04 mtest
+      - env:
+          TEST_ADD_MACHINE_IP: $(lxc list mtest --format=json | jq -r '.[0].state.network.eth0.addresses[0].address')
+          TF_ACC: "1"
+          TEST_CLOUD: ${{ matrix.cloud }}
+        run: |
+          # generate a key pair and set the env variables
+          ssh-keygen -t rsa -N "" -f ./test-add-machine
+          export TEST_SSH_PUB_KEY_PATH=$(pwd)/test-add-machine.pub
+          export TEST_SSH_PRIV_KEY_PATH=$(pwd)/test-add-machine
+          cd ./internal/provider/
+          go test ./... -timeout 30m -v -test.run TestAcc_ResourceMachine_AddMachine
+        timeout-minutes: 40

--- a/.github/workflows/test_add_machine.yml
+++ b/.github/workflows/test_add_machine.yml
@@ -76,7 +76,10 @@ jobs:
           echo "EOF" >> $GITHUB_ENV
       - run: go mod download
       - name: Create a new machine on lxd
-        run: lxc launch ubuntu:22.04 mtest
+        run: |
+          # disable ipv6 on lxdbr0 network (default network for lxc)
+          lxc network set lxdbr0 ipv6.address none
+          lxc launch ubuntu:22.04 mtest
       - env:
           TF_ACC: "1"
           TEST_CLOUD: ${{ matrix.cloud }}

--- a/.github/workflows/test_add_machine.yml
+++ b/.github/workflows/test_add_machine.yml
@@ -84,14 +84,22 @@ jobs:
           TF_ACC: "1"
           TEST_CLOUD: ${{ matrix.cloud }}
         run: |
-          # generate a key pair and set the env variables
+          # generate a new key pair
           ssh-keygen -t rsa -N "" -f ./test-add-machine
-          ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no
 
+          # set the env variables
           echo $(/snap/bin/lxc list mtest --format=json | jq -r '.[0].state.network.eth0.addresses[]')
           export TEST_ADD_MACHINE_IP=$(/snap/bin/lxc list mtest --format=json | jq -r '.[0].state.network.eth0.addresses[] | select(.family == "inet").address')
           export TEST_SSH_PUB_KEY_PATH=$(pwd)/test-add-machine.pub
           export TEST_SSH_PRIV_KEY_PATH=$(pwd)/test-add-machine
+
+          # put the ssh public key into the container
+          /snap/bin/lxc file push $TEST_SSH_PUB_KEY_PATH mtest/home/ubuntu/.ssh/authorized_keys
+
+          # add the host fingerprint to known_hosts to avoid the host key verification prompt
+          ssh-keyscan $TEST_ADD_MACHINE_IP >> ~/.ssh/known_hosts
+
+          # go run the test
           echo "Testing with machine at $TEST_ADD_MACHINE_IP with keys $TEST_SSH_PUB_KEY_PATH and $TEST_SSH_PRIV_KEY_PATH"
           cd ./internal/provider/
           go test ./... -timeout 30m -v -test.run TestAcc_ResourceMachine_AddMachine

--- a/.github/workflows/test_add_machine.yml
+++ b/.github/workflows/test_add_machine.yml
@@ -90,8 +90,10 @@ jobs:
           TF_ACC: "1"
           TEST_CLOUD: ${{ matrix.cloud }}
         run: |
-          # generate a new key pair
+          # generate a new key pair and add it to the agent
           ssh-keygen -t rsa -N "" -f ./test-add-machine
+          eval "$(ssh-agent -s)"
+          ssh-add ./test-add-machine
 
           # set the env variables
           echo $(/snap/bin/lxc list mtest --format=json | jq -r '.[0].state.network.eth0.addresses[]')

--- a/.github/workflows/test_add_machine.yml
+++ b/.github/workflows/test_add_machine.yml
@@ -32,8 +32,8 @@ jobs:
       - run: go build -v .
 
   # Run acceptance tests in a matrix with Terraform CLI versions
-  test:
-    name: Integration
+  add-machine-test:
+    name: Add Machine
     needs: build
     runs-on: ubuntu-latest
     strategy:
@@ -76,17 +76,14 @@ jobs:
           echo "EOF" >> $GITHUB_ENV
       - run: go mod download
       - name: Create a new machine on lxd
-        run: |
-          # disable ipv6 on lxdbr0 network (default network for lxc)
-          lxc network set lxdbr0 ipv6.address none
-          lxc launch ubuntu:22.04 mtest
+        run: lxc launch ubuntu:22.04 mtest
       - env:
           TF_ACC: "1"
           TEST_CLOUD: ${{ matrix.cloud }}
         run: |
           # generate a key pair and set the env variables
           ssh-keygen -t rsa -N "" -f ./test-add-machine
-          export TEST_ADD_MACHINE_IP=$(lxc list mtest --format=json | jq -r '.[0].state.network.eth0.addresses[0].address')
+          export TEST_ADD_MACHINE_IP=$(lxc list mtest --format=json | jq -r '.[0].state.network.eth0.addresses[] | select(.family == "inet").address')
           export TEST_SSH_PUB_KEY_PATH=$(pwd)/test-add-machine.pub
           export TEST_SSH_PRIV_KEY_PATH=$(pwd)/test-add-machine
           echo "Testing with machine at $TEST_ADD_MACHINE_IP with keys $TEST_SSH_PUB_KEY_PATH and $TEST_SSH_PRIV_KEY_PATH"

--- a/.github/workflows/test_add_machine.yml
+++ b/.github/workflows/test_add_machine.yml
@@ -76,7 +76,7 @@ jobs:
           echo "EOF" >> $GITHUB_ENV
       - run: go mod download
       - name: Create a new machine on lxd
-        run: lxc launch ubuntu:22.04 mtest
+        run: /snap/bin/lxc launch ubuntu:22.04 mtest
       - name: Final setup and test
         env:
           TF_ACC: "1"
@@ -84,8 +84,8 @@ jobs:
         run: |
           # generate a key pair and set the env variables
           ssh-keygen -t rsa -N "" -f ./test-add-machine
-          echo $(lxc list mtest --format=json | jq -r '.[0].state.network.eth0.addresses[]')
-          export TEST_ADD_MACHINE_IP=$(lxc list mtest --format=json | jq -r '.[0].state.network.eth0.addresses[] | select(.family == "inet").address')
+          echo $(/snap/bin/lxc list mtest --format=json | jq -r '.[0].state.network.eth0.addresses[]')
+          export TEST_ADD_MACHINE_IP=$(/snap/bin/lxc list mtest --format=json | jq -r '.[0].state.network.eth0.addresses[] | select(.family == "inet").address')
           export TEST_SSH_PUB_KEY_PATH=$(pwd)/test-add-machine.pub
           export TEST_SSH_PRIV_KEY_PATH=$(pwd)/test-add-machine
           echo "Testing with machine at $TEST_ADD_MACHINE_IP with keys $TEST_SSH_PUB_KEY_PATH and $TEST_SSH_PRIV_KEY_PATH"


### PR DESCRIPTION
## Description

This is a follow up on the https://github.com/juju/terraform-provider-juju/pull/233 that adds the integration test for manually provisioning a machine using terraform juju provider. It sets up the environment, creates a machine on lxc, generates a keypair and sets up the environment variables for running the test, which are `TEST_ADD_MACHINE_IP`, `TEST_SSH_PUB_KEY_PATH` and `TEST_SSH_PRIV_KEY_PATH`.

The main logic in the action is in this part:

```yml
- name: Create a new machine on lxd
  run: |
    /snap/bin/lxc launch ubuntu:22.04 mtest
    echo "Waiting on the container to be up and ready"
    while [[ -z $(lxc list --format=json | jq -r '.[] | select(.state.status == "Running") | .name' | grep mtest) ]]; do sleep 1; done
    # Running status doesn't mean the network interface is up, so wait another 10 seconds
    sleep 10
    echo "Container for test is ready"
- name: Final setup and test
  env:
    TF_ACC: "1"
    TEST_CLOUD: ${{ matrix.cloud }}
  run: |
    # generate a new key pair and add it to the agent
    ssh-keygen -t rsa -N "" -f ./test-add-machine
    eval "$(ssh-agent -s)"
    ssh-add ./test-add-machine
    
    # set the env variables
    echo $(/snap/bin/lxc list mtest --format=json | jq -r '.[0].state.network.eth0.addresses[]')
    export TEST_ADD_MACHINE_IP=$(/snap/bin/lxc list mtest --format=json | jq -r '.[0].state.network.eth0.addresses[] | select(.family == "inet").address')
    export TEST_SSH_PUB_KEY_PATH=$(pwd)/test-add-machine.pub
    export TEST_SSH_PRIV_KEY_PATH=$(pwd)/test-add-machine
    echo "Testing with machine at $TEST_ADD_MACHINE_IP with keys $TEST_SSH_PUB_KEY_PATH and $TEST_SSH_PRIV_KEY_PATH"
    
    echo "Pushing the ssh public key at $TEST_SSH_PUB_KEY_PATH into the container"
    /snap/bin/lxc file push $TEST_SSH_PUB_KEY_PATH mtest/home/ubuntu/.ssh/authorized_keys
    
    # to avoid the host key verification prompt
    echo "adding the host fingerprint to known_hosts"
    mkdir -p ~/.ssh
    ssh-keyscan $TEST_ADD_MACHINE_IP >> ~/.ssh/known_hosts
    
    echo "Running the test"
    cd ./internal/provider/
    go test ./... -timeout 30m -v -test.run TestAcc_ResourceMachine_AddMachine
```

## QA steps

The `Manual machine provision` workflow in https://github.com/juju/terraform-provider-juju/actions should be passing. Can be seen in the check list down below in the PR Checks section.

Alternatively it looks like the action can be ran (simulated) locally using something like `act`. Though I don't know how to use it myself to provide some use steps here.

# Additional notes

- [ ] #233 should land before this one