### PR TITLE
Additional make target: docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ VERSION=0.8.0
 REGISTRY_DIR=~/.terraform.d/plugins/registry.terraform.io/juju/juju/${VERSION}/${GOOS}_${GOARCH}
 
 .PHONY: install
-install: lint simplify docs go-install
+install: simplify docs go-install
 ## install: Build terraform-provider-juju and copy to ~/.terraform.d using VERSION
 	@echo "Copied to ~/.terraform.d/plugins/registry.terraform.io/juju/juju/${VERSION}/${GOOS}_${GOARCH}"
 	@mkdir -p ${REGISTRY_DIR}
@@ -27,7 +27,7 @@ install: lint simplify docs go-install
 # Reformat and simplify source files.
 simplify:
 ## simplify: Format and simplify the go source code
-	@echo "Formating the go source code."
+	@echo "Formating the go source code"
 	@gofmt -w -l -s .
 
 .PHONY: lint
@@ -36,11 +36,11 @@ lint:
 	@echo "Running go lint"
 	@golangci-lint run -c .golangci.yml
 
-# require terraform to be installed.... HML
+HAS_TERRAFORM := $(shell command -v terraform 2> /dev/null)
 .PHONY: docs
 docs:
 ## docs: update the generated terraform docs.
-ifeq ($(shell which terraform && echo true),true)
+ifneq ($(HAS_TERRAFORM),)
 	@echo "Generating docs"
 	@go generate ./...
 else


### PR DESCRIPTION

## Description
Generate docs if terraform is installed when doing an install. Updated go-install target
to run go mod tidy. Adding helpers to avoid more commits later.

## Type of change

Please mark if proceeds.

- [ ] New resource (a new resource in the schema)
- [ ] Changed resource (changes in an existing resource)
- [ ] Logic changes in resources (the API interaction with Juju has been changed)
- [ ] Test changes (one or several tests have been changed)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ x] Other - Development experience improvement

## Environment

- Juju controller version: 2.9.43
- Terraform version: 1.5.x

## QA steps

```
$ make
Usage:

  docs           update the generated terraform docs.
  envtestlxd     Under development - Include env var and run unit tests against lxd
  go-install     Build and install terraform-provider-juju in $GOPATH/bin
  install        Build terraform-provider-juju and copy to ~/.terraform.d using VERSION
  lint           run the go linter
  simplify       Format and simplify the go source code
  testlxd        Run unit tests against lxd
  testmicrok8s   Run unit tests against microk8s

# without terraform installed
$ make go-install
Running go lint
Formating the go source code.
Unable to generate docs, terraform not installed
Installing terraform-provider-juju
Copied to ~/.terraform.d/plugins/registry.terraform.io/juju/juju/0.8.0/darwin_amd64
```
