### PR TITLE
[JUJU-4182] Create user resource in framework

### DIFF
--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -3,12 +3,12 @@
 page_title: "juju_user Resource - terraform-provider-juju"
 subcategory: ""
 description: |-
-  A resource that represent a Juju User.
+  A resource that represents a Juju User.
 ---
 
 # juju_user (Resource)
 
-A resource that represent a Juju User.
+A resource that represents a Juju User.
 
 
 
@@ -18,11 +18,11 @@ A resource that represent a Juju User.
 ### Required
 
 - `name` (String) The name to be assigned to the user
-- `password` (String) The password to be assigned to the user
+- `password` (String, Sensitive) The password to be assigned to the user
 
 ### Optional
 
-- `display_name` (String) The display name to be assigned to the user
+- `display_name` (String) The display name to be assigned to the user (optional)
 
 ### Read-Only
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -73,7 +73,6 @@ func New(version string) func() *schema.Provider {
 				"juju_offer":        resourceOffer(),
 				"juju_machine":      resourceMachine(),
 				"juju_ssh_key":      resourceSSHKey(),
-				"juju_user":         resourceUser(),
 			},
 		}
 		p.ConfigureContextFunc = configure()
@@ -363,7 +362,7 @@ func getJujuProviderModel(ctx context.Context, req frameworkprovider.ConfigureRe
 // the Metadata method. All resources must have unique names.
 func (p *jujuProvider) Resources(ctx context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
-		//func() resource.Resource {return NewUserResource()},
+		func() resource.Resource { return NewUserResource() },
 	}
 }
 

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -48,6 +48,7 @@ func init() {
 			return upgradedSdkProvider, err
 		},
 	}
+
 	frameworkProviderFactories = map[string]func() (tfprotov6.ProviderServer, error){
 		"juju": providerserver.NewProtocol6WithError(NewJujuProvider("dev")),
 	}

