### PR TITLE
[JUJU-4177] Migrate integration resource from sdk2 to provider framework

### DIFF
--- a/docs/resources/integration.md
+++ b/docs/resources/integration.md
@@ -33,11 +33,11 @@ resource "juju_integration" "this" {
 
 ### Required
 
-- `application` (Block Set, Min: 2, Max: 2) The two applications to integrate. (see [below for nested schema](#nestedblock--application))
 - `model` (String) The name of the model to operate in.
 
 ### Optional
 
+- `application` (Block Set) The two applications to integrate. (see [below for nested schema](#nestedblock--application))
 - `via` (String) A comma separated list of CIDRs for outbound traffic.
 
 ### Read-Only

--- a/internal/juju/integrations.go
+++ b/internal/juju/integrations.go
@@ -24,6 +24,17 @@ const (
 	IntegrationAppAvailableTimeout = time.Second * 60
 )
 
+var NoIntegrationFoundError = &noIntegrationFoundError{}
+
+// NoIntegrationFoundError
+type noIntegrationFoundError struct {
+	ModelUUID string
+}
+
+func (ie *noIntegrationFoundError) Error() string {
+	return fmt.Sprintf("no integrations exist in model %v", ie.ModelUUID)
+}
+
 type integrationsClient struct {
 	ConnectionFactory
 }
@@ -60,7 +71,6 @@ type UpdateIntegrationResponse struct {
 
 type UpdateIntegrationInput struct {
 	ModelUUID    string
-	ID           string
 	Endpoints    []string
 	OldEndpoints []string
 	ViaCIDRs     string
@@ -126,7 +136,7 @@ func (c integrationsClient) ReadIntegration(input *IntegrationInput) (*ReadInteg
 	integrations := status.Relations
 	var integration params.RelationStatus
 	if len(integrations) == 0 {
-		return nil, fmt.Errorf("no integrations exist in specified model")
+		return nil, &noIntegrationFoundError{ModelUUID: input.ModelUUID}
 	}
 
 	apps := make([][]string, 0, len(input.Endpoints))

--- a/internal/provider/helpers.go
+++ b/internal/provider/helpers.go
@@ -26,6 +26,8 @@ const (
 	LogResourceUser        = "resource-user"
 )
 
+const LogResourceIntegration = "resource-integration"
+
 func addClientNotConfiguredError(diag *diag.Diagnostics, resource, method string) {
 	diag.AddError(
 		"Provider Error, Client Not Configured",

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -61,8 +61,7 @@ func New(version string) func() *schema.Provider {
 				},
 			},
 			ResourcesMap: map[string]*schema.Resource{
-				"juju_integration": resourceIntegration(),
-				"juju_model":       resourceModel(),
+				"juju_model": resourceModel(),
 			},
 		}
 		p.ConfigureContextFunc = configure()
@@ -355,6 +354,7 @@ func (p *jujuProvider) Resources(_ context.Context) []func() resource.Resource {
 		func() resource.Resource { return NewAccessModelResource() },
 		func() resource.Resource { return NewApplicationResource() },
 		func() resource.Resource { return NewCredentialResource() },
+		func() resource.Resource { return NewIntegrationResource() },
 		func() resource.Resource { return NewMachineResource() },
 		func() resource.Resource { return NewOfferResource() },
 		func() resource.Resource { return NewSSHKeyResource() },

--- a/internal/provider/resource_integration.go
+++ b/internal/provider/resource_integration.go
@@ -2,19 +2,22 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-plugin-framework/attr"
-	frameworkdiag "github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	frameworkResSchema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+
 	"github.com/juju/terraform-provider-juju/internal/juju"
 )
 
@@ -22,6 +25,7 @@ import (
 var _ resource.Resource = &integrationResource{}
 var _ resource.ResourceWithConfigure = &integrationResource{}
 var _ resource.ResourceWithImportState = &integrationResource{}
+var _ resource.ResourceWithValidateConfig = &integrationResource{}
 
 func NewIntegrationResource() resource.Resource {
 	return &integrationResource{}
@@ -29,376 +33,9 @@ func NewIntegrationResource() resource.Resource {
 
 type integrationResource struct {
 	client *juju.Client
-}
 
-func (i integrationResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
-}
-
-func (i integrationResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
-	// Prevent panic if the provider has not been configured.
-	if req.ProviderData == nil {
-		return
-	}
-
-	client, ok := req.ProviderData.(*juju.Client)
-	if !ok {
-		resp.Diagnostics.AddError(
-			"Unexpected Resource Configure Type",
-			fmt.Sprintf("Expected *juju.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
-		)
-		return
-	}
-	i.client = client
-}
-
-func (i integrationResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
-	resp.TypeName = req.ProviderTypeName + "_integration"
-}
-
-func (i integrationResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
-	resp.Schema = frameworkResSchema.Schema{
-		Description: "A resource that represents a Juju Integration.",
-		Attributes: map[string]frameworkResSchema.Attribute{
-			"model": frameworkResSchema.StringAttribute{
-				Description: "The name of the model to operate in.",
-				Required:    true,
-			},
-			"via": frameworkResSchema.StringAttribute{
-				Description: "A comma separated list of CIDRs for outbound traffic.",
-				Optional:    true,
-			},
-			"application": frameworkResSchema.SetNestedAttribute{
-				Description: "The two applications to integrate.",
-				NestedObject: frameworkResSchema.NestedAttributeObject{
-					Attributes: map[string]frameworkResSchema.Attribute{
-						"name": frameworkResSchema.StringAttribute{
-							Description: "The name of the application.",
-							Optional:    true,
-						},
-						"endpoint": frameworkResSchema.StringAttribute{
-							Description: "The endpoint name.",
-							Optional:    true,
-							Computed:    true,
-						},
-						"offer_url": frameworkResSchema.StringAttribute{
-							Description: "The URL of a remote application.",
-							Optional:    true,
-							// Computed:    true,
-							PlanModifiers: []planmodifier.String{
-								stringplanmodifier.UseStateForUnknown(),
-							},
-						},
-					},
-				},
-			},
-			"id": frameworkResSchema.StringAttribute{
-				Computed: true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
-			},
-		},
-	}
-}
-
-func (i integrationResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	// Prevent panic if the provider has not been configured.
-	if i.client == nil {
-		addClientNotConfiguredError(&resp.Diagnostics, "ssh_key", "create")
-		return
-	}
-
-	var data integrationResourceModel
-
-	// Read Terraform configuration from the request into the model
-	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-	modelName := data.ModelName.ValueString()
-	modelUUID, err := i.client.Models.ResolveModelUUID(modelName)
-	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to resolve model UUID, got error: %s", err))
-		return
-	}
-
-	var apps []map[string]string
-	resp.Diagnostics.Append(data.Application.ElementsAs(ctx, &apps, false)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	endpoints, offerURL, appNames, err := parseEndpoints(apps)
-	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to parse endpoints, got error: %s", err))
-		return
-	}
-	if len(endpoints) == 0 {
-		resp.Diagnostics.AddError("Client Error", "please provide at least one local application")
-		return
-	}
-	var offerResponse = &juju.ConsumeRemoteOfferResponse{}
-	if offerURL != nil {
-		offerResponse, err = i.client.Offers.ConsumeRemoteOffer(&juju.ConsumeRemoteOfferInput{
-			ModelUUID: modelUUID,
-			OfferURL:  *offerURL,
-		})
-		if err != nil {
-			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to consume remote offer, got error: %s", err))
-			return
-		}
-	}
-
-	if offerResponse.SAASName != "" {
-		endpoints = append(endpoints, offerResponse.SAASName)
-	}
-
-	viaCIDRs := data.Via.ValueString()
-	response, err := i.client.Integrations.CreateIntegration(&juju.IntegrationInput{
-		ModelUUID: modelUUID,
-		Apps:      appNames,
-		Endpoints: endpoints,
-		ViaCIDRs:  viaCIDRs,
-	})
-	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create integration, got error: %s", err))
-		return
-	}
-	tflog.Trace(ctx, fmt.Sprintf("created integration resource between apps: %q", appNames))
-
-	parsedApplications := parseApplications(response.Applications)
-
-	blockAttributeType := map[string]attr.Type{
-		"name":      types.StringType,
-		"endpoint":  types.StringType,
-		"offer_url": types.StringType,
-	}
-
-	appsType := types.ObjectType{AttrTypes: blockAttributeType}
-
-	parsedApps, errDiag := types.SetValueFrom(ctx, appsType, parsedApplications)
-	resp.Diagnostics.Append(errDiag...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-	data.Application = parsedApps
-
-	id := newIDForIntegrationResource(modelName, response.Applications)
-	data.ID = types.StringValue(id)
-
-	// Write the state data into the Response.State
-	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
-}
-
-func (i integrationResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
-	// Prevent panic if the provider has not been configured.
-	if i.client == nil {
-		addClientNotConfiguredError(&resp.Diagnostics, "integration", "read")
-		return
-	}
-
-	var plan integrationResourceModel
-
-	// Read Terraform configuration from the request into the model
-	resp.Diagnostics.Append(req.State.Get(ctx, &plan)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	modelName, provApp, provEndP, reqApp, reqEndP, idErr := modelIntegrationNameAndEndpointsFromID(plan.ID.ValueString())
-	if idErr.HasError() {
-		resp.Diagnostics.Append(idErr...)
-		return
-	}
-
-	modelUUID, err := i.client.Models.ResolveModelUUID(modelName)
-	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to get model uuid, got error: %s", err))
-		return
-	}
-
-	integration := &juju.IntegrationInput{
-		ModelUUID: modelUUID,
-		Endpoints: []string{
-			fmt.Sprintf("%v:%v", provApp, provEndP),
-			fmt.Sprintf("%v:%v", reqApp, reqEndP),
-		},
-	}
-
-	response, err := i.client.Integrations.ReadIntegration(integration)
-	if err != nil {
-		resp.Diagnostics.Append(handleIntegrationNotFoundError(ctx, err, &resp.State)...)
-		return
-	}
-	tflog.Trace(ctx, fmt.Sprintf("read integration resource %q", plan.ID.ValueString()))
-
-	plan.ModelName = types.StringValue(modelName)
-
-	applications := parseApplications(response.Applications)
-	appType := req.State.Schema.GetAttributes()["application"].(frameworkResSchema.SetNestedAttribute).NestedObject.Type()
-	apps, aErr := types.SetValueFrom(ctx, appType, applications)
-	if aErr.HasError() {
-		resp.Diagnostics.Append(aErr...)
-		return
-	}
-	plan.Application = apps
-
-	// Set the plan onto the Terraform state
-	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
-}
-
-func (i integrationResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	// Prevent panic if the provider has not been configured.
-	if i.client == nil {
-		addClientNotConfiguredError(&resp.Diagnostics, "integration", "update")
-		return
-	}
-	var plan, state integrationResourceModel
-
-	// Read Terraform prior state data into the model
-	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
-	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	modelName := plan.ModelName.ValueString()
-	modelUUID, err := i.client.Models.ResolveModelUUID(modelName)
-	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to get model uuid, got error: %s", err))
-		return
-	}
-
-	var oldEndpoints, endpoints []string
-	var oldOfferURL, offerURL *string
-
-	if !plan.Application.Equal(state.Application) {
-		var oldApps []map[string]string
-		state.Application.ElementsAs(ctx, &oldApps, false)
-		oldEndpoints, oldOfferURL, _, err = parseEndpoints(oldApps)
-		if err != nil {
-			resp.Diagnostics.AddError("Provider Error", err.Error())
-			return
-		}
-
-		var newApps []map[string]string
-		plan.Application.ElementsAs(ctx, &newApps, false)
-		endpoints, offerURL, _, err = parseEndpoints(newApps)
-		if err != nil {
-			resp.Diagnostics.AddError("Provider Error", err.Error())
-			return
-		}
-	}
-
-	var offerResponse *juju.ConsumeRemoteOfferResponse
-	//check if the offer url is present and is not the same as before the change
-	if oldOfferURL != offerURL && !(oldOfferURL == nil && offerURL == nil) {
-		if oldOfferURL != nil {
-			//destroy old offer
-			errs := i.client.Offers.RemoveRemoteOffer(&juju.RemoveRemoteOfferInput{
-				ModelUUID: modelUUID,
-				OfferURL:  *oldOfferURL,
-			})
-			if len(errs) > 0 {
-				for _, v := range errs {
-					resp.Diagnostics.AddError("Client Error", v.Error())
-				}
-				return
-			}
-		}
-		if offerURL != nil {
-			offerResponse, err = i.client.Offers.ConsumeRemoteOffer(&juju.ConsumeRemoteOfferInput{
-				ModelUUID: modelUUID,
-				OfferURL:  *offerURL,
-			})
-			if err != nil {
-				resp.Diagnostics.AddError("Client Error", err.Error())
-				return
-			}
-			endpoints = append(endpoints, offerResponse.SAASName)
-		}
-	}
-
-	viaCIDRs := plan.Via.ValueString()
-	input := &juju.UpdateIntegrationInput{
-		ModelUUID:    modelUUID,
-		ID:           plan.ID.ValueString(),
-		Endpoints:    endpoints,
-		OldEndpoints: oldEndpoints,
-		ViaCIDRs:     viaCIDRs,
-	}
-	response, err := i.client.Integrations.UpdateIntegration(input)
-	if err != nil {
-		resp.Diagnostics.AddError("Client Error", err.Error())
-		return
-	}
-
-	applications := parseApplications(response.Applications)
-	appType := req.State.Schema.GetAttributes()["application"].(frameworkResSchema.SetNestedAttribute).NestedObject.Type()
-	apps, aErr := types.SetValueFrom(ctx, appType, applications)
-	if aErr.HasError() {
-		resp.Diagnostics.Append(aErr...)
-		return
-	}
-	plan.Application = apps
-	plan.ID = types.StringValue(newIDForIntegrationResource(modelName, response.Applications))
-
-	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
-}
-
-func (i integrationResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-	// Prevent panic if the provider has not been configured.
-	if i.client == nil {
-		addClientNotConfiguredError(&resp.Diagnostics, "integration", "delete")
-		return
-	}
-
-	var state integrationResourceModel
-
-	// Read Terraform configuration from the request into the model
-	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	modelName := state.ModelName.ValueString()
-	modelUUID, err := i.client.Models.ResolveModelUUID(modelName)
-	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to get model uuid, got error: %s", err))
-		return
-	}
-
-	var apps []map[string]string
-	state.Application.ElementsAs(ctx, &apps, false)
-	endpoints, offer, _, err := parseEndpoints(apps)
-	if err != nil {
-		resp.Diagnostics.AddError("Provider Error", err.Error())
-		return
-	}
-
-	//If one of the endpoints is an offer then we need to remove the remote offer rather than destroying the integration
-	if offer != nil {
-		errs := i.client.Offers.RemoveRemoteOffer(&juju.RemoveRemoteOfferInput{
-			ModelUUID: modelUUID,
-			OfferURL:  *offer,
-		})
-		if len(errs) > 0 {
-			for _, v := range errs {
-				resp.Diagnostics.AddError("Client Error", v.Error())
-			}
-			return
-		}
-	} else {
-		err = i.client.Integrations.DestroyIntegration(&juju.IntegrationInput{
-			ModelUUID: modelUUID,
-			Endpoints: endpoints,
-		})
-		if err != nil {
-			resp.Diagnostics.AddError("Client Error", err.Error())
-			return
-		}
-	}
+	// context for the logging subsystem.
+	subCtx context.Context
 }
 
 type integrationResourceModel struct {
@@ -417,17 +54,412 @@ type nestedApplication struct {
 	OfferURL types.String `tfsdk:"offer_url"`
 }
 
-func IsIntegrationNotFound(err error) bool {
-	return strings.Contains(err.Error(), "no integrations exist")
+func (r *integrationResource) ImportState(ctx context.Context, req resource.ImportStateRequest,
+	resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 
-func handleIntegrationNotFoundError(ctx context.Context, err error, st *tfsdk.State) frameworkdiag.Diagnostics {
-	if IsIntegrationNotFound(err) {
+func (r *integrationResource) Configure(ctx context.Context, req resource.ConfigureRequest,
+	resp *resource.ConfigureResponse) {
+	// Prevent panic if the provider has not been configured.
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*juju.Client)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *juju.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+	r.client = client
+	r.subCtx = tflog.NewSubsystem(ctx, LogResourceIntegration)
+}
+
+// Called during terraform validate through ValidateResourceConfig RPC
+// Validates the logic in the application block in the Schema
+func (r *integrationResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var configData integrationResourceModel
+
+	// Read Terraform configuration from the request into the model
+	resp.Diagnostics.Append(req.Config.Get(ctx, &configData)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var apps []nestedApplication
+	configData.Application.ElementsAs(ctx, &apps, false)
+	for _, app := range apps {
+		if app.Name.IsNull() && app.OfferURL.IsNull() {
+			resp.Diagnostics.AddAttributeError(path.Root("applications"), "Attribute Error", "one and only one of \"name\" or \"offer_url\" fields must be provided.")
+		} else if !app.OfferURL.IsNull() && !app.Name.IsNull() {
+			resp.Diagnostics.AddAttributeError(path.Root("applications"), "Attribute Error", "the \"offer_url\" and \"name\" fields are mutually exclusive.")
+		} else if !app.OfferURL.IsNull() && !app.Endpoint.IsNull() {
+			resp.Diagnostics.AddAttributeError(path.Root("applications"), "Attribute Error", "the \"endpoint\" field can not be specified with the \"offer_url\" field.")
+		}
+	}
+}
+
+func (r *integrationResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_integration"
+}
+
+func (r *integrationResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "A resource that represents a Juju Integration.",
+		Attributes: map[string]schema.Attribute{
+			"model": schema.StringAttribute{
+				Description: "The name of the model to operate in.",
+				Required:    true,
+			},
+			"via": schema.StringAttribute{
+				Description: "A comma separated list of CIDRs for outbound traffic.",
+				Optional:    true,
+			},
+			"id": schema.StringAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+		},
+		Blocks: map[string]schema.Block{
+			"application": schema.SetNestedBlock{
+				Description: "The two applications to integrate.",
+				Validators: []validator.Set{
+					setvalidator.SizeBetween(2, 2),
+					setvalidator.IsRequired(),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"name": schema.StringAttribute{
+							Description: "The name of the application.",
+							Optional:    true,
+						},
+						"endpoint": schema.StringAttribute{
+							Description: "The endpoint name.",
+							Optional:    true,
+							Computed:    true,
+						},
+						"offer_url": schema.StringAttribute{
+							Description: "The URL of a remote application.",
+							Optional:    true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseStateForUnknown(),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (r *integrationResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	// Prevent panic if the provider has not been configured.
+	if r.client == nil {
+		addClientNotConfiguredError(&resp.Diagnostics, "integration", "create")
+		return
+	}
+
+	var plan integrationResourceModel
+
+	// Read Terraform configuration from the request into the model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	modelName := plan.ModelName.ValueString()
+	modelUUID, err := r.client.Models.ResolveModelUUID(modelName)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to resolve model UUID, got error: %s", err))
+		return
+	}
+
+	var apps []nestedApplication
+	resp.Diagnostics.Append(plan.Application.ElementsAs(ctx, &apps, false)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	endpoints, offerURL, appNames, err := parseEndpoints(apps)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to parse endpoints, got error: %s", err))
+		return
+	}
+
+	var offerResponse = &juju.ConsumeRemoteOfferResponse{}
+	if offerURL != nil {
+		offerResponse, err = r.client.Offers.ConsumeRemoteOffer(&juju.ConsumeRemoteOfferInput{
+			ModelUUID: modelUUID,
+			OfferURL:  *offerURL,
+		})
+		if err != nil {
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to consume remote offer, got error: %s", err))
+			return
+		}
+		r.trace(fmt.Sprintf("remote offer created : %q", *offerURL))
+	}
+
+	if offerResponse.SAASName != "" {
+		endpoints = append(endpoints, offerResponse.SAASName)
+	}
+
+	viaCIDRs := plan.Via.ValueString()
+	response, err := r.client.Integrations.CreateIntegration(&juju.IntegrationInput{
+		ModelUUID: modelUUID,
+		Apps:      appNames,
+		Endpoints: endpoints,
+		ViaCIDRs:  viaCIDRs,
+	})
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create integration, got error: %s", err))
+		return
+	}
+	r.trace(fmt.Sprintf("integration created on Juju between %q at %q on model %q", appNames, endpoints, modelName))
+
+	parsedApplications := parseApplications(response.Applications)
+
+	appsType := req.Plan.Schema.GetBlocks()["application"].(schema.SetNestedBlock).NestedObject.Type()
+	parsedApps, errDiag := types.SetValueFrom(ctx, appsType, parsedApplications)
+	resp.Diagnostics.Append(errDiag...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	plan.Application = parsedApps
+
+	id := newIDForIntegrationResource(modelName, response.Applications)
+	plan.ID = types.StringValue(id)
+
+	r.trace(fmt.Sprintf("integration resource created: %q", id))
+	// Write the state plan into the Response.State
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *integrationResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	// Prevent panic if the provider has not been configured.
+	if r.client == nil {
+		addClientNotConfiguredError(&resp.Diagnostics, "integration", "read")
+		return
+	}
+
+	var state integrationResourceModel
+
+	// Read Terraform configuration from the request into the model
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	modelName, endpointA, endpointB, idErr := modelNameAndEndpointsFromID(state.ID.ValueString())
+	if idErr.HasError() {
+		resp.Diagnostics.Append(idErr...)
+		return
+	}
+
+	modelUUID, err := r.client.Models.ResolveModelUUID(modelName)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to get model uuid, got error: %s", err))
+		return
+	}
+
+	integration := &juju.IntegrationInput{
+		ModelUUID: modelUUID,
+		Endpoints: []string{
+			endpointA,
+			endpointB,
+		},
+	}
+
+	response, err := r.client.Integrations.ReadIntegration(integration)
+	if err != nil {
+		resp.Diagnostics.Append(handleIntegrationNotFoundError(ctx, err, &resp.State)...)
+		return
+	}
+	r.trace(fmt.Sprintf("found integration: %v", integration))
+
+	state.ModelName = types.StringValue(modelName)
+
+	applications := parseApplications(response.Applications)
+	appType := req.State.Schema.GetBlocks()["application"].(schema.SetNestedBlock).NestedObject.Type()
+	apps, aErr := types.SetValueFrom(ctx, appType, applications)
+	if aErr.HasError() {
+		resp.Diagnostics.Append(aErr...)
+		return
+	}
+	state.Application = apps
+
+	r.trace(fmt.Sprintf("read integration resource: %v", state.ID.ValueString()))
+	// Set the state onto the Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *integrationResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	// Prevent panic if the provider has not been configured.
+	if r.client == nil {
+		addClientNotConfiguredError(&resp.Diagnostics, "integration", "update")
+		return
+	}
+	var plan, state integrationResourceModel
+
+	// Read Terraform prior state data into the model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	modelName := plan.ModelName.ValueString()
+	modelUUID, err := r.client.Models.ResolveModelUUID(modelName)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to get model uuid, got error: %s", err))
+		return
+	}
+
+	var oldEndpoints, endpoints []string
+	var oldOfferURL, offerURL *string
+
+	if !plan.Application.Equal(state.Application) {
+		var oldApps []nestedApplication
+		state.Application.ElementsAs(ctx, &oldApps, false)
+		oldEndpoints, oldOfferURL, _, err = parseEndpoints(oldApps)
+		if err != nil {
+			resp.Diagnostics.AddError("Provider Error", err.Error())
+			return
+		}
+
+		var newApps []nestedApplication
+		plan.Application.ElementsAs(ctx, &newApps, false)
+		endpoints, offerURL, _, err = parseEndpoints(newApps)
+		if err != nil {
+			resp.Diagnostics.AddError("Provider Error", err.Error())
+			return
+		}
+	}
+
+	var offerResponse *juju.ConsumeRemoteOfferResponse
+	//check if the offer url is present and is not the same as before the change
+	if oldOfferURL != offerURL && !(oldOfferURL == nil && offerURL == nil) {
+		if oldOfferURL != nil {
+			//destroy old offer
+			errs := r.client.Offers.RemoveRemoteOffer(&juju.RemoveRemoteOfferInput{
+				ModelUUID: modelUUID,
+				OfferURL:  *oldOfferURL,
+			})
+			if len(errs) > 0 {
+				for _, v := range errs {
+					resp.Diagnostics.AddError("Client Error", v.Error())
+				}
+				return
+			}
+			r.trace(fmt.Sprintf("removed offer on Juju: %q", *oldOfferURL))
+		}
+		if offerURL != nil {
+			offerResponse, err = r.client.Offers.ConsumeRemoteOffer(&juju.ConsumeRemoteOfferInput{
+				ModelUUID: modelUUID,
+				OfferURL:  *offerURL,
+			})
+			if err != nil {
+				resp.Diagnostics.AddError("Client Error", err.Error())
+				return
+			}
+			endpoints = append(endpoints, offerResponse.SAASName)
+			r.trace(fmt.Sprintf("added offer on Juju: %q", *offerURL))
+		}
+	}
+
+	viaCIDRs := plan.Via.ValueString()
+	input := &juju.UpdateIntegrationInput{
+		ModelUUID:    modelUUID,
+		Endpoints:    endpoints,
+		OldEndpoints: oldEndpoints,
+		ViaCIDRs:     viaCIDRs,
+	}
+	response, err := r.client.Integrations.UpdateIntegration(input)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", err.Error())
+		return
+	}
+
+	applications := parseApplications(response.Applications)
+	appType := req.State.Schema.GetAttributes()["application"].(schema.SetNestedAttribute).NestedObject.Type()
+	apps, aErr := types.SetValueFrom(ctx, appType, applications)
+	if aErr.HasError() {
+		resp.Diagnostics.Append(aErr...)
+		return
+	}
+	plan.Application = apps
+	newId := types.StringValue(newIDForIntegrationResource(modelName, response.Applications))
+	plan.ID = newId
+	r.trace(fmt.Sprintf("Updated integration resource: %q", newId))
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *integrationResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	// Prevent panic if the provider has not been configured.
+	if r.client == nil {
+		addClientNotConfiguredError(&resp.Diagnostics, "integration", "delete")
+		return
+	}
+
+	var state integrationResourceModel
+
+	// Read Terraform configuration from the request into the model
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	modelName := state.ModelName.ValueString()
+	modelUUID, err := r.client.Models.ResolveModelUUID(modelName)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to get model uuid, got error: %s", err))
+		return
+	}
+
+	var apps []nestedApplication
+	state.Application.ElementsAs(ctx, &apps, false)
+	endpoints, offer, _, err := parseEndpoints(apps)
+	if err != nil {
+		resp.Diagnostics.AddError("Provider Error", err.Error())
+		return
+	}
+
+	//If one of the endpoints is an offer then we need to remove the remote offer rather than destroying the integration
+	if offer != nil {
+		errs := r.client.Offers.RemoveRemoteOffer(&juju.RemoveRemoteOfferInput{
+			ModelUUID: modelUUID,
+			OfferURL:  *offer,
+		})
+		if len(errs) > 0 {
+			for _, v := range errs {
+				resp.Diagnostics.AddError("Client Error", v.Error())
+			}
+			return
+		}
+	} else {
+		err = r.client.Integrations.DestroyIntegration(&juju.IntegrationInput{
+			ModelUUID: modelUUID,
+			Endpoints: endpoints,
+		})
+		if err != nil {
+			resp.Diagnostics.AddError("Client Error", err.Error())
+			return
+		}
+	}
+	r.trace(fmt.Sprintf("Deleted integration resource: %q", state.ID.ValueString()))
+}
+
+func handleIntegrationNotFoundError(ctx context.Context, err error, st *tfsdk.State) diag.Diagnostics {
+	if errors.As(err, &juju.NoIntegrationFoundError) {
 		// Integration manually removed
 		st.RemoveResource(ctx)
-		return frameworkdiag.Diagnostics{}
+		return diag.Diagnostics{}
 	}
-	var diags frameworkdiag.Diagnostics
+	var diags diag.Diagnostics
 	diags.AddError("Client Error", err.Error())
 	return diags
 }
@@ -453,39 +485,24 @@ func newIDForIntegrationResource(modelName string, apps []juju.Application) stri
 	return id
 }
 
-func modelIntegrationNameAndEndpointsFromID(ID string) (string, string, string, string, string, frameworkdiag.Diagnostics) {
-	var diags frameworkdiag.Diagnostics
+func modelNameAndEndpointsFromID(ID string) (string, string, string, diag.Diagnostics) {
+	var diags diag.Diagnostics
 	id := strings.Split(ID, ":")
 	if len(id) != 5 {
 		diags.AddError("Malformed ID",
 			fmt.Sprintf("unable to parse model and application name from provided ID: %q", ID))
-		return "", "", "", "", "", diags
+		return "", "", "", diags
 	}
-	return id[0], id[1], id[2], id[3], id[4], diags
+	return id[0], fmt.Sprintf("%v:%v", id[1], id[2]), fmt.Sprintf("%v:%v", id[3], id[4]), diags
 }
 
 // This function can be used to parse the terraform data into usable juju endpoints
 // it also does some sanity checks on inputs and returns user friendly errors
-func parseEndpoints(apps []map[string]string) (endpoints []string, offer *string, appNames []string, err error) {
+func parseEndpoints(apps []nestedApplication) (endpoints []string, offer *string, appNames []string, err error) {
 	for _, app := range apps {
-		if app == nil {
-			return nil, nil, nil, fmt.Errorf("you must provide a non-empty name for each application in an integration")
-		}
-		name := app["name"]
-		offerURL := app["offer_url"]
-		endpoint := app["endpoint"]
-
-		if name == "" && offerURL == "" {
-			return nil, nil, nil, fmt.Errorf("you must provide one of \"name\" or \"offer_url\"")
-		}
-
-		if name != "" && offerURL != "" {
-			return nil, nil, nil, fmt.Errorf("you must only provider one of \"name\" or \"offer_url\" and not both")
-		}
-
-		if offerURL != "" && endpoint != "" {
-			return nil, nil, nil, fmt.Errorf("\"offer_url\" cannot be provided with \"endpoint\"")
-		}
+		name := app.Name.ValueString()
+		offerURL := app.OfferURL.ValueString()
+		endpoint := app.Endpoint.ValueString()
 
 		//Here we check if the endpoint is empty and pass just the application name, this allows juju to attempt to infer endpoints
 		//If the endpoint is specified we pass the format <applicationName>:<endpoint>
@@ -505,26 +522,38 @@ func parseEndpoints(apps []map[string]string) (endpoints []string, offer *string
 		}
 	}
 
+	if len(endpoints) == 0 {
+		return nil, nil, nil, fmt.Errorf("no endpoints are provided with given applications %v", apps)
+	}
+
 	return endpoints, offer, appNames, nil
 }
 
-func parseApplications(apps []juju.Application) []map[string]string {
-	applications := make([]map[string]string, 0, 2)
+func parseApplications(apps []juju.Application) []nestedApplication {
+	applications := make([]nestedApplication, 2)
 
-	for _, app := range apps {
-		a := make(map[string]string)
+	for i, app := range apps {
+		a := nestedApplication{}
 
 		if app.OfferURL != nil {
-			a["offer_url"] = *app.OfferURL
-			a["endpoint"] = ""
-			a["name"] = ""
+			a.OfferURL = types.StringValue(*app.OfferURL)
 		} else {
-			a["endpoint"] = app.Endpoint
-			a["name"] = app.Name
-			a["offer_url"] = ""
+			a.Endpoint = types.StringValue(app.Endpoint)
+			a.Name = types.StringValue(app.Name)
 		}
-		applications = append(applications, a)
+		applications[i] = a
 	}
 
 	return applications
+}
+
+func (r *integrationResource) trace(msg string, additionalFields ...map[string]interface{}) {
+	if r.subCtx == nil {
+		return
+	}
+
+	//SubsystemTrace(subCtx, "my-subsystem", "hello, world", map[string]interface{}{"foo": 123})
+	// Output:
+	// {"@level":"trace","@message":"hello, world","@module":"provider.my-subsystem","foo":123}
+	tflog.SubsystemTrace(r.subCtx, LogResourceIntegration, msg, additionalFields...)
 }

--- a/internal/provider/resource_integration_test.go
+++ b/internal/provider/resource_integration_test.go
@@ -80,7 +80,6 @@ resource "juju_application" "two" {
 }
 
 resource "juju_integration" "this" {
-    provider = oldjuju
 	model = juju_model.this.name
 
 	application {
@@ -169,7 +168,6 @@ resource "juju_offer" "b" {
 }
 
 resource "juju_integration" "a" {
-    provider = oldjuju
 	model = juju_model.a.name
 	via = %q
 


### PR DESCRIPTION
## Description

Migrates the integration resource from sdk2 to terraform provider framework.

## Type of change

- Maintenance work (repository related, like Github actions, or revving the Go version, etc.)

## Environment

- Juju controller version: 2.9

- Terraform version: 1.5.4

## QA steps

Create an integration resource (see `examples/resources/juju_integration`) with `0.7.0`. 

Get this change, and :
```sh
 $ make install
```
-- cd into wherever the plan is --

Change the version in the plan to `0.8.0`:

```terraform
terraform {
  required_providers {
    juju = {
      version = "0.8.0"
      source  = "juju/juju"
    }
  }
}
```

Then run:

```sh
 $ terraform init --upgrade  && terraform plan && terraform apply --auto-approve
```

You should see `No changes ...` output.