### PR TITLE
[JUJU-4186] Use also the Terraform 1.5 for integration tests

### DIFF
--- a/.github/workflows/test_add_machine.yml
+++ b/.github/workflows/test_add_machine.yml
@@ -45,8 +45,7 @@ jobs:
         cloud:
           - "lxd"
         terraform:
-          - "1.3.*"
-          - "1.4.*"
+          - "1.5.*"
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test_integration.yml
+++ b/.github/workflows/test_integration.yml
@@ -79,6 +79,7 @@ jobs:
         terraform:
           - "1.3.*"
           - "1.4.*"
+          - "1.5.*"
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test_new_candidates.yml
+++ b/.github/workflows/test_new_candidates.yml
@@ -26,6 +26,7 @@ jobs:
         terraform:
           - "1.3.*"
           - "1.4.*"
+          - "1.5.*"
     steps:
       - name: Set channel and artifact id
         run: |


### PR DESCRIPTION
## Description

This adds the terraform `1.5` into the `test_integration` and `test_new_candidates` github actions, and replaces the older versions in `test_add_machine` with the latest (1.5), as there's no need to run that specific scenario against multiple terraform versions.

## Type of change

Please mark if proceeds.

- [ ] New resource (a new resource in the schema)
- [ ] Changed resource (changes in an existing resource)
- [ ] Logic changes in resources (the API interaction with Juju has been changed)
- [x] Test changes (one or several tests have been changed)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Other (describe)

## QA steps

Make sure the Github actions are spawning for the 1.5.* version.