--- a/internal/provider/resource_access_model_test.go
+++ b/internal/provider/resource_access_model_test.go
@@ -125,16 +125,20 @@ func TestAcc_ResourceAccessModel_Stable(t *testing.T) {
 
 func testAccResourceAccessModel_Stable(t *testing.T, userName, userPassword, modelName, access string) string {
 	return fmt.Sprintf(`
+provider oldjuju {}
+
 resource "juju_user" "this" {
   name = %q
   password = %q
 }
 
 resource "juju_model" "this" {
+  provider = oldjuju
   name = %q
 }
 
 resource "juju_access_model" "test" {
+  provider = oldjuju
   access = %q
   model = juju_model.this.name
   users = [juju_user.this.name]

--- a/internal/provider/resource_access_model_test.go
+++ b/internal/provider/resource_access_model_test.go
@@ -22,7 +22,7 @@ func TestAcc_ResourceAccessModel_sdk2_framework_migrate(t *testing.T) {
 		ProtoV6ProviderFactories: muxProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccResourceAccessModel_sdk2_framework_migrate(t, userName, userPassword, modelName, accessFail),
+				Config:      testAccResourceAccessModel_sdk2_framework_migrate(userName, userPassword, modelName, accessFail),
 				ExpectError: regexp.MustCompile("Error running pre-apply refresh.*"),
 			},
 			{
@@ -32,7 +32,7 @@ func TestAcc_ResourceAccessModel_sdk2_framework_migrate(t *testing.T) {
 				SkipFunc: func() (bool, error) {
 					return testingCloud != LXDCloudTesting, nil
 				},
-				Config: testAccResourceAccessModel_sdk2_framework_migrate(t, userName, userPassword, modelName, access),
+				Config: testAccResourceAccessModel_sdk2_framework_migrate(userName, userPassword, modelName, access),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "access", access),
 					resource.TestCheckResourceAttr(resourceName, "model", modelName),
@@ -52,12 +52,11 @@ func TestAcc_ResourceAccessModel_sdk2_framework_migrate(t *testing.T) {
 	})
 }
 
-func testAccResourceAccessModel_sdk2_framework_migrate(t *testing.T, userName, userPassword, modelName, access string) string {
+func testAccResourceAccessModel_sdk2_framework_migrate(userName, userPassword, modelName, access string) string {
 	return fmt.Sprintf(`
 provider oldjuju {}
 
 resource "juju_user" "this" {
-  provider = oldjuju
   name = %q
   password = %q
 }
@@ -93,7 +92,7 @@ func TestAcc_ResourceAccessModel_Stable(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccResourceAccessModel_Stable(t, userName, userPassword, modelName, accessFail),
+				Config:      testAccResourceAccessModel_Stable(userName, userPassword, modelName, accessFail),
 				ExpectError: regexp.MustCompile("Error running pre-apply refresh.*"),
 			},
 			{
@@ -103,7 +102,7 @@ func TestAcc_ResourceAccessModel_Stable(t *testing.T) {
 				SkipFunc: func() (bool, error) {
 					return testingCloud != LXDCloudTesting, nil
 				},
-				Config: testAccResourceAccessModel_Stable(t, userName, userPassword, modelName, access),
+				Config: testAccResourceAccessModel_Stable(userName, userPassword, modelName, access),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "access", access),
 					resource.TestCheckResourceAttr(resourceName, "model", modelName),
@@ -123,22 +122,18 @@ func TestAcc_ResourceAccessModel_Stable(t *testing.T) {
 	})
 }
 
-func testAccResourceAccessModel_Stable(t *testing.T, userName, userPassword, modelName, access string) string {
+func testAccResourceAccessModel_Stable(userName, userPassword, modelName, access string) string {
 	return fmt.Sprintf(`
-provider oldjuju {}
-
 resource "juju_user" "this" {
   name = %q
   password = %q
 }
 
 resource "juju_model" "this" {
-  provider = oldjuju
   name = %q
 }
 
 resource "juju_access_model" "test" {
-  provider = oldjuju
   access = %q
   model = juju_model.this.name
   users = [juju_user.this.name]

--- a/internal/provider/resource_user.go
+++ b/internal/provider/resource_user.go
@@ -5,143 +5,242 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+
 	"github.com/juju/terraform-provider-juju/internal/juju"
 )
 
-// The User resource maps to a juju user that is operated via
-// `juju add-user`, `juju remove-user`
-// Display name is optional.
-func resourceUser() *schema.Resource {
-	return &schema.Resource{
+// Ensure provider defined types fully satisfy framework interfaces.
+var _ resource.Resource = &userResource{}
+var _ resource.ResourceWithConfigure = &userResource{}
+var _ resource.ResourceWithImportState = &userResource{}
+
+func NewUserResource() resource.Resource {
+	return &userResource{}
+}
+
+// userResource defines the resource implementation.
+type userResource struct {
+	client *juju.Client
+}
+
+// userResourceModel describes the user resource data model.
+// tfsdk must match user resource schema attribute names.
+type userResourceModel struct {
+	Name        types.String `tfsdk:"name"`
+	DisplayName types.String `tfsdk:"display_name"`
+	Password    types.String `tfsdk:"password"`
+	// ID required by the testing framework
+	ID types.String `tfsdk:"id"`
+}
+
+func (r *userResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_user"
+}
+
+func (r *userResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	// The User resource maps to a juju user that is operated via
+	// `juju add-user`, `juju remove-user`
+	// Display name is optional.
+	resp.Schema = schema.Schema{
 		// This description is used by the documentation generator and the language server.
-		Description: "A resource that represent a Juju User.",
-
-		CreateContext: resourceUserCreate,
-		ReadContext:   resourceUserRead,
-		UpdateContext: resourceUserUpdate,
-		DeleteContext: resourceUserDelete,
-		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
-		},
-
-		Schema: map[string]*schema.Schema{
-			"name": {
+		Description: "A resource that represents a Juju User.",
+		Attributes: map[string]schema.Attribute{
+			"name": schema.StringAttribute{
 				Description: "The name to be assigned to the user",
-				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
-			"display_name": {
-				Description: "The display name to be assigned to the user",
-				Type:        schema.TypeString,
+			"display_name": schema.StringAttribute{
+				Description: "The display name to be assigned to the user (optional)",
 				Optional:    true,
 			},
-			"password": {
+			"password": schema.StringAttribute{
 				Description: "The password to be assigned to the user",
-				Type:        schema.TypeString,
 				Required:    true,
+				Sensitive:   true,
+			},
+			"id": schema.StringAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 		},
 	}
 }
 
-func resourceUserCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*juju.Client)
-
-	var diags diag.Diagnostics
-
-	name := d.Get("name").(string)
-	displayName := d.Get("display_name").(string)
-	password := d.Get("password").(string)
-
-	_, err := client.Users.CreateUser(juju.CreateUserInput{
-		Name:        name,
-		DisplayName: displayName,
-		Password:    password,
-	})
-	if err != nil {
-		return diag.FromErr(err)
+// Configure enables provider-level data or clients to be set in the
+// provider-defined DataSource type. It is separately executed for each
+// ReadDataSource RPC.
+func (r *userResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	// Prevent panic if the provider has not been configured.
+	if req.ProviderData == nil {
+		return
 	}
 
-	d.SetId(fmt.Sprintf("user:%s", name))
+	client, ok := req.ProviderData.(*juju.Client)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *juju.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
 
-	return diags
+	r.client = client
 }
 
-func resourceUserRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*juju.Client)
+// Create is called when the provider must create a new resource. Config
+// and planned state values should be read from the
+// CreateRequest and new state values set on the CreateResponse.
+func (r *userResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data userResourceModel
 
-	var diags diag.Diagnostics
-
-	id := strings.Split(d.Id(), ":")
-	name := id[1]
-	response, err := client.Users.ReadUser(name)
-	if err != nil {
-		return diag.FromErr(err)
+	// Read Terraform plan data into the model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
-	if err := d.Set("name", response.UserInfo.Username); err != nil {
-		return diag.FromErr(err)
-	}
-	if err := d.Set("display_name", response.UserInfo.DisplayName); err != nil {
-		return diag.FromErr(err)
-	}
-
-	return diags
-}
-
-func resourceUserUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*juju.Client)
-
-	var diags diag.Diagnostics
-	anyChange := false
-
-	var newPassword string
-
-	var err error
-
-	if d.HasChange("password") {
-		anyChange = true
-		newPassword = d.Get("password").(string)
-	}
-
-	if !anyChange {
-		return diags
-	}
-
-	id := strings.Split(d.Id(), ":")
-	name := id[1]
-	err = client.Users.UpdateUser(juju.UpdateUserInput{
-		Name:     name,
-		Password: newPassword,
+	_, err := r.client.Users.CreateUser(juju.CreateUserInput{
+		Name:        data.Name.ValueString(),
+		DisplayName: data.DisplayName.ValueString(),
+		Password:    data.Password.ValueString(),
 	})
 	if err != nil {
-		return diag.FromErr(err)
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create user, got error: %s", err))
+		return
 	}
+	tflog.Trace(ctx, fmt.Sprintf("created user resource %q", data.Name))
 
-	return diags
+	// Save data into Terraform state
+	data.ID = types.StringValue(newIDFromUserName(data.Name.ValueString()))
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
-// Juju refers to user deletion as "destroy" so we call the Destroy function of our client here rather than delete
-// This function remains named Delete for parity across the provider and to stick within terraform naming conventions
-func resourceUserDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*juju.Client)
+// Read is called when the provider must read resource values in order
+// to update state. Planned state values should be read from the
+// ReadRequest and new state values set on the ReadResponse.
+// Take the juju api input from the ID, it may not exist in the plan.
+// Only set optional values if they exist.
+func (r *userResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data userResourceModel
 
-	var diags diag.Diagnostics
-
-	id := strings.Split(d.Id(), ":")
-	name := id[1]
-
-	err := client.Users.DestroyUser(juju.DestroyUserInput{
-		Name: name,
-	})
-	if err != nil {
-		return diag.FromErr(err)
+	// Read Terraform prior state data into the model
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
-	d.SetId("")
+	// If applicable, this is a great opportunity to initialize any necessary
+	// provider client data and make a call using it.
+	response, err := r.client.Users.ReadUser(userNameFromID(data.ID.ValueString()))
+	if err != nil {
+		// TODO (hmlanigan) 2023-06-14
+		// Add a user NotFound error type to the client.
+		// On read, if NotFound, remove the resource:
+		// resp.State.RemoveResource()
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read user, got error: %s", err))
+		return
+	}
+	tflog.Trace(ctx, fmt.Sprintf("read user resource %q", data.Name.ValueString()))
 
-	return diags
+	// Save updated data into Terraform state
+	plan := userResourceModel{
+		Name:     types.StringValue(response.UserInfo.Username),
+		Password: data.Password,
+		ID:       types.StringValue(fmt.Sprintf("user:%s", response.UserInfo.Username)),
+	}
+	// Display name is optional, therefore if it doesn't exist in the plan
+	// if not set, do not add an empty string as they are not the same thing.
+	// Conversely, if the returned user info does not contain an empty string,
+	// make it of type ValueStateNull to indicate not set.
+	if !data.DisplayName.IsNull() && !data.DisplayName.IsUnknown() && response.UserInfo.DisplayName != "" {
+		plan.DisplayName = types.StringValue(response.UserInfo.DisplayName)
+	} else if response.UserInfo.DisplayName == "" {
+		plan.DisplayName = types.StringNull()
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+// Update is called to update the state of the resource. Config, planned
+// state, and prior state values should be read from the
+// UpdateRequest and new state values set on the UpdateResponse.
+func (r *userResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data userResourceModel
+
+	// Read Terraform plan data into the model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Update user can only change the password.
+	if err := r.client.Users.UpdateUser(juju.UpdateUserInput{
+		Name:     data.Name.ValueString(),
+		Password: data.Password.ValueString(),
+	}); err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update user, got error: %s", err))
+		return
+	}
+	tflog.Trace(ctx, fmt.Sprintf("updated user resource %q", data.Name))
+
+	// Save updated data into Terraform state, save a new copy for
+	// update functionality.
+	// The juju api as written here cannot update the Display Name,
+	// take care with the optional value.
+	plan := userResourceModel{
+		Name:        types.StringValue(data.Name.ValueString()),
+		DisplayName: data.DisplayName,
+		Password:    types.StringValue(data.Password.ValueString()),
+		ID:          types.StringValue(newIDFromUserName(data.Name.ValueString())),
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+// Delete is called when the provider must delete the resource. Config
+// values may be read from the DeleteRequest.
+//
+// If execution completes without error, the framework will automatically
+// call DeleteResponse.State.RemoveResource(), so it can be omitted
+// from provider logic.
+func (r *userResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data userResourceModel
+
+	// Read Terraform prior state data into the model
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	err := r.client.Users.DestroyUser(juju.DestroyUserInput{
+		Name: userNameFromID(data.ID.ValueString()),
+	})
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete user, got error: %s", err))
+		return
+	}
+	tflog.Trace(ctx, fmt.Sprintf("deleted user resource %q", data.Name.ValueString()))
+}
+
+func (r *userResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+// ID is 'user:<username'
+func newIDFromUserName(value string) string {
+	return fmt.Sprintf("user:%s", value)
+}
+
+func userNameFromID(value string) string {
+	return strings.Split(value, ":")[1]
 }

--- a/internal/provider/resource_user_test.go
+++ b/internal/provider/resource_user_test.go
@@ -15,19 +15,13 @@ func TestAcc_ResourceUser_sdk2_framework_migrate(t *testing.T) {
 	resourceName := "juju_user.user"
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: muxProviderFactories,
+		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceUser_Migrate(t, userName, userPassword),
+				Config: testAccResourceUser(userName, userPassword),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", resourceName),
 				),
-				ExternalProviders: map[string]resource.ExternalProvider{
-					"juju": {
-						VersionConstraint: "0.8.0",
-						Source:            "juju/juju",
-					},
-				},
 				PreConfig: func() { testAccPreCheck(t) },
 			},
 			{
@@ -37,23 +31,14 @@ func TestAcc_ResourceUser_sdk2_framework_migrate(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"password"},
 				ImportStateId:           fmt.Sprintf("user:%s", resourceName),
 				ResourceName:            resourceName,
-				ExternalProviders: map[string]resource.ExternalProvider{
-					"juju": {
-						VersionConstraint: "0.8.0",
-						Source:            "juju/juju",
-					},
-				},
 			},
 		},
 	})
 }
 
-func testAccResourceUser_Migrate(t *testing.T, userName, userPassword string) string {
+func testAccResourceUser(userName, userPassword string) string {
 	return fmt.Sprintf(`
-provider oldjuju {}
-
 resource "juju_user" "user" {
-  provider = oldjuju
   name = %q
   password = %q
 
@@ -75,7 +60,7 @@ func TestAcc_ResourceUser_Stable(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceUser_Stable(t, userName, userPassword),
+				Config: testAccResourceUser(userName, userPassword),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", userName),
 				),
@@ -89,13 +74,4 @@ func TestAcc_ResourceUser_Stable(t *testing.T) {
 			},
 		},
 	})
-}
-
-func testAccResourceUser_Stable(t *testing.T, userName, userPassword string) string {
-	return fmt.Sprintf(`
-resource "juju_user" "test-user" {
-  name = %q
-  password = %q
-
-}`, userName, userPassword)
 }

--- a/internal/provider/resource_user_test.go
+++ b/internal/provider/resource_user_test.go
@@ -20,7 +20,7 @@ func TestAcc_ResourceUser_sdk2_framework_migrate(t *testing.T) {
 			{
 				Config: testAccResourceUser(userName, userPassword),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", userName),
 				),
 				PreConfig: func() { testAccPreCheck(t) },
 			},
@@ -29,7 +29,7 @@ func TestAcc_ResourceUser_sdk2_framework_migrate(t *testing.T) {
 				ImportStateVerify:       true,
 				ImportState:             true,
 				ImportStateVerifyIgnore: []string{"password"},
-				ImportStateId:           fmt.Sprintf("user:%s", resourceName),
+				ImportStateId:           fmt.Sprintf("user:%s", userName),
 				ResourceName:            resourceName,
 			},
 		},

--- a/internal/provider/resource_user_test.go
+++ b/internal/provider/resource_user_test.go
@@ -20,15 +20,29 @@ func TestAcc_ResourceUser_sdk2_framework_migrate(t *testing.T) {
 			{
 				Config: testAccResourceUser_Migrate(t, userName, userPassword),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", userName),
+					resource.TestCheckResourceAttr(resourceName, "name", resourceName),
 				),
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"juju": {
+						VersionConstraint: "0.8.0",
+						Source:            "juju/juju",
+					},
+				},
+				PreConfig: func() { testAccPreCheck(t) },
 			},
 			{
+				Destroy:                 true,
 				ImportStateVerify:       true,
 				ImportState:             true,
 				ImportStateVerifyIgnore: []string{"password"},
-				ImportStateId:           fmt.Sprintf("user:%s", userName),
+				ImportStateId:           fmt.Sprintf("user:%s", resourceName),
 				ResourceName:            resourceName,
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"juju": {
+						VersionConstraint: "0.8.0",
+						Source:            "juju/juju",
+					},
+				},
 			},
 		},
 	})
