### PR TITLE
[JUJU-4179] Create model data source in framework

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,9 @@ require (
 require (
 	github.com/hashicorp/terraform-plugin-framework v1.3.2
 	github.com/hashicorp/terraform-plugin-go v0.17.0
+	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-mux v0.11.1
+	github.com/hashicorp/terraform-plugin-testing v1.3.0
 	github.com/juju/charm/v8 v8.0.6
 	github.com/juju/cmd/v3 v3.0.10
 	github.com/juju/errors v1.0.0
@@ -89,7 +91,6 @@ require (
 	github.com/hashicorp/raft v1.3.2-0.20210825230038-1a621031eb2b // indirect
 	github.com/hashicorp/terraform-exec v0.18.1 // indirect
 	github.com/hashicorp/terraform-json v0.17.1 // indirect
-	github.com/hashicorp/terraform-plugin-log v0.9.0 // indirect
 	github.com/hashicorp/terraform-registry-address v0.2.1 // indirect
 	github.com/hashicorp/terraform-svchost v0.1.1 // indirect
 	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect

--- a/go.sum
+++ b/go.sum
@@ -444,6 +444,8 @@ github.com/hashicorp/terraform-plugin-mux v0.11.1 h1:cDCrmkrNHf/c2zC1oREIMdgCYWi
 github.com/hashicorp/terraform-plugin-mux v0.11.1/go.mod h1:eMZPcv8b5y+alMeQmocgaphPj4zAnM3uXiMLd1emqMQ=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.27.0 h1:I8efBnjuDrgPjNF1MEypHy48VgcTIUY4X6rOFunrR3Y=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.27.0/go.mod h1:cUEP4ly/nxlHy5HzD6YRrHydtlheGvGRJDhiWqqVik4=
+github.com/hashicorp/terraform-plugin-testing v1.3.0 h1:4Pn8fSspPCRUc5zRGPNZYc00VhQmQPEH6y6Pv4e/42M=
+github.com/hashicorp/terraform-plugin-testing v1.3.0/go.mod h1:mGOfGFTVIhP9buGPZyDQhmZFIO/Ig8E0Fo694UACr64=
 github.com/hashicorp/terraform-registry-address v0.2.1 h1:QuTf6oJ1+WSflJw6WYOHhLgwUiQ0FrROpHPYFtwTYWM=
 github.com/hashicorp/terraform-registry-address v0.2.1/go.mod h1:BSE9fIFzp0qWsJUUyGquo4ldV9k2n+psif6NYkBRS3Y=
 github.com/hashicorp/terraform-svchost v0.1.1 h1:EZZimZ1GxdqFRinZ1tpJwVxxt49xc/S52uzrw4x0jKQ=

--- a/internal/provider/data_source_machine_test.go
+++ b/internal/provider/data_source_machine_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAcc_DataSourceMachine(t *testing.T) {

--- a/internal/provider/data_source_model_test.go
+++ b/internal/provider/data_source_model_test.go
@@ -4,22 +4,43 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAcc_DataSourceModel(t *testing.T) {
 	modelName := acctest.RandomWithPrefix("tf-datasource-model-test")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceModel(t, modelName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.juju_model.model", "name", modelName),
 				),
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"juju": {
+						VersionConstraint: "0.8.0",
+						Source:            "juju/juju",
+					},
+				},
+				PreConfig: func() { testAccPreCheck(t) },
+			},
+			{
+				Config: testAccFrameworkDataSourceModel(t, modelName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.juju_model.model", "name", modelName),
+					resource.TestCheckResourceAttrSet("data.juju_model.model", "uuid"),
+				),
+				ProtoV5ProviderFactories: map[string]func() (tfprotov5.ProviderServer, error){
+					"juju": providerserver.NewProtocol5WithError(NewJujuProvider("dev")),
+					"oldjuju": func() (tfprotov5.ProviderServer, error) {
+						return schema.NewGRPCProviderServer(New("dev")()), nil
+					},
+				},
 			},
 		},
 	})
@@ -32,6 +53,23 @@ resource "juju_model" "model" {
 }
 
 data "juju_model" "model" {
-  name = juju_model.model.name
+	name = juju_model.model.name
+}`, modelName)
+}
+
+func testAccFrameworkDataSourceModel(t *testing.T, modelName string) string {
+	return fmt.Sprintf(`
+provider "juju" {}
+
+provider "oldjuju" {}
+
+resource "juju_model" "model" {
+	provider = oldjuju
+	name = %q
+}
+
+data "juju_model" "model" {
+	provider = juju
+	name = juju_model.model.name
 }`, modelName)
 }

--- a/internal/provider/data_source_model_test.go
+++ b/internal/provider/data_source_model_test.go
@@ -19,7 +19,7 @@ func TestAcc_DataSourceModel(t *testing.T) {
 			{
 				Config: testAccDataSourceModel(t, modelName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.juju_model.model", "name", modelName),
+					resource.TestCheckResourceAttr("data.juju_model.test-model", "name", modelName),
 				),
 				ExternalProviders: map[string]resource.ExternalProvider{
 					"juju": {
@@ -32,8 +32,8 @@ func TestAcc_DataSourceModel(t *testing.T) {
 			{
 				Config: testAccFrameworkDataSourceModel(t, modelName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.juju_model.model", "name", modelName),
-					resource.TestCheckResourceAttrSet("data.juju_model.model", "uuid"),
+					resource.TestCheckResourceAttr("data.juju_model.test-model", "name", modelName),
+					resource.TestCheckResourceAttrSet("data.juju_model.test-model", "uuid"),
 				),
 				ProtoV5ProviderFactories: map[string]func() (tfprotov5.ProviderServer, error){
 					"juju": providerserver.NewProtocol5WithError(NewJujuProvider("dev")),
@@ -48,12 +48,12 @@ func TestAcc_DataSourceModel(t *testing.T) {
 
 func testAccDataSourceModel(t *testing.T, modelName string) string {
 	return fmt.Sprintf(`
