### PR TITLE
[JUJU-4176] Migrate Credential Resource from sdk2 to provider framework

### DIFF
--- a/docs/resources/credential.md
+++ b/docs/resources/credential.md
@@ -42,7 +42,7 @@ resource "juju_credential" "this" {
 
 - `attributes` (Map of String) Credential attributes accordingly to the cloud
 - `client_credential` (Boolean) Add credentials to the client
-- `cloud` (Block List, Max: 1) JuJu Cloud where the credentials will be used to access (see [below for nested schema](#nestedblock--cloud))
+- `cloud` (Block List) JuJu Cloud where the credentials will be used to access (see [below for nested schema](#nestedblock--cloud))
 - `controller_credential` (Boolean) Add credentials to the controller
 
 ### Read-Only

--- a/docs/resources/credential.md
+++ b/docs/resources/credential.md
@@ -40,7 +40,7 @@ resource "juju_credential" "this" {
 
 ### Optional
 
-- `attributes` (Map of String) Credential attributes accordingly to the cloud
+- `attributes` (Map of String, Sensitive) Credential attributes accordingly to the cloud
 - `client_credential` (Boolean) Add credentials to the client
 - `cloud` (Block List) JuJu Cloud where the credentials will be used to access (see [below for nested schema](#nestedblock--cloud))
 - `controller_credential` (Boolean) Add credentials to the controller

--- a/internal/juju/credentials.go
+++ b/internal/juju/credentials.go
@@ -19,7 +19,7 @@ type CreateCredentialInput struct {
 	Attributes           map[string]string
 	AuthType             string
 	ClientCredential     bool
-	CloudList            []interface{}
+	CloudName            string
 	ControllerCredential bool
 	Name                 string
 }
@@ -115,11 +115,7 @@ func (c *credentialsClient) CreateCredential(input CreateCredentialInput) (*Crea
 		return nil, errors.Errorf("%q is not a valid credential name", credentialName)
 	}
 
-	var cloudName string
-	for _, cloud := range input.CloudList {
-		cloudMap := cloud.(map[string]interface{})
-		cloudName = cloudMap["name"].(string)
-	}
+	cloudName := input.CloudName
 
 	if err := c.ValidateCredentialForCloud(cloudName, input.AuthType); err != nil {
 		return nil, err

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -403,3 +403,11 @@ func checkClientErr(err error, config juju.Configuration) frameworkdiag.Diagnost
 	diags.AddError("Client Error", err.Error())
 	return diags
 }
+
+func addClientNotConfiguredError(diag *frameworkdiag.Diagnostics, resource, method string) {
+	diag.AddError(
+		"Provider Error, Client Not Configured",
+		fmt.Sprintf("Unable to %s %s resource. Expected configured Juju Client. "+
+			"Please report this issue to the provider developers.", method, resource),
+	)
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -66,7 +66,6 @@ func New(version string) func() *schema.Provider {
 			},
 			ResourcesMap: map[string]*schema.Resource{
 				"juju_application": resourceApplication(),
-				"juju_credential":  resourceCredential(),
 				"juju_integration": resourceIntegration(),
 				"juju_model":       resourceModel(),
 				"juju_offer":       resourceOffer(),
@@ -363,6 +362,7 @@ func (p *jujuProvider) Resources(ctx context.Context) []func() resource.Resource
 		func() resource.Resource { return NewAccessModelResource() },
 		func() resource.Resource { return NewMachineResource() },
 		func() resource.Resource { return NewUserResource() },
+		func() resource.Resource { return NewCredentialResource() },
 	}
 }
 

--- a/internal/provider/resource_access_model.go
+++ b/internal/provider/resource_access_model.go
@@ -103,7 +103,7 @@ func (a *accessModelResource) Configure(_ context.Context, req resource.Configur
 func (a *accessModelResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	// Check first if the client is configured
 	if a.client == nil {
-		addClientNotConfiguredError(&resp.Diagnostics, "create")
+		addClientNotConfiguredError(&resp.Diagnostics, "access model", "create")
 		return
 	}
 	var plan accessModelResourceModel
@@ -152,7 +152,7 @@ func (a *accessModelResource) Create(ctx context.Context, req resource.CreateReq
 func (a *accessModelResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	// Check first if the client is configured
 	if a.client == nil {
-		addClientNotConfiguredError(&resp.Diagnostics, "read")
+		addClientNotConfiguredError(&resp.Diagnostics, "access model", "read")
 		return
 	}
 	var plan accessModelResourceModel
@@ -215,7 +215,7 @@ func (a *accessModelResource) Read(ctx context.Context, req resource.ReadRequest
 func (a *accessModelResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	// Check first if the client is configured
 	if a.client == nil {
-		addClientNotConfiguredError(&resp.Diagnostics, "update")
+		addClientNotConfiguredError(&resp.Diagnostics, "access model", "update")
 		return
 	}
 
@@ -299,7 +299,7 @@ func (a *accessModelResource) Update(ctx context.Context, req resource.UpdateReq
 func (a *accessModelResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	// Check first if the client is configured
 	if a.client == nil {
-		addClientNotConfiguredError(&resp.Diagnostics, "delete")
+		addClientNotConfiguredError(&resp.Diagnostics, "access model", "delete")
 		return
 	}
 
@@ -373,14 +373,6 @@ func (a *accessModelResource) ImportState(ctx context.Context, req resource.Impo
 		return
 	}
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
-}
-
-func addClientNotConfiguredError(diag *diag.Diagnostics, method string) {
-	diag.AddError(
-		"Provider Error, Client Not Configured",
-		fmt.Sprintf("Unable to %s access model resource. Expected configured Juju Client. "+
-			"Please report this issue to the provider developers.", method),
-	)
 }
 
 func newAccessModelIDFrom(modelNameStr string, accessStr string, users []string) string {

--- a/internal/provider/resource_credential.go
+++ b/internal/provider/resource_credential.go
@@ -55,8 +55,20 @@ func (c credentialResource) Delete(ctx context.Context, req resource.DeleteReque
 }
 
 func (c credentialResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
-	//TODO implement me
-	panic("implement me")
+	// Prevent panic if the provider has not been configured.
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*juju.Client)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *juju.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+	c.client = client
 }
 
 type credentialResourceModel struct {

--- a/internal/provider/resource_credential.go
+++ b/internal/provider/resource_credential.go
@@ -18,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	"github.com/juju/terraform-provider-juju/internal/juju"
@@ -120,7 +119,7 @@ func (c *credentialResource) Schema(_ context.Context, _ resource.SchemaRequest,
 func (c *credentialResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	// Check first if the client is configured
 	if c.client == nil {
-		addClientNotConfiguredError(&resp.Diagnostics, "create")
+		addClientNotConfiguredError(&resp.Diagnostics, "credential", "create")
 		return
 	}
 
@@ -183,7 +182,7 @@ func (c *credentialResource) Create(ctx context.Context, req resource.CreateRequ
 func (c *credentialResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	// Check first if the client is configured
 	if c.client == nil {
-		addClientNotConfiguredError(&resp.Diagnostics, "read")
+		addClientNotConfiguredError(&resp.Diagnostics, "credential", "read")
 		return
 	}
 
@@ -264,7 +263,7 @@ func (c *credentialResource) Read(ctx context.Context, req resource.ReadRequest,
 func (c *credentialResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	// Check first if the client is configured
 	if c.client == nil {
-		addClientNotConfiguredError(&resp.Diagnostics, "update")
+		addClientNotConfiguredError(&resp.Diagnostics, "credential", "update")
 		return
 	}
 
@@ -337,7 +336,7 @@ func (c *credentialResource) Update(ctx context.Context, req resource.UpdateRequ
 func (c *credentialResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	// Check first if the client is configured
 	if c.client == nil {
-		addClientNotConfiguredError(&resp.Diagnostics, "delete")
+		addClientNotConfiguredError(&resp.Diagnostics, "credential", "delete")
 		return
 	}
 
@@ -437,7 +436,7 @@ func retrieveCredentialDataFromID(idStr string, diag *diag.Diagnostics, method s
 	if len(resID) != 4 {
 		diag.AddError("Provider Error",
 			fmt.Sprintf("unable to %s credential resource, invalid ID, expected {credentialName, cloudName, "+
-				"isClient, isController} - given : %s",
+				"isClient, isController} - given : %q",
 				method, resID))
 		return "", "", false, false
 	}
@@ -445,7 +444,7 @@ func retrieveCredentialDataFromID(idStr string, diag *diag.Diagnostics, method s
 	clientCredential, controllerCredential, err := convertOptionsBool(clientCredentialStr, controllerCredentialStr)
 	if err != nil {
 		diag.AddError("Provider Error",
-			fmt.Sprintf("Unable to %s credential resource, got error: %s", err, method))
+			fmt.Sprintf("Unable to %s credential resource, got error: %s", method, err))
 		return "", "", false, false
 	}
 	return credentialName, cloudName, clientCredential, controllerCredential
@@ -476,12 +475,4 @@ func convertOptionsBool(clientCredentialStr, controllerCredentialStr string) (bo
 	}
 
 	return clientCredentialBool, controllerCredentialBool, nil
-}
-
-func addClientNotConfiguredError(diag *diag.Diagnostics, method string) {
-	diag.AddError(
-		"Provider Error, Client Not Configured",
-		fmt.Sprintf("Unable to %s credential resource. Expected configured Juju Client. "+
-			"Please report this issue to the provider developers.", method),
-	)
 }

--- a/internal/provider/resource_credential.go
+++ b/internal/provider/resource_credential.go
@@ -3,6 +3,8 @@ package provider
 import (
 	"context"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"strconv"
 	"strings"
 
@@ -10,6 +12,65 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/juju/terraform-provider-juju/internal/juju"
 )
+
+// Ensure provider defined types fully satisfy framework interfaces.
+var _ resource.Resource = &credentialResource{}
+var _ resource.ResourceWithConfigure = &credentialResource{}
+
+func NewCredentialResource() resource.Resource {
+	return &credentialResource{}
+}
+
+type credentialResource struct {
+	client *juju.Client
+}
+
+func (c credentialResource) Metadata(ctx context.Context, request resource.MetadataRequest, response *resource.MetadataResponse) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (c credentialResource) Schema(ctx context.Context, request resource.SchemaRequest, response *resource.SchemaResponse) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (c credentialResource) Create(ctx context.Context, request resource.CreateRequest, response *resource.CreateResponse) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (c credentialResource) Read(ctx context.Context, request resource.ReadRequest, response *resource.ReadResponse) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (c credentialResource) Update(ctx context.Context, request resource.UpdateRequest, response *resource.UpdateResponse) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (c credentialResource) Delete(ctx context.Context, request resource.DeleteRequest, response *resource.DeleteResponse) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (c credentialResource) Configure(ctx context.Context, request resource.ConfigureRequest, response *resource.ConfigureResponse) {
+	//TODO implement me
+	panic("implement me")
+}
+
+type credentialResourceModel struct {
+	Cloud                types.List   `tfsdk:"cloud"`
+	Attributes           types.Map    `tfsdk:"attributes"`
+	AuthType             types.String `tfsdk:"auth_type"`
+	ClientCredential     types.Bool   `tfsdk:"client_credential"`
+	ControllerCredential types.Bool   `tfsdk:"controller_credential"`
+	Name                 types.String `tfsdk:"name"`
+
+	// ID required by the testing framework
+	ID types.String `tfsdk:"id"`
+}
 
 func resourceCredential() *schema.Resource {
 	return &schema.Resource{

--- a/internal/provider/resource_credential.go
+++ b/internal/provider/resource_credential.go
@@ -79,6 +79,7 @@ func (c *credentialResource) Schema(_ context.Context, _ resource.SchemaRequest,
 				Description: "Credential attributes accordingly to the cloud",
 				ElementType: types.StringType,
 				Optional:    true,
+				Sensitive:   true,
 			},
 			"auth_type": schema.StringAttribute{
 				Description: "Credential authorization type",

--- a/internal/provider/resource_credential.go
+++ b/internal/provider/resource_credential.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
@@ -135,8 +136,7 @@ func (c credentialResource) Configure(ctx context.Context, req resource.Configur
 }
 
 func (c credentialResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	//TODO implement me
-	panic("implement me")
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 
 /*

--- a/internal/provider/resource_credential.go
+++ b/internal/provider/resource_credential.go
@@ -25,37 +25,36 @@ type credentialResource struct {
 	client *juju.Client
 }
 
-func (c credentialResource) Metadata(ctx context.Context, request resource.MetadataRequest, response *resource.MetadataResponse) {
+func (c credentialResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_credential"
+}
+
+func (c credentialResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	//TODO implement me
 	panic("implement me")
 }
 
-func (c credentialResource) Schema(ctx context.Context, request resource.SchemaRequest, response *resource.SchemaResponse) {
+func (c credentialResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	//TODO implement me
 	panic("implement me")
 }
 
-func (c credentialResource) Create(ctx context.Context, request resource.CreateRequest, response *resource.CreateResponse) {
+func (c credentialResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	//TODO implement me
 	panic("implement me")
 }
 
-func (c credentialResource) Read(ctx context.Context, request resource.ReadRequest, response *resource.ReadResponse) {
+func (c credentialResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	//TODO implement me
 	panic("implement me")
 }
 
-func (c credentialResource) Update(ctx context.Context, request resource.UpdateRequest, response *resource.UpdateResponse) {
+func (c credentialResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	//TODO implement me
 	panic("implement me")
 }
 
-func (c credentialResource) Delete(ctx context.Context, request resource.DeleteRequest, response *resource.DeleteResponse) {
-	//TODO implement me
-	panic("implement me")
-}
-
-func (c credentialResource) Configure(ctx context.Context, request resource.ConfigureRequest, response *resource.ConfigureResponse) {
+func (c credentialResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	//TODO implement me
 	panic("implement me")
 }

--- a/internal/provider/resource_credential_test.go
+++ b/internal/provider/resource_credential_test.go
@@ -19,7 +19,7 @@ func TestAcc_ResourceCredential_sdk2_framework_migrate(t *testing.T) {
 	authTypeInvalid := "invalid"
 	token := "123abc"
 
-	resourceName := "juju_credential.credential"
+	resourceName := "juju_credential.test-credential"
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: muxProviderFactories,
@@ -30,10 +30,23 @@ func TestAcc_ResourceCredential_sdk2_framework_migrate(t *testing.T) {
 				// https://github.com/hashicorp/terraform-plugin-sdk/issues/118
 				Config:      testAccResourceCredential_sdk2_framework_migrate(t, credentialName, authTypeInvalid),
 				ExpectError: regexp.MustCompile(fmt.Sprintf("Error: supported auth-types (.*), \"%s\" not supported", authTypeInvalid)),
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"juju": {
+						VersionConstraint: "0.8.0",
+						Source:            "juju/juju",
+					},
+				},
+				PreConfig: func() { testAccPreCheck(t) },
 			},
 			{
 				Config:      testAccResourceCredential_sdk2_framework_migrate(t, credentialInvalidName, authType),
 				ExpectError: regexp.MustCompile(fmt.Sprintf("Error: \"%s\" is not a valid credential name", credentialInvalidName)),
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"juju": {
+						VersionConstraint: "0.8.0",
+						Source:            "juju/juju",
+					},
+				},
 			},
 			{
 				Config: testAccResourceCredential_sdk2_framework_migrate(t, credentialName, authType),
@@ -51,6 +64,7 @@ func TestAcc_ResourceCredential_sdk2_framework_migrate(t *testing.T) {
 				),
 			},
 			{
+				Destroy:           true,
 				ImportStateVerify: true,
 				ImportState:       true,
 				ImportStateVerifyIgnore: []string{
@@ -160,7 +174,7 @@ func TestAcc_ResourceCredential_Stable(t *testing.T) {
 
 func testAccResourceCredential_Stable(t *testing.T, credentialName string, authType string) string {
 	return fmt.Sprintf(`
-resource "juju_credential" "credential" {
+resource "juju_credential" "test-credential" {
   name = %q
 
   cloud {
@@ -173,7 +187,7 @@ resource "juju_credential" "credential" {
 
 func testAccResourceCredentialToken_Stable(t *testing.T, credentialName, authType, token string) string {
 	return fmt.Sprintf(`
-resource "juju_credential" "credential" {
+resource "juju_credential" "test-credential" {
   name = %q
 
   cloud {

--- a/internal/provider/resource_credential_test.go
+++ b/internal/provider/resource_credential_test.go
@@ -68,10 +68,7 @@ func TestAcc_ResourceCredential_sdk2_framework_migrate(t *testing.T) {
 
 func testAccResourceCredential_sdk2_framework_migrate(t *testing.T, credentialName string, authType string) string {
 	return fmt.Sprintf(`
-provider juju {}
-
 resource "juju_credential" "test-credential" {
-  provider = juju
   name = %q
 
   cloud {
@@ -84,10 +81,7 @@ resource "juju_credential" "test-credential" {
 
 func testAccResourceCredentialToken_sdk2_framework_migrate(t *testing.T, credentialName, authType, token string) string {
 	return fmt.Sprintf(`
-provider juju {}
-
 resource "juju_credential" "test-credential" {
-  provider = juju
   name = %q
 
   cloud {

--- a/internal/provider/resource_credential_test.go
+++ b/internal/provider/resource_credential_test.go
@@ -29,24 +29,13 @@ func TestAcc_ResourceCredential_sdk2_framework_migrate(t *testing.T) {
 				// "When tests have an ExpectError[...]; this results in any previous state being cleared. "
 				// https://github.com/hashicorp/terraform-plugin-sdk/issues/118
 				Config:      testAccResourceCredential_sdk2_framework_migrate(t, credentialName, authTypeInvalid),
-				ExpectError: regexp.MustCompile(fmt.Sprintf("Error: supported auth-types (.*), \"%s\" not supported", authTypeInvalid)),
-				ExternalProviders: map[string]resource.ExternalProvider{
-					"juju": {
-						VersionConstraint: "0.8.0",
-						Source:            "juju/juju",
-					},
-				},
-				PreConfig: func() { testAccPreCheck(t) },
+				ExpectError: regexp.MustCompile(fmt.Sprintf("%q not supported", authTypeInvalid)),
+				PreConfig:   func() { testAccPreCheck(t) },
 			},
 			{
-				Config:      testAccResourceCredential_sdk2_framework_migrate(t, credentialInvalidName, authType),
-				ExpectError: regexp.MustCompile(fmt.Sprintf("Error: \"%s\" is not a valid credential name", credentialInvalidName)),
-				ExternalProviders: map[string]resource.ExternalProvider{
-					"juju": {
-						VersionConstraint: "0.8.0",
-						Source:            "juju/juju",
-					},
-				},
+				Config: testAccResourceCredential_sdk2_framework_migrate(t, credentialInvalidName, authType),
+				ExpectError: regexp.MustCompile(fmt.Sprintf(".*%q is not\na valid credential name.*",
+					credentialInvalidName)),
 			},
 			{
 				Config: testAccResourceCredential_sdk2_framework_migrate(t, credentialName, authType),
@@ -79,10 +68,10 @@ func TestAcc_ResourceCredential_sdk2_framework_migrate(t *testing.T) {
 
 func testAccResourceCredential_sdk2_framework_migrate(t *testing.T, credentialName string, authType string) string {
 	return fmt.Sprintf(`
-provider oldjuju {}
+provider juju {}
 
-resource "juju_credential" "credential" {
-  provider = oldjuju
+resource "juju_credential" "test-credential" {
+  provider = juju
   name = %q
 
   cloud {
@@ -95,10 +84,10 @@ resource "juju_credential" "credential" {
 
 func testAccResourceCredentialToken_sdk2_framework_migrate(t *testing.T, credentialName, authType, token string) string {
 	return fmt.Sprintf(`
-provider oldjuju {}
+provider juju {}
 
-resource "juju_credential" "credential" {
-  provider = oldjuju
+resource "juju_credential" "test-credential" {
+  provider = juju
   name = %q
 
   cloud {
@@ -123,7 +112,7 @@ func TestAcc_ResourceCredential_Stable(t *testing.T) {
 	authTypeInvalid := "invalid"
 	token := "123abc"
 
-	resourceName := "juju_credential.credential"
+	resourceName := "juju_credential.test-credential"
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() { testAccPreCheck(t) },
 		ExternalProviders: map[string]resource.ExternalProvider{

--- a/main.go
+++ b/main.go
@@ -42,7 +42,7 @@ func main() {
 	flag.Parse()
 
 	upgradedSdkProvider, err := tf5to6server.UpgradeServer(
-		context.Background(),
+		ctx,
 		provider.New(version)().GRPCProvider,
 	)
 	if err != nil {


### PR DESCRIPTION
## Description

Migrates the `resource_credential` from using sdkv2 to the newer provider framework.

Needs to be rebased after going protocol v6, see discussion below.

## Type of change

Please mark if proceeds.

- [ ] New resource (a new resource in the schema)
- [ ] Changed resource (changes in an existing resource)
- [ ] Logic changes in resources (the API interaction with Juju has been changed)
- [ ] Test changes (one or several tests have been changed)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Other (maintenance)

## Environment

- Juju controller version: 2.9.43
- Terraform version: 1.5.2

## QA steps

Use the following plan:

```tf
terraform {
  required_providers {
    juju = {
      version = "0.8.0"
      source  = "juju/juju"
    }
  }
}

resource "juju_credential" "this" {
  name = "creddev"

  cloud {
    name = "localhost"
  }

  auth_type = "certificate"

  attributes = {
    client-cert    = "/srv/cert.crt"
    client-key     = "/srv/cert.key"
    trust-password = "S0m3P@$$w0rd"
  }
}
```

Use the main provider (0.8.0) to run:

```sh
$ terraform init && terraform plan && terraform apply -auto-approve
```

Then make the provider with these changes, and using that binary, run:

```sh
$ terraform init && terraform plan
```

should say:

```sh
juju_credential.this: Refreshing state... [id=creddev:localhost:false:true]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are
needed.
```

Then add a credential `juju add-credential localhost`

Add this to the plan:

```tf
resource "juju_credential" "caner" {
  name = "testupgrade"

  cloud {
    name = "localhost"
  }

}
```

And the import should work well with that:

```sh
$ terraform import juju_credential.caner testupgrade:localhost:false:true
juju_credential.caner: Importing from ID "testupgrade:localhost:false:true"...
juju_credential.caner: Import prepared!
  Prepared juju_credential for import
juju_credential.caner: Refreshing state... [id=testupgrade:localhost:false:true]

Import successful!

The resources that were imported are shown above. These resources are now in
your Terraform state and will henceforth be managed by Terraform.

```