### PR TITLE
[JUJU-4180] Migrate offer resource from sdk2 to provider framework

### DIFF
--- a/internal/provider/data_source_offer_test.go
+++ b/internal/provider/data_source_offer_test.go
@@ -49,7 +49,6 @@ resource "juju_application" "this" {
 }
 
 resource "juju_offer" "this" {
-    provider = oldjuju
 	model            = juju_model.this.name
 	application_name = juju_application.this.name
 	endpoint         = "db"

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -68,7 +68,6 @@ func New(version string) func() *schema.Provider {
 				"juju_application": resourceApplication(),
 				"juju_integration": resourceIntegration(),
 				"juju_model":       resourceModel(),
-				"juju_offer":       resourceOffer(),
 				"juju_ssh_key":     resourceSSHKey(),
 			},
 		}
@@ -363,6 +362,7 @@ func (p *jujuProvider) Resources(ctx context.Context) []func() resource.Resource
 		func() resource.Resource { return NewMachineResource() },
 		func() resource.Resource { return NewUserResource() },
 		func() resource.Resource { return NewCredentialResource() },
+		func() resource.Resource { return NewOfferResource() },
 	}
 }
 

--- a/internal/provider/resource_integration_test.go
+++ b/internal/provider/resource_integration_test.go
@@ -167,7 +167,6 @@ resource "juju_application" "b" {
 }
 
 resource "juju_offer" "b" {
-    provider = oldjuju
 	model            = juju_model.b.name
 	application_name = juju_application.b.name
 	endpoint         = "backend-db-admin"

--- a/internal/provider/resource_offer.go
+++ b/internal/provider/resource_offer.go
@@ -34,18 +34,18 @@ type offerResource struct {
 type offerResourceModel struct {
 	ModelName       types.String `tfsdk:"model"`
 	OfferName       types.String `tfsdk:"name"`
-	ApplicationName types.String `tfsdk:"application"`
-	EndpointName    types.String `tfsdk:"endpooint"`
+	ApplicationName types.String `tfsdk:"application_name"`
+	EndpointName    types.String `tfsdk:"endpoint"`
 	URL             types.String `tfsdk:"url"`
 	// ID required by the testing framework
 	ID types.String `tfsdk:"id"`
 }
 
-func (o offerResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+func (o *offerResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_offer"
 }
 
-func (o offerResource) Schema(_ context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+func (o *offerResource) Schema(_ context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = frameworkResSchema.Schema{
 		Description: "A resource that represent a Juju Offer.",
 		Attributes: map[string]frameworkResSchema.Attribute{
@@ -92,7 +92,7 @@ func (o offerResource) Schema(_ context.Context, req resource.SchemaRequest, res
 	}
 }
 
-func (o offerResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+func (o *offerResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	// Prevent panic if the provider has not been configured.
 	if o.client == nil {
 		addClientNotConfiguredError(&resp.Diagnostics, "offer", "create")
@@ -146,7 +146,7 @@ func (o offerResource) Create(ctx context.Context, req resource.CreateRequest, r
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
-func (o offerResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+func (o *offerResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	// Prevent panic if the provider has not been configured.
 	if o.client == nil {
 		addClientNotConfiguredError(&resp.Diagnostics, "offer", "read")
@@ -179,7 +179,7 @@ func (o offerResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
-func (o offerResource) Update(_ context.Context, _ resource.UpdateRequest, _ *resource.UpdateResponse) {
+func (o *offerResource) Update(_ context.Context, _ resource.UpdateRequest, _ *resource.UpdateResponse) {
 	// There's no non-Computed attribute that's not RequiresReplace
 	// So no in-place update can happen on any field on this resource
 }
@@ -193,7 +193,7 @@ func (o offerResource) Update(_ context.Context, _ resource.UpdateRequest, _ *re
 //
 // Juju refers to deletion as "destroy" so we call the Destroy function of our client here rather than delete
 // This function remains named Delete for parity across the provider and to stick within terraform naming conventions
-func (o offerResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+func (o *offerResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	// Prevent panic if the provider has not been configured.
 	if o.client == nil {
 		addClientNotConfiguredError(&resp.Diagnostics, "offer", "delete")
@@ -217,7 +217,7 @@ func (o offerResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 	tflog.Trace(ctx, fmt.Sprintf("delete offer resource %q", plan.OfferName))
 }
 
-func (o offerResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+func (o *offerResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	// Prevent panic if the provider has not been configured.
 	if req.ProviderData == nil {
 		return
@@ -235,7 +235,7 @@ func (o offerResource) Configure(ctx context.Context, req resource.ConfigureRequ
 	o.client = client
 }
 
-func (o offerResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+func (o *offerResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 

--- a/internal/provider/resource_offer.go
+++ b/internal/provider/resource_offer.go
@@ -7,6 +7,9 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	frameworkResSchema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
@@ -26,13 +29,49 @@ type offerResource struct {
 	client *juju.Client
 }
 
-func (o offerResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+func (o offerResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_offer"
 }
 
-func (o offerResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
-	//TODO implement me
-	panic("implement me")
+func (o offerResource) Schema(_ context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = frameworkResSchema.Schema{
+		Description: "A resource that represent a Juju Offer.",
+		Attributes: map[string]frameworkResSchema.Attribute{
+			"model": frameworkResSchema.StringAttribute{
+				Description: "The name of the model to operate in.",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"name": frameworkResSchema.StringAttribute{
+				Description: "The name of the offer.",
+				Optional:    true,
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"application_name": frameworkResSchema.StringAttribute{
+				Description: "The name of the application.",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"endpoint": frameworkResSchema.StringAttribute{
+				Description: "The endpoint name.",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"url": frameworkResSchema.StringAttribute{
+				Description: "The offer URL.",
+				Computed:    true,
+			},
+		},
+	}
 }
 
 func (o offerResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
@@ -74,52 +113,6 @@ func (c offerResource) Configure(ctx context.Context, req resource.ConfigureRequ
 
 func (c offerResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
-}
-
-func resourceOffer() *schema.Resource {
-	return &schema.Resource{
-		// This description is used by the documentation generator and the language server.
-		Description: "A resource that represent a Juju Offer.",
-
-		CreateContext: resourceOfferCreate,
-		ReadContext:   resourceOfferRead,
-		DeleteContext: resourceOfferDelete,
-		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
-		},
-		Schema: map[string]*schema.Schema{
-			"model": {
-				Description: "The name of the model to operate in.",
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-			},
-			"name": {
-				Description: "The name of the offer.",
-				Type:        schema.TypeString,
-				Optional:    true,
-				Computed:    true,
-				ForceNew:    true,
-			},
-			"application_name": {
-				Description: "The name of the application.",
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-			},
-			"endpoint": {
-				Description: "The endpoint name.",
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-			},
-			"url": {
-				Description: "The offer URL.",
-				Type:        schema.TypeString,
-				Computed:    true,
-			},
-		},
-	}
 }
 
 func resourceOfferCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/internal/provider/resource_offer.go
+++ b/internal/provider/resource_offer.go
@@ -4,11 +4,65 @@ import (
 	"context"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/juju/terraform-provider-juju/internal/juju"
 )
+
+// Ensure provider defined types fully satisfy framework interfaces.
+var _ resource.Resource = &offerResource{}
+var _ resource.ResourceWithConfigure = &offerResource{}
+var _ resource.ResourceWithImportState = &offerResource{}
+
+func NewOfferResource() resource.Resource {
+	return &offerResource{}
+}
+
+type offerResource struct {
+	client *juju.Client
+}
+
+func (o offerResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (o offerResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (o offerResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (o offerResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (o offerResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (o offerResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (c offerResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (c offerResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
 
 func resourceOffer() *schema.Resource {
 	return &schema.Resource{

--- a/internal/provider/resource_offer.go
+++ b/internal/provider/resource_offer.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -26,8 +27,7 @@ type offerResource struct {
 }
 
 func (o offerResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
-	//TODO implement me
-	panic("implement me")
+	resp.TypeName = req.ProviderTypeName + "_offer"
 }
 
 func (o offerResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
@@ -56,8 +56,20 @@ func (o offerResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 }
 
 func (c offerResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
-	//TODO implement me
-	panic("implement me")
+	// Prevent panic if the provider has not been configured.
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*juju.Client)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *juju.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+	c.client = client
 }
 
 func (c offerResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {

--- a/internal/provider/resource_offer_test.go
+++ b/internal/provider/resource_offer_test.go
@@ -67,7 +67,6 @@ resource "juju_application" "this" {
 }
 
 resource "juju_offer" "this" {
-    provider = oldjuju
 	model            = juju_model.this.name
 	application_name = juju_application.this.name
 	endpoint         = "db"
@@ -96,7 +95,6 @@ resource "juju_application" "this" {
 }
 
 resource "juju_offer" "this" {
-    provider = oldjuju
 	model            = juju_model.this.name
 	application_name = juju_application.this.name
 	endpoint         = "db"


### PR DESCRIPTION
## Description

Migrates the offer resource from sdk2 to terraform provider framework. Schema isn't changed.

## Type of change

- Maintenance work (repository related, like Github actions, or revving the Go version, etc.)

## Environment

- Juju controller version: 2.9

- Terraform version: 1.5.4

## QA steps

Create an offer and use it in an integration (see `examples/resources/juju_offer`) with `0.7.0`, and get this change:

```sh
 $ make install
```


-- cd into wherever the plan is --

Change the version in the plan to `0.8.0`:

```terraform
terraform {
  required_providers {
    juju = {
      version = "0.8.0"
      source  = "juju/juju"
    }
  }
}
```

Then run:

```sh
 $ terraform init --upgrade  && terraform plan && terraform apply --auto-approve
```

You should see `No changes ...` output.