-resource "juju_model" "model" {
+resource "juju_model" "test-model" {
 	name = %q
 }
 
-data "juju_model" "model" {
-	name = juju_model.model.name
+data "juju_model" "test-model" {
+	name = juju_model.test-model.name
 }`, modelName)
 }
 
@@ -63,13 +63,13 @@ provider "juju" {}
 
 provider "oldjuju" {}
 
-resource "juju_model" "model" {
+resource "juju_model" "test-model" {
 	provider = oldjuju
 	name = %q
 }
 
-data "juju_model" "model" {
+data "juju_model" "test-model" {
 	provider = juju
-	name = juju_model.model.name
+	name = juju_model.test-model.name
 }`, modelName)
 }

--- a/internal/provider/data_source_offer_test.go
+++ b/internal/provider/data_source_offer_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAcc_DataSourceOffer(t *testing.T) {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -61,7 +61,6 @@ func New(version string) func() *schema.Provider {
 				},
 			},
 			DataSourcesMap: map[string]*schema.Resource{
-				"juju_model":   dataSourceModel(),
 				"juju_machine": dataSourceMachine(),
 				"juju_offer":   dataSourceOffer(),
 			},
@@ -375,7 +374,7 @@ func (p *jujuProvider) Resources(ctx context.Context) []func() resource.Resource
 // the Metadata method. All data sources must have unique names.
 func (p *jujuProvider) DataSources(ctx context.Context) []func() datasource.DataSource {
 	return []func() datasource.DataSource{
-		//func() datasource.DataSource { return NewModelDataSource() },
+		func() datasource.DataSource { return NewModelDataSource() },
 		//func() datasource.DataSource { return NewMachineDataSource() },
 		//func() datasource.DataSource { return NewOfferDataSource() },
 	}

--- a/internal/provider/resource_access_model_test.go
+++ b/internal/provider/resource_access_model_test.go
@@ -5,8 +5,8 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAcc_ResourceAccessModel_Basic(t *testing.T) {

--- a/internal/provider/resource_application_test.go
+++ b/internal/provider/resource_application_test.go
@@ -5,9 +5,9 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAcc_ResourceApplication_Basic(t *testing.T) {

--- a/internal/provider/resource_credential_test.go
+++ b/internal/provider/resource_credential_test.go
@@ -5,8 +5,8 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAcc_ResourceCredential_Basic(t *testing.T) {

--- a/internal/provider/resource_integration_test.go
+++ b/internal/provider/resource_integration_test.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestAcc_ResourceIntegration(t *testing.T) {

--- a/internal/provider/resource_machine_test.go
+++ b/internal/provider/resource_machine_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAcc_ResourceMachine_Basic(t *testing.T) {

--- a/internal/provider/resource_model_test.go
+++ b/internal/provider/resource_model_test.go
@@ -5,13 +5,14 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/juju/juju/api/client/modelconfig"
 	"github.com/juju/juju/rpc/params"
+
 	"github.com/juju/terraform-provider-juju/internal/juju"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAcc_ResourceModel_Basic(t *testing.T) {

--- a/internal/provider/resource_offer_test.go
+++ b/internal/provider/resource_offer_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAcc_ResourceOffer_Basic(t *testing.T) {

--- a/internal/provider/resource_ssh_key_test.go
+++ b/internal/provider/resource_ssh_key_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAcc_ResourceSSHKey_Basic(t *testing.T) {

--- a/internal/provider/resource_user_test.go
+++ b/internal/provider/resource_user_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAcc_ResourceUser_Basic(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -62,7 +62,7 @@ func main() {
 	}
 
 	if err = tf5server.Serve(
-		"registry.terraform.io/canonical/juju",
+		"registry.terraform.io/juju/juju",
 		muxServer.ProviderServer,
 		serveOpts...,
 	); err != nil {


### PR DESCRIPTION
## Description

Transform the model data source from the sdk/v2 methodology to using the newer terraform framework.

## Type of change

Please mark if proceeds.

- [ ] New resource (a new resource in the schema)
- [ ] Changed resource (changes in an existing resource)
- [ ] Logic changes in resources (the API interaction with Juju has been changed)
- [ ] Test changes (one or several tests have been changed)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Other: maintenance

## Environment

- Juju controller version: 2.9.43
- Terraform version: 1.5.2

## QA steps

There should be no change in current behavior and all AT should pass.

