### PR TITLE
[JUJU-4178] Migrate the machine resource from the sdk to framework style.

### DIFF
--- a/internal/provider/data_source_machine_test.go
+++ b/internal/provider/data_source_machine_test.go
@@ -38,7 +38,6 @@ resource "juju_model" "model" {
 }
 
 resource "juju_machine" "machine" {
-  provider = oldjuju
   model = juju_model.model.name
   name = "machine"
   series = "jammy"

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -70,7 +70,6 @@ func New(version string) func() *schema.Provider {
 				"juju_integration": resourceIntegration(),
 				"juju_model":       resourceModel(),
 				"juju_offer":       resourceOffer(),
-				"juju_machine":     resourceMachine(),
 				"juju_ssh_key":     resourceSSHKey(),
 			},
 		}
@@ -361,8 +360,9 @@ func getJujuProviderModel(ctx context.Context, req frameworkprovider.ConfigureRe
 // the Metadata method. All resources must have unique names.
 func (p *jujuProvider) Resources(ctx context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
-		func() resource.Resource { return NewUserResource() },
 		func() resource.Resource { return NewAccessModelResource() },
+		func() resource.Resource { return NewMachineResource() },
+		func() resource.Resource { return NewUserResource() },
 	}
 }
 

--- a/internal/provider/resource_machine.go
+++ b/internal/provider/resource_machine.go
@@ -5,232 +5,443 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	"github.com/juju/terraform-provider-juju/internal/juju"
 )
 
