### PR TITLE
Create application resource in framework

### DIFF
--- a/docs/resources/application.md
+++ b/docs/resources/application.md
@@ -56,14 +56,14 @@ resource "juju_application" "placement_example" {
 
 ### Required
 
-- `charm` (Block List, Min: 1) The name of the charm to be installed from Charmhub. (see [below for nested schema](#nestedblock--charm))
 - `model` (String) The name of the model where the application is to be deployed.
 
 ### Optional
 
-- `config` (Map of String) Application specific configuration.
+- `charm` (Block List) The name of the charm to be installed from Charmhub. (see [below for nested schema](#nestedblock--charm))
+- `config` (Map of String) Application specific configuration. Must evaluate to a string, integer or boolean.
 - `constraints` (String) Constraints imposed on this application.
-- `expose` (Block List, Max: 1) Makes an application publicly available over the network (see [below for nested schema](#nestedblock--expose))
+- `expose` (Block List) Makes an application publicly available over the network (see [below for nested schema](#nestedblock--expose))
 - `name` (String) A custom name for the application deployment. If empty, uses the charm's name.
 - `placement` (String) Specify the target location for the application's units
 - `trust` (Boolean) Set the trust for the application.

--- a/go.mod
+++ b/go.mod
@@ -19,9 +19,11 @@ require (
 	github.com/hashicorp/terraform-plugin-mux v0.11.2
 	github.com/hashicorp/terraform-plugin-testing v1.4.0
 	github.com/juju/charm/v8 v8.0.6
+	github.com/juju/clock v1.0.2
 	github.com/juju/cmd/v3 v3.0.13
 	github.com/juju/errors v1.0.0
 	github.com/juju/names/v4 v4.0.0
+	github.com/juju/retry v1.0.0
 	github.com/juju/utils/v3 v3.0.2
 	github.com/rs/zerolog v1.30.0
 	github.com/stretchr/testify v1.8.4
@@ -108,7 +110,6 @@ require (
 	github.com/juju/ansiterm v1.0.0 // indirect
 	github.com/juju/blobstore/v2 v2.0.0 // indirect
 	github.com/juju/charmrepo/v6 v6.0.3 // indirect
-	github.com/juju/clock v1.0.2 // indirect
 	github.com/juju/collections v1.0.2 // indirect
 	github.com/juju/description/v3 v3.0.15 // indirect
 	github.com/juju/featureflag v1.0.0 // indirect
@@ -131,7 +132,6 @@ require (
 	github.com/juju/proxy v1.0.0 // indirect
 	github.com/juju/pubsub/v2 v2.0.0 // indirect
 	github.com/juju/replicaset/v2 v2.0.2 // indirect
-	github.com/juju/retry v1.0.0 // indirect
 	github.com/juju/rfc/v2 v2.0.0 // indirect
 	github.com/juju/romulus v1.0.0 // indirect
 	github.com/juju/rpcreflect v1.0.0 // indirect

--- a/internal/juju/applications.go
+++ b/internal/juju/applications.go
@@ -95,7 +95,7 @@ type CreateApplicationInput struct {
 	Units           int
 	Trust           bool
 	Expose          map[string]interface{}
-	Config          map[string]interface{}
+	Config          map[string]string
 	Placement       string
 	Constraints     constraints.Value
 }
@@ -140,7 +140,7 @@ type UpdateApplicationInput struct {
 	Expose   map[string]interface{}
 	// Unexpose indicates what endpoints to unexpose
 	Unexpose []string
-	Config   map[string]interface{}
+	Config   map[string]string
 	//Series    string // TODO: Unsupported for now
 	Placement   map[string]interface{}
 	Constraints *constraints.Value
@@ -320,16 +320,9 @@ func (c applicationsClient) CreateApplication(input *CreateApplicationInput) (*C
 		return nil, err
 	}
 
-	// The deploy API endpoint expects string values for the
-	// constraints.
-	var appConfig map[string]string
-	if input.Config == nil {
+	appConfig := input.Config
+	if appConfig == nil {
 		appConfig = make(map[string]string)
-	} else {
-		appConfig = make(map[string]string, len(input.Config))
-		for k, v := range input.Config {
-			appConfig[k] = ConfigEntryToString(v)
-		}
 	}
 	appConfig["trust"] = fmt.Sprintf("%v", input.Trust)
 

--- a/internal/provider/data_source_offer_test.go
+++ b/internal/provider/data_source_offer_test.go
@@ -38,7 +38,6 @@ resource "juju_model" "this" {
 }
 
 resource "juju_application" "this" {
-    provider = oldjuju
 	model = juju_model.this.name
 	name  = "this"
 

--- a/internal/provider/helpers.go
+++ b/internal/provider/helpers.go
@@ -1,12 +1,10 @@
-// Copyright 2023 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
-
 package provider
 
 import (
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 // model names for logging
@@ -15,6 +13,7 @@ import (
 //
 //	@module=juju.resource-application
 const LogDataSourceMachine = "datasource-machine"
+const LogResourceApplication = "resource-application"
 
 func addClientNotConfiguredError(diag *diag.Diagnostics, resource, method string) {
 	diag.AddError(
@@ -30,4 +29,9 @@ func addDSClientNotConfiguredError(diag *diag.Diagnostics, dataSource string) {
 		fmt.Sprintf("Unable to read data source %s. Expected configured Juju Client. "+
 			"Please report this issue to the provider developers.", dataSource),
 	)
+}
+
+func intPtr(value types.Int64) *int {
+	count := int(value.ValueInt64())
+	return &count
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -64,7 +64,6 @@ func New(version string) func() *schema.Provider {
 				"juju_offer": dataSourceOffer(),
 			},
 			ResourcesMap: map[string]*schema.Resource{
-				"juju_application": resourceApplication(),
 				"juju_integration": resourceIntegration(),
 				"juju_model":       resourceModel(),
 			},
@@ -357,6 +356,7 @@ func getJujuProviderModel(ctx context.Context, req frameworkprovider.ConfigureRe
 func (p *jujuProvider) Resources(_ context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
 		func() resource.Resource { return NewAccessModelResource() },
+		func() resource.Resource { return NewApplicationResource() },
 		func() resource.Resource { return NewCredentialResource() },
 		func() resource.Resource { return NewMachineResource() },
 		func() resource.Resource { return NewOfferResource() },

--- a/internal/provider/resource_application.go
+++ b/internal/provider/resource_application.go
@@ -2,340 +2,544 @@ package provider
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/juju/errors"
 	"github.com/juju/juju/core/constraints"
 
 	"github.com/juju/terraform-provider-juju/internal/juju"
 )
 
-func resourceApplication() *schema.Resource {
-	return &schema.Resource{
+const (
+	CharmKey     = "charm"
+	CidrsKey     = "cidrs"
+	ConfigKey    = "config"
+	EndpointsKey = "endpoints"
+	ExposeKey    = "expose"
+	SpacesKey    = "spaces"
+)
+
+// Ensure provider defined types fully satisfy framework interfaces.
+var _ resource.Resource = &applicationResource{}
+var _ resource.ResourceWithConfigure = &applicationResource{}
+var _ resource.ResourceWithImportState = &applicationResource{}
+
+func NewApplicationResource() resource.Resource {
+	return &applicationResource{}
+}
+
+type applicationResource struct {
+	client *juju.Client
+
+	// subCtx is the context created with the new tflog subsystem for applications.
+	subCtx context.Context
+}
+
+// applicationResourceModel describes the application data model.
+// tfsdk must match user resource schema attribute names.
+type applicationResourceModel struct {
+	ApplicationName types.String `tfsdk:"name"`
+	Charm           types.List   `tfsdk:"charm"`
+	Config          types.Map    `tfsdk:"config"`
+	Constraints     types.String `tfsdk:"constraints"`
+	Expose          types.List   `tfsdk:"expose"`
+	ModelName       types.String `tfsdk:"model"`
+	Placement       types.String `tfsdk:"placement"`
+	Principal       types.Bool   `tfsdk:"principal"`
+	Trust           types.Bool   `tfsdk:"trust"`
+	UnitCount       types.Int64  `tfsdk:"units"`
+	// ID required by the testing framework
+	ID types.String `tfsdk:"id"`
+}
+
+func (r *applicationResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_application"
+}
+
+// Configure enables provider-level data or clients to be set in the
+// provider-defined DataSource type. It is separately executed for each
+// ReadDataSource RPC.
+func (r *applicationResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	// Prevent panic if the provider has not been configured.
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*juju.Client)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *juju.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	r.client = client
+	// Create the local logging subsystem here, using the TF context when creating it.
+	r.subCtx = tflog.NewSubsystem(ctx, LogResourceApplication)
+}
+
+func (r *applicationResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
 		Description: "A resource that represents a Juju application deployment.",
-
-		CreateContext: resourceApplicationCreate,
-		ReadContext:   resourceApplicationRead,
-		UpdateContext: resourceApplicationUpdate,
-		DeleteContext: resourceApplicationDelete,
-
-		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
-		},
-
-		Schema: map[string]*schema.Schema{
-			"name": {
+		Attributes: map[string]schema.Attribute{
+			"name": schema.StringAttribute{
 				Description: "A custom name for the application deployment. If empty, uses the charm's name.",
-				Type:        schema.TypeString,
 				Optional:    true,
 				Computed:    true,
-				ForceNew:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplaceIfConfigured(),
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
-			"model": {
+			"model": schema.StringAttribute{
 				Description: "The name of the model where the application is to be deployed.",
-				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
-			},
-			"charm": {
-				Description: "The name of the charm to be installed from Charmhub.",
-				Type:        schema.TypeList,
-				Required:    true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"name": {
-							Description: "The name of the charm",
-							Type:        schema.TypeString,
-							Required:    true,
-							ForceNew:    true,
-						},
-						"channel": {
-							Description: "The channel to use when deploying a charm. Specified as \\<track>/\\<risk>/\\<branch>.",
-							Type:        schema.TypeString,
-							Optional:    true,
-							Computed:    true,
-						},
-						"revision": {
-							Description: "The revision of the charm to deploy.",
-							Type:        schema.TypeInt,
-							Optional:    true,
-							Computed:    true,
-						},
-						"series": {
-							Description: "The series on which to deploy.",
-							Type:        schema.TypeString,
-							Optional:    true,
-							Computed:    true,
-						},
-					},
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplaceIfConfigured(),
 				},
 			},
-			"units": {
+			"units": schema.Int64Attribute{
 				Description: "The number of application units to deploy for the charm.",
-				Type:        schema.TypeInt,
 				Optional:    true,
-				Default:     1,
+				Computed:    true,
+				Default:     int64default.StaticInt64(int64(1)),
 			},
-			"config": {
-				Description: "Application specific configuration.",
-				Type:        schema.TypeMap,
+			ConfigKey: schema.MapAttribute{
+				Description: "Application specific configuration. Must evaluate to a string, integer or boolean.",
 				Optional:    true,
-				DefaultFunc: func() (interface{}, error) {
-					return make(map[string]interface{}), nil
-				},
+				ElementType: types.StringType,
 			},
-			"constraints": {
+			"constraints": schema.StringAttribute{
 				Description: "Constraints imposed on this application.",
-				Type:        schema.TypeString,
 				Optional:    true,
 				// Set as "computed" to pre-populate and preserve any implicit constraints
 				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplaceIfConfigured(),
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
-			"trust": {
+			"trust": schema.BoolAttribute{
 				Description: "Set the trust for the application.",
-				Type:        schema.TypeBool,
 				Optional:    true,
-				Default:     false,
+				Computed:    true,
+				Default:     booldefault.StaticBool(false),
 			},
-			"expose": {
-				Description: "Makes an application publicly available over the network",
-				Type:        schema.TypeList,
+			"placement": schema.StringAttribute{
+				Description: "Specify the target location for the application's units",
 				Optional:    true,
-				Default:     nil,
-				MaxItems:    1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"endpoints": {
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplaceIfConfigured(),
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"principal": schema.BoolAttribute{
+				Description: "Whether this is a Principal application",
+				Computed:    true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"id": schema.StringAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+		},
+		Blocks: map[string]schema.Block{
+			CharmKey: schema.ListNestedBlock{
+				Description: "The name of the charm to be installed from Charmhub.",
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"name": schema.StringAttribute{
+							Required:    true,
+							Description: "The name of the charm",
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.RequiresReplaceIfConfigured(),
+							},
+						},
+						"channel": schema.StringAttribute{
+							Description: "The channel to use when deploying a charm. Specified as \\<track>/\\<risk>/\\<branch>.",
+							Optional:    true,
+							Computed:    true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseStateForUnknown(),
+							},
+						},
+						"revision": schema.Int64Attribute{
+							Description: "The revision of the charm to deploy.",
+							Optional:    true,
+							Computed:    true,
+							PlanModifiers: []planmodifier.Int64{
+								int64planmodifier.UseStateForUnknown(),
+							},
+						},
+						"series": schema.StringAttribute{
+							Description: "The series on which to deploy.",
+							Optional:    true,
+							Computed:    true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseStateForUnknown(),
+							},
+						},
+					},
+				},
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+					listvalidator.IsRequired(),
+				},
+			},
+			ExposeKey: schema.ListNestedBlock{
+				Description: "Makes an application publicly available over the network",
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						EndpointsKey: schema.StringAttribute{
 							Description: "Expose only the ports that charms have opened for this comma-delimited list of endpoints",
-							Type:        schema.TypeString,
-							Default:     "",
 							Optional:    true,
 						},
-						"spaces": {
+						SpacesKey: schema.StringAttribute{
 							Description: "A comma-delimited list of spaces that should be able to access the application ports once exposed.",
-							Type:        schema.TypeString,
-							Default:     "",
 							Optional:    true,
 						},
-						"cidrs": {
+						CidrsKey: schema.StringAttribute{
 							Description: "A comma-delimited list of CIDRs that should be able to access the application ports once exposed.",
-							Type:        schema.TypeString,
-							Default:     "",
 							Optional:    true,
 						},
 					},
 				},
-			},
-			"placement": {
-				Description: "Specify the target location for the application's units",
-				Type:        schema.TypeString,
-				Optional:    true,
-				Computed:    true,
-			},
-			"principal": {
-				Description: "Whether this is a Principal application",
-				Type:        schema.TypeBool,
-				Computed:    true,
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+				},
 			},
 		},
 	}
 }
 
-func resourceApplicationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*juju.Client)
+// nestedCharm represents the single element of the charm ListNestedBlock
+// of the in the application resource schema
+type nestedCharm struct {
+	Name     types.String `tfsdk:"name"`
+	Channel  types.String `tfsdk:"channel"`
+	Revision types.Int64  `tfsdk:"revision"`
+	Series   types.String `tfsdk:"series"`
+}
 
-	modelName := d.Get("model").(string)
-	modelUUID, err := client.Models.ResolveModelUUID(modelName)
+// nestedExpose represents the single element of expose ListNestedBlock
+// of the in the application resource schema
+type nestedExpose struct {
+	Endpoints types.String `tfsdk:"endpoints"`
+	Spaces    types.String `tfsdk:"spaces"`
+	Cidrs     types.String `tfsdk:"cidrs"`
+}
+
+func (n nestedExpose) transformToMapStringInterface() map[string]interface{} {
+	// An empty map is equivalent to `juju expose` with no
+	// endpoints, cidrs nor spaces
+	expose := make(map[string]interface{})
+	if val := n.Endpoints.ValueString(); val != "" {
+		expose[EndpointsKey] = val
+	}
+	if val := n.Spaces.ValueString(); val != "" {
+		expose[SpacesKey] = val
+	}
+	if val := n.Cidrs.ValueString(); val != "" {
+		expose[CidrsKey] = val
+	}
+	return expose
+}
+
+func parseNestedExpose(value map[string]interface{}) nestedExpose {
+	// an empty expose structure, indicates exposure
+	// the values are optional.
+	resp := nestedExpose{}
+	if cidrs, ok := value[CidrsKey]; ok && cidrs != "" {
+		resp.Cidrs = types.StringValue(cidrs.(string))
+	}
+	if endpoints, ok := value[EndpointsKey]; ok && endpoints != "" {
+		resp.Endpoints = types.StringValue(endpoints.(string))
+	}
+	if spaces, ok := value[SpacesKey]; ok && spaces != "" {
+		resp.Spaces = types.StringValue(spaces.(string))
+	}
+	return resp
+}
+
+// Create is called when the provider must create a new resource. Config
+// and planned state values should be read from the
+// CreateRequest and new state values set on the CreateResponse.
+func (r *applicationResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	// Prevent panic if the provider has not been configured.
+	if r.client == nil {
+		addClientNotConfiguredError(&resp.Diagnostics, "application", "create")
+		return
+	}
+
+	var plan applicationResourceModel
+
+	// Read Terraform plan into the model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	r.trace("Create", applicationResourceModelForLogging(ctx, &plan))
+
+	modelInfo, err := r.client.Models.GetModelByName(plan.ModelName.ValueString())
 	if err != nil {
-		return diag.FromErr(err)
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to resolve model uuid, got error: %s", err))
+		return
 	}
 
-	name := d.Get("name").(string)
-	charm := d.Get("charm").([]interface{})[0].(map[string]interface{})
-	charmName := charm["name"].(string)
-	channel := charm["channel"].(string)
-	if channel == "" {
-		// if no channel was set we will request the stable by default
-		channel = "stable"
+	charms := []nestedCharm{}
+	resp.Diagnostics.Append(plan.Charm.ElementsAs(ctx, &charms, false)...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
-	series := charm["series"].(string)
-	units := d.Get("units").(int)
-	trust := d.Get("trust").(bool)
-	placement := d.Get("placement").(string)
-	// populate the config parameter
-	// terraform only permits a single type. We have to treat
-	// strings to have different types
-	configField := d.Get("config").(map[string]interface{})
+	planCharm := charms[0]
+	charmName := planCharm.Name.ValueString()
+	channel := "stable"
+	if !planCharm.Channel.IsUnknown() {
+		channel = planCharm.Channel.ValueString()
+	}
+	revision := -1
+	if !planCharm.Revision.IsUnknown() {
+		revision = int(planCharm.Revision.ValueInt64())
+	}
+	series := planCharm.Series.ValueString()
 
-	// if expose is nil, it was not defined
+	// TODO: investigate using map[string]string here and let
+	// terraform do the conversion, will help in CreateApplication.
+	configField := map[string]string{}
+	resp.Diagnostics.Append(plan.Config.ElementsAs(ctx, &configField, false)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// If the plan has an empty expose block, that has meaning.
+	// It's equivalent to using the expose flag on the juju cli.
+	// Be sure to understand if the expose block exists or not.
+	// Then to understand if any of the contained values exist.
 	var expose map[string]interface{} = nil
-	exposeField, exposeWasSet := d.GetOk("expose")
-	if exposeWasSet {
-		// this was set, by default get no fields there
-		expose = make(map[string]interface{}, 0)
-		aux := exposeField.([]interface{})[0]
-		if aux != nil {
-			expose = aux.(map[string]interface{})
+	if !plan.Expose.IsNull() {
+		var exposeSlice []nestedExpose
+		resp.Diagnostics.Append(plan.Expose.ElementsAs(ctx, &exposeSlice, false)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		r.trace("Creating application, expose values", map[string]interface{}{"exposeSlice": exposeSlice})
+		if len(exposeSlice) == 1 {
+			expose = exposeSlice[0].transformToMapStringInterface()
 		}
 	}
 
-	revision := charm["revision"].(int)
-	if _, exist := d.GetOk("charm.0.revision"); !exist {
-		revision = -1
-	}
-
-	var parsedConstraints constraints.Value = constraints.Value{}
-	readConstraints := d.Get("constraints").(string)
-	if readConstraints != "" {
-		parsedConstraints, err = constraints.Parse(readConstraints)
+	var parsedConstraints = constraints.Value{}
+	if plan.Constraints.ValueString() != "" {
+		parsedConstraints, err = constraints.Parse(plan.Constraints.ValueString())
 		if err != nil {
-			return diag.FromErr(err)
+			resp.Diagnostics.AddError("Input Error", fmt.Sprintf("Unable to parse constraints, go error: %s", err))
 		}
 	}
-
-	response, err := client.Applications.CreateApplication(&juju.CreateApplicationInput{
-		ApplicationName: name,
-		ModelUUID:       modelUUID,
+	createResp, err := r.client.Applications.CreateApplication(&juju.CreateApplicationInput{
+		ApplicationName: plan.ApplicationName.ValueString(),
+		ModelUUID:       modelInfo.UUID,
 		CharmName:       charmName,
 		CharmChannel:    channel,
 		CharmRevision:   revision,
 		CharmSeries:     series,
-		Units:           units,
+		Units:           int(plan.UnitCount.ValueInt64()),
 		Config:          configField,
 		Constraints:     parsedConstraints,
-		Trust:           trust,
+		Trust:           plan.Trust.ValueBool(),
 		Expose:          expose,
-		Placement:       placement,
+		Placement:       plan.Placement.ValueString(),
 	})
-
 	if err != nil {
-		return diag.FromErr(err)
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create application, got error: %s", err))
+		return
 	}
+	r.trace(fmt.Sprintf("create application resource %q", createResp.AppName))
 
-	// These values can be computed, and so set from the response.
-	if err = d.Set("name", response.AppName); err != nil {
-		return diag.FromErr(err)
+	readResp, err := r.client.Applications.ReadApplicationWithRetryOnNotFound(ctx, &juju.ReadApplicationInput{
+		ModelUUID: modelInfo.UUID,
+		ModelType: modelInfo.Type,
+		AppName:   createResp.AppName,
+	})
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read application, got error: %s", err))
+		return
 	}
+	r.trace(fmt.Sprintf("read application resource %q", createResp.AppName))
 
-	charm["revision"] = response.Revision
-	charm["series"] = response.Series
-	if err = d.Set("charm", []map[string]interface{}{charm}); err != nil {
-		return diag.FromErr(err)
+	// Save plan into Terraform state
+	plan.Constraints = types.StringValue(readResp.Constraints.String())
+	plan.Principal = types.BoolValue(readResp.Principal)
+	plan.Placement = types.StringValue(readResp.Placement)
+	plan.ApplicationName = types.StringValue(createResp.AppName)
+	planCharm.Revision = types.Int64Value(int64(readResp.Revision))
+	planCharm.Series = types.StringValue(readResp.Series)
+	planCharm.Channel = types.StringValue(readResp.Channel)
+	charmType := req.Config.Schema.GetBlocks()[CharmKey].(schema.ListNestedBlock).NestedObject.Type()
+	var dErr diag.Diagnostics
+	plan.Charm, dErr = types.ListValueFrom(ctx, charmType, []nestedCharm{planCharm})
+	if dErr.HasError() {
+		resp.Diagnostics.Append(dErr...)
+		return
 	}
+	plan.ID = types.StringValue(newAppID(plan.ModelName.ValueString(), createResp.AppName))
+	r.trace("Created", applicationResourceModelForLogging(ctx, &plan))
 
-	id := fmt.Sprintf("%s:%s", modelName, response.AppName)
-	d.SetId(id)
-
-	return resourceApplicationRead(ctx, d, meta)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
-func handleApplicationNotFoundError(err error, d *schema.ResourceData) diag.Diagnostics {
+func handleApplicationNotFoundError(ctx context.Context, err error, st *tfsdk.State) diag.Diagnostics {
 	if errors.As(err, &juju.ApplicationNotFoundError) {
 		// Application manually removed
-		d.SetId("")
+		st.RemoveResource(ctx)
 		return diag.Diagnostics{}
 	}
-
-	return diag.FromErr(err)
+	var diags diag.Diagnostics
+	diags.AddError("Not Found", err.Error())
+	return diags
 }
 
-func resourceApplicationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*juju.Client)
-	id := strings.Split(d.Id(), ":")
-	//If importing with an incorrect ID we need to catch and provide a user-friendly error
-	if len(id) != 2 {
-		return diag.Errorf("unable to parse model and application name from provided ID")
+// Read is called when the provider must read resource values in order
+// to update state. Planned state values should be read from the
+// ReadRequest and new state values set on the ReadResponse.
+// Take the juju api input from the ID, it may not exist in the plan.
+// Only set optional values if they exist.
+func (r *applicationResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	// Prevent panic if the provider has not been configured.
+	if r.client == nil {
+		addClientNotConfiguredError(&resp.Diagnostics, "application", "read")
+		return
+	}
+	var state applicationResourceModel
+
+	// Read Terraform prior state into the model
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
-	modelName, appName := id[0], id[1]
+	r.trace("Read", map[string]interface{}{
+		"ID": state.ID.ValueString(),
+	})
 
-	modelInfo, err := client.Models.GetModelByName(modelName)
+	modelName, appName, dErr := modelAppNameFromID(state.ID.ValueString())
+	if dErr.HasError() {
+		resp.Diagnostics.Append(dErr...)
+		return
+	}
+
+	modelInfo, err := r.client.Models.GetModelByName(modelName)
 	if err != nil {
-		return diag.FromErr(err)
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to get model info, got error: %s", err))
+		return
 	}
 
-	response, err := client.Applications.ReadApplication(&juju.ReadApplicationInput{
+	response, err := r.client.Applications.ReadApplication(&juju.ReadApplicationInput{
 		ModelUUID: modelInfo.UUID,
 		ModelType: modelInfo.Type,
 		AppName:   appName,
 	})
 	if err != nil {
-		return handleApplicationNotFoundError(err, d)
+		resp.Diagnostics.Append(handleApplicationNotFoundError(ctx, err, &resp.State)...)
+		return
 	}
-
 	if response == nil {
-		return nil
+		return
 	}
+	r.trace(fmt.Sprintf("read application resource %q", appName))
 
-	var charmList map[string]interface{}
-	_, exists := d.GetOk("charm")
-	if exists {
-		charmList = d.Get("charm").([]interface{})[0].(map[string]interface{})
-		charmList["name"] = response.Name
-		charmList["channel"] = response.Channel
-		charmList["revision"] = response.Revision
-		charmList["series"] = response.Series
-	} else {
-		charmList = map[string]interface{}{
-			"name":     response.Name,
-			"channel":  response.Channel,
-			"revision": response.Revision,
-			"series":   response.Series,
-		}
-	}
+	state.ApplicationName = types.StringValue(appName)
+	state.ModelName = types.StringValue(modelName)
 
-	if err = d.Set("charm", []map[string]interface{}{charmList}); err != nil {
-		return diag.FromErr(err)
-	}
+	// Use the response to fill in state
+	state.Placement = types.StringValue(response.Placement)
+	state.Principal = types.BoolValue(response.Principal)
+	state.UnitCount = types.Int64Value(int64(response.Units))
+	state.Trust = types.BoolValue(response.Trust)
 
-	if err = d.Set("model", modelName); err != nil {
-		return diag.FromErr(err)
+	// state requiring transformation
+	dataCharm := nestedCharm{
+		Name:     types.StringValue(response.Name),
+		Channel:  types.StringValue(response.Channel),
+		Revision: types.Int64Value(int64(response.Revision)),
+		Series:   types.StringValue(response.Series),
 	}
-	if err = d.Set("name", appName); err != nil {
-		return diag.FromErr(err)
-	}
-	if err = d.Set("units", response.Units); err != nil {
-		return diag.FromErr(err)
-	}
-
-	if err = d.Set("trust", response.Trust); err != nil {
-		return diag.FromErr(err)
-	}
-
-	if err = d.Set("principal", response.Principal); err != nil {
-		return diag.FromErr(err)
+	charmType := req.State.Schema.GetBlocks()[CharmKey].(schema.ListNestedBlock).NestedObject.Type()
+	state.Charm, dErr = types.ListValueFrom(ctx, charmType, []nestedCharm{dataCharm})
+	if dErr.HasError() {
+		resp.Diagnostics.Append(dErr...)
+		return
 	}
 
 	// constraints do not apply to subordinate applications.
 	if response.Principal {
-		if err = d.Set("constraints", response.Constraints.String()); err != nil {
-			return diag.FromErr(err)
-		}
+		state.Constraints = types.StringValue(response.Constraints.String())
 	}
-
-	var exposeValue []map[string]interface{} = nil
+	exposeType := req.State.Schema.GetBlocks()[ExposeKey].(schema.ListNestedBlock).NestedObject.Type()
 	if response.Expose != nil {
-		exposeValue = []map[string]interface{}{response.Expose}
-	}
-	if err = d.Set("expose", exposeValue); err != nil {
-		return diag.FromErr(err)
+		exp := parseNestedExpose(response.Expose)
+		state.Expose, dErr = types.ListValueFrom(ctx, exposeType, []nestedExpose{exp})
+		if dErr.HasError() {
+			resp.Diagnostics.Append(dErr...)
+			return
+		}
+	} else {
+		state.Expose = types.ListNull(exposeType)
 	}
 
-	// We focus on those config entries that
-	// are not the default value. If the value was the same
-	// we ignore it. If no changes were made, jump to the
-	// next step.
-	// Terraform does not allow to have several types
-	// for a schema attribute. We have to transform the string
-	// with the potential type we want to compare with.
-	previousConfig := d.Get("config").(map[string]interface{})
+	// we only set changes if there is any difference between
+	// the previous and the current config values
+	configType := req.State.Schema.GetAttributes()[ConfigKey].(schema.MapAttribute).ElementType
+	state.Config, dErr = r.configureConfigData(ctx, configType, state.Config, response.Config)
+	if dErr.HasError() {
+		resp.Diagnostics.Append(dErr...)
+		return
+	}
+
+	r.trace("Found", applicationResourceModelForLogging(ctx, &state))
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *applicationResource) configureConfigData(ctx context.Context, configType attr.Type, config types.Map, respCfg map[string]juju.ConfigEntry) (types.Map, diag.Diagnostics) {
+	// We focus on those config entries that are not the default value.
+	// If the value was the same we ignore it. If no changes were made,
+	// jump to the next step.
+	var previousConfig map[string]string
+	diagErr := config.ElementsAs(ctx, &previousConfig, false)
+	if diagErr.HasError() {
+		r.trace("configureConfigData exit A")
+		return types.Map{}, diagErr
+	}
+	if previousConfig == nil {
+		previousConfig = make(map[string]string)
+	}
 	// known previously
 	// update the values from the previous config
 	changes := false
-	for k, v := range response.Config {
+	for k, v := range respCfg {
 		// Add if the value has changed from the previous state
 		if previousValue, found := previousConfig[k]; found {
 			if !juju.EqualConfigEntries(v, previousValue) {
@@ -349,151 +553,176 @@ func resourceApplicationRead(ctx context.Context, d *schema.ResourceData, meta i
 			changes = true
 		}
 	}
-	// we only set changes if there is any difference between
-	// the previous and the current config values
 	if changes {
-		if err = d.Set("config", previousConfig); err != nil {
-			return diag.FromErr(err)
-		}
+		return types.MapValueFrom(ctx, configType, previousConfig)
 	}
-
-	if err = d.Set("placement", response.Placement); err != nil {
-		return diag.FromErr(err)
-	}
-
-	return nil
+	return config, nil
 }
 
-func resourceApplicationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*juju.Client)
-
-	appName := d.Get("name").(string)
-	modelName := d.Get("model").(string)
-	modelInfo, err := client.Models.GetModelByName(modelName)
-	if err != nil {
-		return diag.FromErr(err)
+// Update is called to update the state of the resource. Config, planned
+// state, and prior state values should be read from the
+// UpdateRequest and new state values set on the UpdateResponse.
+func (r *applicationResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	// Prevent panic if the provider has not been configured.
+	if r.client == nil {
+		addClientNotConfiguredError(&resp.Diagnostics, "application", "update")
+		return
 	}
+	var plan, state applicationResourceModel
+
+	// Read Terraform prior state data into the model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	r.trace("Proposed update", applicationResourceModelForLogging(ctx, &plan))
+	r.trace("Current state", applicationResourceModelForLogging(ctx, &state))
+
+	modelInfo, err := r.client.Models.GetModelByName(state.ModelName.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to get model info, got error: %s", err))
+		return
+	}
+
 	updateApplicationInput := juju.UpdateApplicationInput{
 		ModelUUID: modelInfo.UUID,
 		ModelType: modelInfo.Type,
-		AppName:   appName,
+		AppName:   state.ApplicationName.ValueString(),
 	}
 
-	if d.HasChange("units") {
-		units := d.Get("units").(int)
-		updateApplicationInput.Units = &units
+	if !plan.ApplicationName.IsUnknown() && !plan.ApplicationName.Equal(state.ApplicationName) {
+		resp.Diagnostics.AddWarning("Unsupported", "unable to update application name")
 	}
 
-	if d.HasChange("trust") {
-		trust := d.Get("trust").(bool)
-		updateApplicationInput.Trust = &trust
+	if !plan.UnitCount.Equal(state.UnitCount) {
+		updateApplicationInput.Units = intPtr(plan.UnitCount)
 	}
 
-	if d.HasChange("expose") {
-		oldExpose, newExpose := d.GetChange("expose")
-		_, exposeWasSet := d.GetOk("expose")
+	if !plan.Trust.Equal(state.Trust) {
+		updateApplicationInput.Trust = plan.Trust.ValueBoolPointer()
+	}
 
-		expose, unexpose := computeExposeDeltas(oldExpose, newExpose, exposeWasSet)
+	if !plan.Charm.Equal(state.Charm) {
+		var planCharms, stateCharms []nestedCharm
+		resp.Diagnostics.Append(plan.Charm.ElementsAs(ctx, &planCharms, false)...)
+		resp.Diagnostics.Append(state.Charm.ElementsAs(ctx, &stateCharms, false)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		planCharm := planCharms[0]
+		stateCharm := stateCharms[0]
+		if !planCharm.Channel.Equal(stateCharm.Channel) {
+			updateApplicationInput.Channel = planCharm.Channel.ValueString()
+		}
+		if !planCharm.Series.Equal(stateCharm.Series) {
+			updateApplicationInput.Series = planCharm.Series.ValueString()
+		}
+		if !planCharm.Revision.Equal(stateCharm.Revision) {
+			updateApplicationInput.Revision = intPtr(planCharm.Revision)
+		}
+	}
 
+	if !plan.Expose.Equal(state.Expose) {
+		expose, unexpose, exposeDiags := r.computeExposeDeltas(ctx, state.Expose, plan.Expose)
+		resp.Diagnostics.Append(exposeDiags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 		updateApplicationInput.Expose = expose
 		updateApplicationInput.Unexpose = unexpose
 	}
 
-	if d.HasChange("charm.0.revision") {
-		revision := d.Get("charm.0.revision").(int)
-		updateApplicationInput.Revision = &revision
-	}
-
-	if d.HasChange("charm.0.series") {
-		series := d.Get("charm.0.series").(string)
-		updateApplicationInput.Series = series
-	}
-
-	if d.HasChange("charm.0.channel") {
-		channel := d.Get("charm.0.channel").(string)
-		updateApplicationInput.Channel = channel
-	}
-
-	if d.HasChange("config") {
-		oldConfig, newConfig := d.GetChange("config")
-		oldConfigMap := oldConfig.(map[string]interface{})
-		newConfigMap := newConfig.(map[string]interface{})
-		for k, v := range newConfigMap {
+	if !plan.Config.Equal(state.Config) {
+		planConfigMap := map[string]string{}
+		stateConfigMap := map[string]string{}
+		resp.Diagnostics.Append(plan.Config.ElementsAs(ctx, &planConfigMap, false)...)
+		resp.Diagnostics.Append(state.Config.ElementsAs(ctx, &stateConfigMap, false)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		for k, v := range planConfigMap {
 			// we've lost the type of the config value. We compare the string
 			// values.
-			oldEntry := fmt.Sprintf("%#v", oldConfigMap[k])
+			oldEntry := fmt.Sprintf("%#v", stateConfigMap[k])
 			newEntry := fmt.Sprintf("%#v", v)
 			if oldEntry != newEntry {
 				if updateApplicationInput.Config == nil {
 					// initialize just in case
-					updateApplicationInput.Config = make(map[string]interface{})
+					updateApplicationInput.Config = make(map[string]string)
 				}
 				updateApplicationInput.Config[k] = v
 			}
 		}
 	}
 
-	if d.HasChange("constraints") {
-		_, newConstraints := d.GetChange("constraints")
-		appConstraints, err := constraints.Parse(newConstraints.(string))
+	if !plan.Constraints.Equal(state.Constraints) {
+		appConstraints, err := constraints.Parse(plan.Constraints.ValueString())
 		if err != nil {
-			return diag.FromErr(err)
+			resp.Diagnostics.AddError("Conversion", fmt.Sprintf("Unable to parse plan constraints, got error: %s", err))
 		}
 		updateApplicationInput.Constraints = &appConstraints
 	}
 
-	err = client.Applications.UpdateApplication(&updateApplicationInput)
-	if err != nil {
-		return diag.FromErr(err)
+	if err = r.client.Applications.UpdateApplication(&updateApplicationInput); err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update application resource, got error: %s", err))
+		return
 	}
 
-	return resourceApplicationRead(ctx, d, meta)
+	plan.ID = types.StringValue(newAppID(plan.ModelName.ValueString(), plan.ApplicationName.ValueString()))
+	r.trace("Updated", applicationResourceModelForLogging(ctx, &plan))
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
 // computeExposeDeltas computes the differences between the previously
 // stored expose value and the current one. The valueSet argument is used
 // to indicate whether the value was already set or not in the latest
 // read of the plan.
-func computeExposeDeltas(oldExpose interface{}, newExpose interface{}, valueSet bool) (map[string]interface{}, []string) {
-	var old map[string]interface{} = nil
-	var new map[string]interface{} = nil
+func (r *applicationResource) computeExposeDeltas(ctx context.Context, stateExpose types.List, planExpose types.List) (map[string]interface{}, []string, diag.Diagnostics) {
+	diags := diag.Diagnostics{}
+	if planExpose.IsNull() {
+		// if plan is nil we unexpose everything via
+		// an non empty list.
+		return nil, []string{""}, diags
+	}
+	if stateExpose.IsNull() {
+		// State has no expose, but new plan does, setup for expose
+		var planExposeSlice []nestedExpose
+		diags.Append(planExpose.ElementsAs(ctx, &planExposeSlice, false)...)
+		if diags.HasError() {
+			return nil, []string{}, diags
+		}
+		if len(planExposeSlice) == 1 {
+			return planExposeSlice[0].transformToMapStringInterface(), []string{}, diags
+		}
+		diags.AddError("Provider error", "plan expose has no objects, should be impossible")
+		return nil, []string{}, diags
+	}
 
-	if oldExpose != nil {
-		aux := oldExpose.([]interface{})
-		if len(aux) != 0 && aux[0] != nil {
-			old = aux[0].(map[string]interface{})
-		}
+	var planNestedExpose, stateNestedExpose []nestedExpose
+	diags.Append(stateExpose.ElementsAs(ctx, &stateNestedExpose, false)...)
+	if diags.HasError() {
+		return nil, []string{}, diags
 	}
-	if newExpose != nil {
-		aux := newExpose.([]interface{})
-		if len(aux) != 0 && aux[0] != nil {
-			new = aux[0].(map[string]interface{})
-		}
-	}
-	if new == nil && valueSet {
-		new = make(map[string]interface{})
+	diags.Append(planExpose.ElementsAs(ctx, &planNestedExpose, false)...)
+	if diags.HasError() {
+		return nil, []string{}, diags
 	}
 
 	toExpose := make(map[string]interface{})
 	toUnexpose := make([]string, 0)
-	// if new is nil we unexpose everything
-	if new == nil {
-		// set all the endpoints to be unexposed
-		toUnexpose = append(toUnexpose, old["endpoints"].(string))
-		return nil, toUnexpose
-	}
 
-	if old != nil {
-		old = make(map[string]interface{})
-	}
+	plan := planNestedExpose[0].transformToMapStringInterface()
+	state := stateNestedExpose[0].transformToMapStringInterface()
 
-	// if we have new endpoints we have to expose them
-	for endpoint, v := range new {
-		_, found := old[endpoint]
+	// if we have plan endpoints we have to expose them
+	for endpoint, v := range plan {
+		_, found := state[endpoint]
 		if found {
 			// this was already set
 			// If it is different, unexpose and then expose
-			if v != old[endpoint] {
+			if v != state[endpoint] {
 				toUnexpose = append(toUnexpose, endpoint)
 				toExpose[endpoint] = v
 			}
@@ -502,30 +731,104 @@ func computeExposeDeltas(oldExpose interface{}, newExpose interface{}, valueSet 
 			toExpose[endpoint] = v
 		}
 	}
-	return toExpose, toUnexpose
+	return toExpose, toUnexpose, diags
 }
 
+// Delete is called when the provider must delete the resource. Config
+// values may be read from the DeleteRequest.
+//
+// If execution completes without error, the framework will automatically
+// call DeleteResponse.State.RemoveResource(), so it can be omitted
+// from provider logic.
+//
 // Juju refers to deletion as "destroy" so we call the Destroy function of our client here rather than delete
 // This function remains named Delete for parity across the provider and to stick within terraform naming conventions
-func resourceApplicationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*juju.Client)
-
-	modelName := d.Get("model").(string)
-	modelUUID, err := client.Models.ResolveModelUUID(modelName)
-	if err != nil {
-		return diag.FromErr(err)
+func (r *applicationResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	// Prevent panic if the provider has not been configured.
+	if r.client == nil {
+		addClientNotConfiguredError(&resp.Diagnostics, "application", "delete")
+		return
+	}
+	var state applicationResourceModel
+	// Read Terraform prior state state into the model
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
-	var diags diag.Diagnostics
+	r.trace("Deleting", map[string]interface{}{
+		"ID": state.ID.ValueString(),
+	})
 
-	err = client.Applications.DestroyApplication(&juju.DestroyApplicationInput{
-		ApplicationName: d.Get("name").(string),
+	modelName, appName, dErr := modelAppNameFromID(state.ID.ValueString())
+	if dErr.HasError() {
+		resp.Diagnostics.Append(dErr...)
+	}
+
+	modelUUID, err := r.client.Models.ResolveModelUUID(modelName)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to get model uuid, got error: %s", err))
+		return
+	}
+
+	err = r.client.Applications.DestroyApplication(&juju.DestroyApplicationInput{
+		ApplicationName: appName,
 		ModelUUID:       modelUUID,
 	})
 	if err != nil {
-		return diag.FromErr(err)
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete application, got error: %s", err))
+	}
+	r.trace(fmt.Sprintf("deleted application resource %q", state.ID.ValueString()))
+}
+
+// ImportState is called when the provider must import the state of a
+// resource instance. This method must return enough state so the Read
+// method can properly refresh the full resource.
+//
+// If setting an attribute with the import identifier, it is recommended
+// to use the ImportStatePassthroughID() call in this method.
+func (r *applicationResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+// ID is '<model name>:<app name>'
+func newAppID(model, app string) string {
+	return fmt.Sprintf("%s:%s", model, app)
+}
+
+func modelAppNameFromID(value string) (string, string, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	id := strings.Split(value, ":")
+	//If importing with an incorrect ID we need to catch and provide a user-friendly error
+	if len(id) != 2 {
+		diags.AddError("Malformed ID", fmt.Sprintf("unable to parse model and application name from provided ID: %q", value))
+		return "", "", diags
+	}
+	return id[0], id[1], diags
+}
+
+func (r *applicationResource) trace(msg string, additionalFields ...map[string]interface{}) {
+	if r.subCtx == nil {
+		return
 	}
 
-	d.SetId("")
-	return diags
+	//SubsystemTrace(subCtx, "my-subsystem", "hello, world", map[string]interface{}{"foo": 123})
+	// Output:
+	// {"@level":"trace","@message":"hello, world","@module":"provider.my-subsystem","foo":123}
+	tflog.SubsystemTrace(r.subCtx, LogResourceApplication, msg, additionalFields...)
+}
+
+func applicationResourceModelForLogging(_ context.Context, app *applicationResourceModel) map[string]interface{} {
+	value := map[string]interface{}{
+		"application-name": app.ApplicationName.ValueString(),
+		"charm":            app.Charm.String(),
+		"constraints":      app.Constraints.ValueString(),
+		"model":            app.ModelName.ValueString(),
+		"placement":        app.Placement.ValueString(),
+		"principal":        app.Principal.ValueBoolPointer(),
+		"expose":           app.Expose.String(),
+		"trust":            app.Trust.ValueBoolPointer(),
+		"units":            app.UnitCount.ValueInt64(),
+	}
+	return value
 }

--- a/internal/provider/resource_integration_test.go
+++ b/internal/provider/resource_integration_test.go
@@ -60,7 +60,6 @@ resource "juju_model" "this" {
 }
 
 resource "juju_application" "one" {
-    provider = oldjuju
 	model = juju_model.this.name
 	name  = "one" 
 	
@@ -71,8 +70,7 @@ resource "juju_application" "one" {
 }
 
 resource "juju_application" "two" {
-    provider = oldjuju
-	model = juju_model.this.name
+ 	model = juju_model.this.name
 	name  = "two"
 
 	charm {
@@ -140,8 +138,7 @@ resource "juju_model" "a" {
 }
 
 resource "juju_application" "a" {
-    provider = oldjuju
-	model = juju_model.a.name
+ 	model = juju_model.a.name
 	name  = "a" 
 	
 	charm {
@@ -156,8 +153,7 @@ resource "juju_model" "b" {
 }
 
 resource "juju_application" "b" {
-    provider = oldjuju
-	model = juju_model.b.name
+ 	model = juju_model.b.name
 	name  = "b"
 	
 	charm {

--- a/internal/provider/resource_offer_test.go
+++ b/internal/provider/resource_offer_test.go
@@ -56,8 +56,7 @@ resource "juju_model" "this" {
 }
 
 resource "juju_application" "this" {
-    provider = oldjuju
-	model = juju_model.this.name
+ 	model = juju_model.this.name
 	name  = "this"
 
 	charm {
@@ -84,7 +83,6 @@ resource "juju_model" "this" {
 }
 
 resource "juju_application" "this" {
-    provider = oldjuju
 	model = juju_model.this.name
 	name  = "this"
 
@@ -106,7 +104,6 @@ resource "juju_model" "that" {
 }
 
 resource "juju_application" "that" {
-    provider = oldjuju
 	model = juju_model.that.name
 	name = "that"
 


### PR DESCRIPTION
Note - there are 2 acceptance tests failing right now, though I'm not sure why. I cannot reproduce outside of the 

## Description

Convert the application resource from using the terraform sdk to the newer framework. There is a small bug fix related to exposing an application without an application name specified in the plan. 

This PR also adds use the `tflog` package for logging including using a tflog subsystem for granularity. Each resource and data source should have its own subsystem. For applications, log line will include `"@module":"juju.resource-application"`. To setup: `export TF_LOG_PROVIDER=TRACE ; export TF_LOG_PATH=./terraform.log`. Without the log path, logging will be printed within the normal terraform output.

Includes a fix for:
#274 Provider panics when generating plan

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Maintenance work (repository related, like Github actions, or revving the Go version, etc.)

## Environment

- Juju controller version: 2.9.43

- Terraform version: 0.8.0 next

## QA steps

Here is a plan to test with. Also do import testing.

```tf
terraform {
  required_providers {
    juju = {
      version = ">= 0.7.0"
      source  = "juju/juju"
    }
  }
}

provider "juju" {
}

resource "juju_model" "testmodel" {
  name = "machinetest"
}

resource "juju_application" "application_example" {
  model = juju_model.testmodel.name
  charm {
    name = "juju-qa-test"
  }
  units = 2
  expose {}
  config = {
	status = "application resource testing"
        foo-file = true
        skill = 42
  }
}
```

## Notes
JUJU-4175
JUJU-4500