@@ -79,7 +93,7 @@ func TestAcc_ResourceUser_Stable(t *testing.T) {
 
 func testAccResourceUser_Stable(t *testing.T, userName, userPassword string) string {
 	return fmt.Sprintf(`
-resource "juju_user" "user" {
+resource "juju_user" "test-user" {
   name = %q
   password = %q
 


### PR DESCRIPTION
## Description

Update the User resource to use the terraform framework rather than the SDK2. The schema stayed the same with one minor change, the password is now marked as Sensitive and will not be displayed on the cli.

Care must be taken with optional values. The terraform types differentiate between null, unknown and a value. Especially with Read, and empty string is not the same a StringNull().

Always use the ID to reference the user's name in Read, as it can be used with import as well, thus the only hint of which user available.

Created variables for provider factories in test. frameworkProviderFactories provides the newer provider for test to be used when tests only contain items which are now in the framework provider. muxProviderFactories provides both the sdk and framework providers in a mix, to be used were test plans contain items in both the sdk and framework providers.

## Type of change

Please mark if proceeds.

- [ ] New resource (a new resource in the schema)
- [ ] Changed resource (changes in an existing resource)
- [ ] Logic changes in resources (the API interaction with Juju has been changed)
- [ ] Test changes (one or several tests have been changed)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ x] Other (describe) maintenance

## Environment

- Juju controller version: 2.9.43
- Terraform version: 0.8.0 next

## QA steps

1. Use juju provider 0.7.0 to add a user.
2. Upgrade to juju provider under development.
3. Add a new user.
4. Change the password of an existing user.
5. Add a third user with juju and import to terraform.