-func resourceMachine() *schema.Resource {
-	return &schema.Resource{
+// Ensure provider defined types fully satisfy framework interfaces.
+var _ resource.Resource = &machineResource{}
+var _ resource.ResourceWithConfigure = &machineResource{}
+var _ resource.ResourceWithImportState = &machineResource{}
+
+func NewMachineResource() resource.Resource {
+	return &machineResource{}
+}
+
+type machineResource struct {
+	client *juju.Client
+}
+
+type machineResourceModel struct {
+	Name           types.String `tfsdk:"name"`
+	ModelName      types.String `tfsdk:"model"`
+	Constraints    types.String `tfsdk:"constraints"`
+	Disks          types.String `tfsdk:"disks"`
+	Series         types.String `tfsdk:"series"`
+	MachineID      types.String `tfsdk:"machine_id"`
+	SSHAddress     types.String `tfsdk:"ssh_address"`
+	PublicKeyFile  types.String `tfsdk:"public_key_file"`
+	PrivateKeyFile types.String `tfsdk:"private_key_file"`
+	// ID required by the testing framework
+	ID types.String `tfsdk:"id"`
+}
+
+func (r *machineResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_machine"
+}
+
+// Configure enables provider-level data or clients to be set in the
+// provider-defined DataSource type. It is separately executed for each
+// ReadDataSource RPC.
+func (r *machineResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	// Prevent panic if the provider has not been configured.
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*juju.Client)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *juju.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	r.client = client
+}
+
+const (
+	NameKey           = "name"
+	ModelKey          = "model"
+	ConstraintsKey    = "constraints"
+	DisksKey          = "disks"
+	SeriesKey         = "series"
+	MachineIDKey      = "machine_id"
+	SSHAddressKey     = "ssh_address"
+	PrivateKeyFileKey = "private_key_file"
+	PublicKeyFileKey  = "public_key_file"
+)
+
+func (r *machineResource) Schema(_ context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
 		Description: "A resource that represents a Juju machine deployment. Refer to the juju add-machine CLI command for more information and limitations.",
-
-		CreateContext: resourceMachineCreate,
-		ReadContext:   resourceMachineRead,
-		DeleteContext: resourceMachineDelete,
-
-		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
-		},
-
-		Schema: map[string]*schema.Schema{
-			"name": {
+		Attributes: map[string]schema.Attribute{
+			NameKey: schema.StringAttribute{
 				Description: "A name for the machine resource in Terraform.",
-				Type:        schema.TypeString,
 				Optional:    true,
 				Computed:    true,
-				ForceNew:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
-			"model": {
+			ModelKey: schema.StringAttribute{
 				Description: "The Juju model in which to add a new machine.",
-				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
-			"constraints": {
-				Description:   "Machine constraints that overwrite those available from 'juju get-model-constraints' and provider's defaults.",
-				Type:          schema.TypeString,
-				Optional:      true,
-				Default:       "",
-				ForceNew:      true,
-				ConflictsWith: []string{"ssh_address"},
+			ConstraintsKey: schema.StringAttribute{
+				Description: "Machine constraints that overwrite those available from 'juju get-model-constraints' and provider's defaults.",
+				Optional:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplaceIfConfigured(),
+				},
+				Validators: []validator.String{
+					stringvalidator.ConflictsWith(path.Expressions{
+						path.MatchRoot(SSHAddressKey),
+					}...),
+				},
 			},
-			"disks": {
-				Description:   "Storage constraints for disks to attach to the machine(s).",
-				Type:          schema.TypeString,
-				Optional:      true,
-				Default:       "",
-				ForceNew:      true,
-				ConflictsWith: []string{"ssh_address"},
+			DisksKey: schema.StringAttribute{
+				Description: "Storage constraints for disks to attach to the machine(s).",
+				Optional:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplaceIfConfigured(),
+				},
+				Validators: []validator.String{
+					stringvalidator.ConflictsWith(path.Expressions{
+						path.MatchRoot(SSHAddressKey),
+					}...),
+				},
 			},
-			"series": {
-				Description:   "The operating system series to install on the new machine(s).",
-				Type:          schema.TypeString,
-				Optional:      true,
-				Computed:      true,
-				ForceNew:      true,
-				ConflictsWith: []string{"ssh_address"},
+			SeriesKey: schema.StringAttribute{
+				Description: "The operating system series to install on the new machine(s).",
+				Optional:    true,
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplaceIfConfigured(),
+					stringplanmodifier.UseStateForUnknown(),
+				},
+				Validators: []validator.String{
+					stringvalidator.ConflictsWith(path.Expressions{
+						path.MatchRoot(SSHAddressKey),
+					}...),
+				},
 			},
-			"machine_id": {
+			MachineIDKey: schema.StringAttribute{
 				Description: "The id of the machine Juju creates.",
-				Type:        schema.TypeString,
 				Computed:    true,
 				Optional:    false,
 				Required:    false,
 			},
-			"ssh_address": {
+			SSHAddressKey: schema.StringAttribute{
 				Description: "The user@host directive for manual provisioning an existing machine via ssh. " +
 					"Requires public_key_file & private_key_file arguments.",
-				Type:          schema.TypeString,
-				Optional:      true,
-				Default:       "",
-				ForceNew:      true,
-				RequiredWith:  []string{"public_key_file", "private_key_file"},
-				ConflictsWith: []string{"series", "constraints"},
+				Optional: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplaceIfConfigured(),
+				},
+				Validators: []validator.String{
+					stringvalidator.ConflictsWith(path.Expressions{
+						path.MatchRoot(SeriesKey),
+						path.MatchRoot(ConstraintsKey),
+					}...),
+					stringvalidator.AlsoRequires(path.Expressions{
+						path.MatchRoot(PublicKeyFileKey),
+						path.MatchRoot(PrivateKeyFileKey),
+					}...),
+				},
 			},
-			"public_key_file": {
+			PublicKeyFileKey: schema.StringAttribute{
 				Description: "The file path to read the public key from.",
-				Type:        schema.TypeString,
 				Optional:    true,
-				Default:     "",
-				ForceNew:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplaceIfConfigured(),
+				},
+				Validators: []validator.String{
+					stringvalidator.AlsoRequires(path.Expressions{
+						path.MatchRoot(SSHAddressKey),
+						path.MatchRoot(PrivateKeyFileKey),
+					}...),
+				},
 			},
-			"private_key_file": {
+			PrivateKeyFileKey: schema.StringAttribute{
 				Description: "The file path to read the private key from.",
-				Type:        schema.TypeString,
 				Optional:    true,
-				Default:     "",
-				ForceNew:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplaceIfConfigured(),
+				},
+				Validators: []validator.String{
+					stringvalidator.AlsoRequires(path.Expressions{
+						path.MatchRoot(PublicKeyFileKey),
+						path.MatchRoot(SSHAddressKey),
+					}...),
+				},
+			},
+			"id": schema.StringAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 		},
 	}
 }
 
-func resourceMachineCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*juju.Client)
-
-	modelName := d.Get("model").(string)
-	modelUUID, err := client.Models.ResolveModelUUID(modelName)
-	if err != nil {
-		return diag.FromErr(err)
+// Create is called when the provider must create a new resource. Config
+// and planned state values should be read from the
+// CreateRequest and new state values set on the CreateResponse.
+func (r *machineResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	// Prevent panic if the provider has not been configured.
+	if r.client == nil {
+		resp.Diagnostics.AddError(
+			"Unconfigured HTTP Client",
+			"Expected configured HTTP client. Please report this issue to the provider developers.",
+		)
+		return
 	}
-	name := d.Get("name").(string)
-	constraints := d.Get("constraints").(string)
-	disks := d.Get("disks").(string)
-	series := d.Get("series").(string)
-	sshAddress := d.Get("ssh_address").(string)
-	publicKeyFile := d.Get("public_key_file").(string)
-	privateKeyFile := d.Get("private_key_file").(string)
+
+	var data machineResourceModel
+	// Read Terraform prior state data into the model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	modelInfo, err := r.client.Models.GetModelByName(data.ModelName.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to resolve model UUID, got error: %s", err))
+		return
+	}
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	series := data.Series.ValueString()
+	sshAddress := data.SSHAddress.ValueString()
 
 	if sshAddress == "" {
 		// If not provisioning manually, check the series argument.
 		// If not set, get it from the model default.
 		// TODO (cderici): revisit this part when switched to juju 3.x.
 		if series == "" {
-			modelInfo, err := client.Models.GetModelByName(modelName)
-			if err != nil {
-				return diag.FromErr(err)
-			}
 			series = modelInfo.DefaultSeries
 		}
 	}
 
-	response, err := client.Machines.CreateMachine(&juju.CreateMachineInput{
-		Constraints:    constraints,
-		ModelUUID:      modelUUID,
-		Disks:          disks,
+	response, err := r.client.Machines.CreateMachine(&juju.CreateMachineInput{
+		Constraints:    data.Constraints.ValueString(),
+		ModelUUID:      modelInfo.UUID,
+		Disks:          data.Disks.ValueString(),
 		Series:         series,
 		SSHAddress:     sshAddress,
-		PublicKeyFile:  publicKeyFile,
-		PrivateKeyFile: privateKeyFile,
+		PublicKeyFile:  data.PublicKeyFile.ValueString(),
+		PrivateKeyFile: data.PrivateKeyFile.ValueString(),
 	})
-
 	if err != nil {
-		return diag.FromErr(err)
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create machine, got error: %s", err))
+		return
 	}
 	if response.Machine.Error != nil {
-		return diag.FromErr(err)
+		resp.Diagnostics.AddError("Juju Error", fmt.Sprintf("Failed to create machine, got error: %s", err))
+		return
 	}
-	id := fmt.Sprintf("%s:%s:%s", modelName, response.Machine.Machine, name)
-	if err = d.Set("machine_id", response.Machine.Machine); err != nil {
-		return diag.FromErr(err)
+	tflog.Trace(ctx, fmt.Sprintf("create machine resource %q", response.Machine.Machine))
+
+	machineName := data.Name.ValueString()
+	if machineName == "" {
+		machineName = fmt.Sprintf("machine-%s", response.Machine.Machine)
 	}
-	if err = d.Set("series", response.Series); err != nil {
-		return diag.FromErr(err)
-	}
-	d.SetId(id)
-	return nil
+
+	id := newMachineID(data.ModelName.ValueString(), response.Machine.Machine, machineName)
+	data.ID = types.StringValue(id)
+	data.MachineID = types.StringValue(response.Machine.Machine)
+	data.Series = types.StringValue(response.Series)
+	data.Name = types.StringValue(machineName)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
 func IsMachineNotFound(err error) bool {
 	return strings.Contains(err.Error(), "no status returned for machine")
 }
 
-func handleMachineNotFoundError(err error, d *schema.ResourceData) diag.Diagnostics {
+func handleMachineNotFoundError(ctx context.Context, err error, st *tfsdk.State) diag.Diagnostics {
 	if IsMachineNotFound(err) {
 		// Machine manually removed
-		d.SetId("")
+		st.RemoveResource(ctx)
 		return diag.Diagnostics{}
 	}
-
-	return diag.FromErr(err)
+	var diags diag.Diagnostics
+	diags.AddError("Not Found", err.Error())
+	return diags
 }
 
-func resourceMachineRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	var diags diag.Diagnostics
-
-	client := meta.(*juju.Client)
-	id := strings.Split(d.Id(), ":")
-
-	if len(id) != 3 {
-		return diag.Errorf("unable to parse model, machine ID, and name from provided ID")
+// Read is called when the provider must read resource values in order
+// to update state. Planned state values should be read from the
+// ReadRequest and new state values set on the ReadResponse.
+// Take the juju api input from the ID, it may not exist in the plan.
+// Only set optional values if they exist.
+func (r *machineResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	// Prevent panic if the provider has not been configured.
+	if r.client == nil {
+		resp.Diagnostics.AddError(
+			"Unconfigured HTTP Client",
+			"Expected configured HTTP client. Please report this issue to the provider developers.",
+		)
+		return
 	}
 
-	modelName, machineId, machineName := id[0], id[1], id[2]
-	modelUUID, err := client.Models.ResolveModelUUID(modelName)
+	var data machineResourceModel
+	// Read Terraform prior state data into the model
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	modelName, machineID, machineName := modeMachineIDAndName(data.ID.ValueString(), &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	modelUUID, err := r.client.Models.ResolveModelUUID(modelName)
 	if err != nil {
-		return diag.FromErr(err)
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to resolve model UUID, got error: %s", err))
+		return
 	}
 
-	response, err := client.Machines.ReadMachine(&juju.ReadMachineInput{
+	response, err := r.client.Machines.ReadMachine(&juju.ReadMachineInput{
 		ModelUUID: modelUUID,
-		MachineId: machineId,
+		MachineId: machineID,
 	})
 	if err != nil {
-		return handleMachineNotFoundError(err, d)
+		resp.Diagnostics.Append(handleMachineNotFoundError(ctx, err, &resp.State)...)
+		return
 	}
-
 	if response == nil {
-		return nil
+		return
 	}
+	tflog.Trace(ctx, fmt.Sprintf("read machine resource %q", machineID))
 
-	if err = d.Set("model", modelName); err != nil {
-		return diag.FromErr(err)
+	data.Name = types.StringValue(machineName)
+	data.ModelName = types.StringValue(modelName)
+	data.MachineID = types.StringValue(machineID)
+	data.Series = types.StringValue(response.MachineStatus.Series)
+	if response.MachineStatus.Constraints != "" {
+		data.Constraints = types.StringValue(response.MachineStatus.Constraints)
 	}
-	if err = d.Set("name", machineName); err != nil {
-		return diag.FromErr(err)
-	}
-	if err = d.Set("series", response.MachineStatus.Series); err != nil {
-		return diag.FromErr(err)
-	}
-	if err = d.Set("machine_id", machineId); err != nil {
-		return diag.FromErr(err)
-	}
-
-	return diags
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
-func resourceMachineDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	var diags diag.Diagnostics
-
-	client := meta.(*juju.Client)
-
-	id := strings.Split(d.Id(), ":")
-
-	modelName, machineId, _ := id[0], id[1], id[2]
-	modelUUID, err := client.Models.ResolveModelUUID(modelName)
-	if err != nil {
-		return diag.FromErr(err)
+// Update is called to update the state of the resource. Config, planned
+// state, and prior state values should be read from the
+// UpdateRequest and new state values set on the UpdateResponse.
+func (r *machineResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan, state machineResourceModel
+	// Read Terraform prior state data into the model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
-	err = client.Machines.DestroyMachine(&juju.DestroyMachineInput{
+	// TODO hml 28-Jul-2023
+	// Delete the machine resource if it no longer exists in juju.
+
+	// Only the name can be updated it is terraform data and
+	// not saved in juju.
+	if plan.Name.Equal(state.Name) {
+		return
+	}
+	state.Name = plan.Name
+	id := newMachineID(plan.ModelName.ValueString(), plan.MachineID.ValueString(), plan.Name.ValueString())
+	state.ID = types.StringValue(id)
+
+	tflog.Trace(ctx, fmt.Sprintf("update machine resource %q", plan.MachineID.ValueString()))
+
+	// Save updated data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+// Delete is called when the provider must delete the resource. Config
+// values may be read from the DeleteRequest.
+//
+// If execution completes without error, the framework will automatically
+// call DeleteResponse.State.RemoveResource(), so it can be omitted
+// from provider logic.
+//
+// Juju refers to deletion as "destroy" so we call the Destroy function of our client here rather than delete
+// This function remains named Delete for parity across the provider and to stick within terraform naming conventions
+func (r *machineResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	// Prevent panic if the provider has not been configured.
+	if r.client == nil {
+		resp.Diagnostics.AddError(
+			"Unconfigured HTTP Client",
+			"Expected configured HTTP client. Please report this issue to the provider developers.",
+		)
+		return
+	}
+
+	var data machineResourceModel
+	// Read Terraform prior state data into the model
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	modelName, machineID, _ := modeMachineIDAndName(data.ID.ValueString(), &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	modelUUID, err := r.client.Models.ResolveModelUUID(modelName)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to resolve model UUID, got error: %s", err))
+		return
+	}
+
+	err = r.client.Machines.DestroyMachine(&juju.DestroyMachineInput{
 		ModelUUID: modelUUID,
-		MachineId: machineId,
+		MachineId: machineID,
 	})
 	if err != nil {
-		return diag.FromErr(err)
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete machine, got error: %s", err))
 	}
+	tflog.Trace(ctx, fmt.Sprintf("delete machine resource %q", machineID))
+}
 
-	d.SetId("")
-	return diags
+// ImportState is called when the provider must import the state of a
+// resource instance. This method must return enough state so the Read
+// method can properly refresh the full resource.
+//
+// If setting an attribute with the import identifier, it is recommended
+// to use the ImportStatePassthroughID() call in this method.
+func (r *machineResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+func newMachineID(model, machine_id, machine_name string) string {
+	return fmt.Sprintf("%s:%s:%s", model, machine_id, machine_name)
+}
+
+// Machines can be imported using the format: `model_name:machine_id:machine_name`.
+func modeMachineIDAndName(value string, diags *diag.Diagnostics) (string, string, string) {
+	id := strings.Split(value, ":")
+	//If importing with an incorrect ID we need to catch and provide a user-friendly error
+	if len(id) != 3 {
+		diags.AddError("Malformed ID", fmt.Sprintf("unable to parse model name, machine id, and machine name from provided ID: %q", value))
+		return "", "", ""
+	}
+	return id[0], id[1], id[2]
 }

--- a/internal/provider/resource_machine.go
+++ b/internal/provider/resource_machine.go
@@ -226,9 +226,6 @@ func (r *machineResource) Create(ctx context.Context, req resource.CreateRequest
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to resolve model UUID, got error: %s", err))
 		return
 	}
-	if resp.Diagnostics.HasError() {
-		return
-	}
 
 	series := data.Series.ValueString()
 	sshAddress := data.SSHAddress.ValueString()
@@ -311,7 +308,7 @@ func (r *machineResource) Read(ctx context.Context, req resource.ReadRequest, re
 		return
 	}
 
-	modelName, machineID, machineName := modeMachineIDAndName(data.ID.ValueString(), &resp.Diagnostics)
+	modelName, machineID, machineName := modelMachineIDAndName(data.ID.ValueString(), &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -400,7 +397,7 @@ func (r *machineResource) Delete(ctx context.Context, req resource.DeleteRequest
 		return
 	}
 
-	modelName, machineID, _ := modeMachineIDAndName(data.ID.ValueString(), &resp.Diagnostics)
+	modelName, machineID, _ := modelMachineIDAndName(data.ID.ValueString(), &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -436,7 +433,7 @@ func newMachineID(model, machine_id, machine_name string) string {
 }
 
 // Machines can be imported using the format: `model_name:machine_id:machine_name`.
-func modeMachineIDAndName(value string, diags *diag.Diagnostics) (string, string, string) {
+func modelMachineIDAndName(value string, diags *diag.Diagnostics) (string, string, string) {
 	id := strings.Split(value, ":")
 	//If importing with an incorrect ID we need to catch and provide a user-friendly error
 	if len(id) != 3 {


### PR DESCRIPTION

## Description

Update the Machine resource to use the terraform framework rather than the SDK2. The schema stayed the same.

Care must be taken with optional values. The terraform types differentiate between null, unknown and a value. Especially with Read, and empty string is not the same a StringNull().

Always use the ID to reference the user's name in Read, as it can be used with import as well, thus the only hint of which user available.

## Type of change

- Maintenance work (repository related, like Github actions, or revving the Go version, etc.)

## Environment

- Juju controller version: 2.9

- Terraform version: 0.8.0 next

## QA steps

Test use of the machine resource, upgrade from 0.7.0 plan and import.
