### PR TITLE
[JUJU-4181] Migrate ssh key resource from sdk2 to provider framework

### DIFF
--- a/docs/resources/ssh_key.md
+++ b/docs/resources/ssh_key.md
@@ -25,7 +25,7 @@ resource "juju_ssh_key" "mykey" {
 ### Required
 
 - `model` (String) The name of the model to operate in.
-- `payload` (String) SSH key payload.
+- `payload` (String, Sensitive) SSH key payload.
 
 ### Read-Only
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -68,7 +68,6 @@ func New(version string) func() *schema.Provider {
 				"juju_application": resourceApplication(),
 				"juju_integration": resourceIntegration(),
 				"juju_model":       resourceModel(),
-				"juju_ssh_key":     resourceSSHKey(),
 			},
 		}
 		p.ConfigureContextFunc = configure()
@@ -359,10 +358,11 @@ func getJujuProviderModel(ctx context.Context, req frameworkprovider.ConfigureRe
 func (p *jujuProvider) Resources(ctx context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
 		func() resource.Resource { return NewAccessModelResource() },
-		func() resource.Resource { return NewMachineResource() },
-		func() resource.Resource { return NewUserResource() },
 		func() resource.Resource { return NewCredentialResource() },
+		func() resource.Resource { return NewMachineResource() },
 		func() resource.Resource { return NewOfferResource() },
+		func() resource.Resource { return NewSSHKeyResource() },
+		func() resource.Resource { return NewUserResource() },
 	}
 }
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -355,7 +355,7 @@ func getJujuProviderModel(ctx context.Context, req frameworkprovider.ConfigureRe
 //
 // The resource type name is determined by the Resource implementing
 // the Metadata method. All resources must have unique names.
-func (p *jujuProvider) Resources(ctx context.Context) []func() resource.Resource {
+func (p *jujuProvider) Resources(_ context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
 		func() resource.Resource { return NewAccessModelResource() },
 		func() resource.Resource { return NewCredentialResource() },
@@ -371,7 +371,7 @@ func (p *jujuProvider) Resources(ctx context.Context) []func() resource.Resource
 //
 // The data source type name is determined by the DataSource implementing
 // the Metadata method. All data sources must have unique names.
-func (p *jujuProvider) DataSources(ctx context.Context) []func() datasource.DataSource {
+func (p *jujuProvider) DataSources(_ context.Context) []func() datasource.DataSource {
 	return []func() datasource.DataSource{
 		func() datasource.DataSource { return NewModelDataSource() },
 		//func() datasource.DataSource { return NewMachineDataSource() },

--- a/internal/provider/resource_ssh_key.go
+++ b/internal/provider/resource_ssh_key.go
@@ -5,184 +5,309 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-
+	frameworkdiag "github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	frameworkResSchema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/juju/terraform-provider-juju/internal/juju"
 	"github.com/juju/terraform-provider-juju/internal/utils"
 )
 
-func resourceSSHKey() *schema.Resource {
-	return &schema.Resource{
-		// This description is used by the documentation generator and the language server.
+// Ensure provider defined types fully satisfy framework interfaces.
+var _ resource.Resource = &sshKeyResource{}
+var _ resource.ResourceWithConfigure = &sshKeyResource{}
+var _ resource.ResourceWithImportState = &sshKeyResource{}
+
+func NewSSHKeyResource() resource.Resource {
+	return &sshKeyResource{}
+}
+
+type sshKeyResource struct {
+	client *juju.Client
+}
+
+type sshKeyResourceModel struct {
+	ModelName types.String `tfsdk:"model"`
+	Payload   types.String `tfsdk:"payload"`
+	// ID required by the testing framework
+	ID types.String `tfsdk:"id"`
+}
+
+func (s *sshKeyResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+func (s *sshKeyResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	// Prevent panic if the provider has not been configured.
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*juju.Client)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *juju.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+	s.client = client
+}
+
+func (s *sshKeyResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_ssh_key"
+}
+
+func (s *sshKeyResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = frameworkResSchema.Schema{
 		Description: "Resource representing an SSH key.",
-
-		CreateContext: sshKeyCreate,
-		ReadContext:   sshKeyRead,
-		UpdateContext: sshKeyUpdate,
-		DeleteContext: sshKeyDelete,
-
-		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
-		},
-
-		Schema: map[string]*schema.Schema{
-			"model": {
+		Attributes: map[string]frameworkResSchema.Attribute{
+			"model": frameworkResSchema.StringAttribute{
 				Description: "The name of the model to operate in.",
-				Type:        schema.TypeString,
 				Required:    true,
 			},
-			"payload": {
+			"payload": frameworkResSchema.StringAttribute{
 				Description: "SSH key payload.",
-				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"id": frameworkResSchema.StringAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 		},
 	}
 }
 
-func sshKeyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*juju.Client)
-
-	var diags diag.Diagnostics
-
-	modelName := d.Get("model").(string)
-	modelUUID, err := client.Models.ResolveModelUUID(modelName)
-	if err != nil {
-		return diag.FromErr(err)
+func (s *sshKeyResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	// Prevent panic if the provider has not been configured.
+	if s.client == nil {
+		addClientNotConfiguredError(&resp.Diagnostics, "ssh_key", "create")
+		return
 	}
 
-	payload := d.Get("payload").(string)
+	var data sshKeyResourceModel
 
+	// Read Terraform configuration from the request into the model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	modelName := data.ModelName.ValueString()
+	modelUUID, err := s.client.Models.ResolveModelUUID(modelName)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to resolve model UUID, got error: %s", err))
+		return
+	}
+	payload := data.Payload.ValueString()
 	user := utils.GetUserFromSSHKey(payload)
 	if user == "" {
-		return diag.Errorf("malformed SSH key, user not found")
+		resp.Diagnostics.AddError("Client Error", "malformed SSH key, user not found")
+		return
 	}
 
-	err = client.SSHKeys.CreateSSHKey(&juju.CreateSSHKeyInput{
+	err = s.client.SSHKeys.CreateSSHKey(&juju.CreateSSHKeyInput{
 		ModelName: modelName,
 		ModelUUID: modelUUID,
 		Payload:   payload,
 	})
-
 	if err != nil {
-		diags = append(diags, diag.FromErr(err)...)
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create ssh_key, got error %s", err))
+		return
 	}
+	tflog.Trace(ctx, fmt.Sprintf("create ssh_key with payload: %q", payload))
 
-	d.SetId(fmt.Sprintf("sshkey:%s:%s", modelName, user))
-
-	return diags
+	data.ID = types.StringValue(newSSHKeyID(modelName, user))
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
-func sshKeyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*juju.Client)
+func newSSHKeyID(modelName string, user string) string {
+	return fmt.Sprintf("sshkey:%s:%s", modelName, user)
+}
 
-	// sshkey:model:user
-	tokens := strings.Split(d.Id(), ":")
-	modelName := tokens[1]
-	user := tokens[2]
+func retrieveSSHKeyInfoFromID(id string, d *frameworkdiag.Diagnostics) (string, string) {
+	tokens := strings.Split(id, ":")
+	//If importing with an incorrect ID we need to catch and provide a user-friendly error
+	if len(tokens) != 2 {
+		d.AddError("Malformed ID", fmt.Sprintf("unable to parse model name and user from provided ID: %q", id))
+		return "", ""
+	}
+	return tokens[0], tokens[1]
+}
 
-	modelUUID, err := client.Models.GetModelByName(modelName)
-	if err != nil {
-		return diag.FromErr(err)
+func (s *sshKeyResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	// Prevent panic if the provider has not been configured.
+	if s.client == nil {
+		addClientNotConfiguredError(&resp.Diagnostics, "ssh_key", "read")
+		return
 	}
 
-	result, err := client.SSHKeys.ReadSSHKey(&juju.ReadSSHKeyInput{
-		ModelName: modelUUID.Name,
-		ModelUUID: modelUUID.UUID,
+	var plan sshKeyResourceModel
+
+	// Read Terraform configuration from the request into the model
+	resp.Diagnostics.Append(req.State.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	modelName, user := retrieveSSHKeyInfoFromID(plan.ID.ValueString(), &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	modelInfo, err := s.client.Models.GetModelByName(modelName)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to resolve model UUID, got error: %s", err))
+		return
+	}
+
+	result, err := s.client.SSHKeys.ReadSSHKey(&juju.ReadSSHKeyInput{
+		ModelName: modelInfo.Name,
+		ModelUUID: modelInfo.UUID,
 		User:      user,
 	})
 	if err != nil {
-		return diag.FromErr(err)
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read ssh key, got error: %s", err))
+		return
 	}
+	tflog.Trace(ctx, fmt.Sprintf("read ssh key resource %q", plan.ID.ValueString()))
 
-	if err = d.Set("model", result.ModelName); err != nil {
-		return diag.FromErr(err)
-	}
+	plan.ModelName = types.StringValue(result.ModelName)
+	plan.Payload = types.StringValue(result.Payload)
 
-	if err = d.Set("payload", result.Payload); err != nil {
-		return diag.FromErr(err)
-	}
-
-	d.SetId(fmt.Sprintf("sshkey:%s:%s", modelName, user))
-
-	return diag.Diagnostics{}
+	// Set the plan onto the Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
-func sshKeyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	var diags diag.Diagnostics
-
-	client := meta.(*juju.Client)
-
-	if !d.HasChange("payload") {
-		return diags
+func (s *sshKeyResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	// Prevent panic if the provider has not been configured.
+	if s.client == nil {
+		addClientNotConfiguredError(&resp.Diagnostics, "ssh_key", "update")
+		return
 	}
 
-	// any change in the payload has to be considered as a new key
-	modelName := d.Get("model").(string)
-	modelUUID, err := client.Models.ResolveModelUUID(modelName)
+	var plan, state sshKeyResourceModel
+
+	// Get the Terraform state from the request into the state model
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	// Read Terraform configuration from the request into the plan model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Return early if nothing has changed
+	if plan.Payload.Equal(state.Payload) && plan.ModelName.Equal(state.ModelName) {
+		return
+	}
+
+	modelName := state.ModelName.ValueString()
+	modelUUID, err := s.client.Models.ResolveModelUUID(modelName)
 	if err != nil {
-		return diag.FromErr(err)
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to resolve model UUID, got error: %s", err))
+		return
 	}
 
-	user := utils.GetUserFromSSHKey(d.Get("payload").(string))
+	payload := state.Payload.ValueString()
+	user := utils.GetUserFromSSHKey(payload)
 	if user == "" {
-		return diag.Errorf("malformed SSH key, user not found")
+		resp.Diagnostics.AddError("Client Error", "malformed SSH key, user not found")
+		return
 	}
 
-	// delete
-	err = client.SSHKeys.DeleteSSHKey(&juju.DeleteSSHKeyInput{
+	// Delete the key
+	err = s.client.SSHKeys.DeleteSSHKey(&juju.DeleteSSHKeyInput{
 		ModelName: modelName,
 		ModelUUID: modelUUID,
 		User:      user,
 	})
 	if err != nil {
-		diags = diag.FromErr(err)
-		return diags
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete ssh key for updating, got error: %s", err))
+		return
+	}
+	tflog.Trace(ctx, fmt.Sprintf("ssh key deleted : %q", state.ID.ValueString()))
+
+	// Get the model name from the plan because it might have changed
+	newModelName := state.ModelName.ValueString()
+	newModelUUID, err := s.client.Models.ResolveModelUUID(newModelName)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to resolve model UUID, got error: %s", err))
+		return
 	}
 
-	// create again
-	err = client.SSHKeys.CreateSSHKey(&juju.CreateSSHKeyInput{
-		ModelName: modelName,
-		ModelUUID: modelUUID,
-		Payload:   d.Get("payload").(string),
+	// Create a new key
+	err = s.client.SSHKeys.CreateSSHKey(&juju.CreateSSHKeyInput{
+		ModelName: newModelName,
+		ModelUUID: newModelUUID,
+		Payload:   plan.Payload.ValueString(),
 	})
 	if err != nil {
-		diags = diag.FromErr(err)
-		return diags
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create ssh key for updating, got error: %s", err))
+		return
 	}
+	tflog.Trace(ctx, fmt.Sprintf("ssh key created : %q", plan.ID.ValueString()))
 
-	return diags
+	// Set the plan onto the Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
-func sshKeyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*juju.Client)
+// Delete is called when the provider must delete the resource. Config
+// values may be read from the DeleteRequest.
+//
+// If execution completes without error, the framework will automatically
+// call DeleteResponse.State.RemoveResource(), so it can be omitted
+// from provider logic.
+//
+// Juju refers to deletion as "destroy" so we call the Destroy function of our client here rather than delete
+// This function remains named Delete for parity across the provider and to stick within terraform naming conventions
+func (s *sshKeyResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	// Prevent panic if the provider has not been configured.
+	if s.client == nil {
+		addClientNotConfiguredError(&resp.Diagnostics, "ssh_key", "delete")
+		return
+	}
 
-	var diags diag.Diagnostics
+	var data sshKeyResourceModel
 
-	modelName := d.Get("model").(string)
-	modelUUID, err := client.Models.GetModelByName(modelName)
+	// Read Terraform configuration from the request into the data model
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	modelName := data.ModelName.ValueString()
+	modelUUID, err := s.client.Models.ResolveModelUUID(modelName)
 	if err != nil {
-		return diag.FromErr(err)
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to resolve model UUID, got error: %s", err))
+		return
 	}
 
-	user := utils.GetUserFromSSHKey(d.Get("payload").(string))
+	payload := data.Payload.ValueString()
+	user := utils.GetUserFromSSHKey(payload)
 	if user == "" {
-		return diag.Errorf("malformed SSH key, user not found")
+		resp.Diagnostics.AddError("Client Error", "malformed SSH key, user not found")
+		return
 	}
-
-	err = client.SSHKeys.DeleteSSHKey(&juju.DeleteSSHKeyInput{
-		ModelName: modelUUID.Name,
-		ModelUUID: modelUUID.UUID,
+	// Delete the key
+	err = s.client.SSHKeys.DeleteSSHKey(&juju.DeleteSSHKeyInput{
+		ModelName: modelName,
+		ModelUUID: modelUUID,
 		User:      user,
 	})
-
 	if err != nil {
-		diags = append(diags, diag.FromErr(err)...)
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete ssh key for updating, got error: %s", err))
+		return
 	}
-
-	d.SetId("")
-
-	return diags
+	tflog.Trace(ctx, fmt.Sprintf("delete ssh_key resource : %q", data.ID.ValueString()))
 }

--- a/internal/provider/resource_ssh_key_test.go
+++ b/internal/provider/resource_ssh_key_test.go
@@ -68,7 +68,6 @@ resource "juju_model" "this" {
 }
 
 resource "juju_ssh_key" "this" {
-    provider = oldjuju
 	model = juju_model.this.name
 	payload= %q
 }

--- a/internal/utils/sshkeys.go
+++ b/internal/utils/sshkeys.go
@@ -2,8 +2,9 @@ package utils
 
 import "strings"
 
-// GetUserFromSSHKey returns the user of the key
-func GetUserFromSSHKey(key string) string {
+// GetKeyIdentifierFromSSHKey returns the identifier of the key,
+// which is currently based on the comment field (TODO issue #267)
+func GetKeyIdentifierFromSSHKey(key string) string {
 	// The key is broken down into component values.
 	// components[0] is the type of key (e.g. ssh-rsa)
 	// components[1] is the key string itself


### PR DESCRIPTION
## Description

Migrates the ssh key resource from sdk2 to terraform provider framework. Schema isn't changed.

## Type of change

- Maintenance work (repository related, like Github actions, or revving the Go version, etc.)

## Environment

- Juju controller version: 2.9

- Terraform version: 1.5.4

## QA steps

Create an ssh key resource (see `examples/resources/juju_ssh_key`) with `0.7.0`. 

Get this change, and :
```sh
 $ make install
```
-- cd into wherever the plan is --

Change the version in the plan to `0.8.0`:

```terraform
terraform {
  required_providers {
    juju = {
      version = "0.8.0"
      source  = "juju/juju"
    }
  }
}
```

Then run:

```sh
 $ terraform init --upgrade  && terraform plan && terraform apply --auto-approve
```

You should see `No changes ...` output.