### PR TITLE
[JUJU-4441] Fix app name incorrect useage

### DIFF
--- a/internal/juju/applications.go
+++ b/internal/juju/applications.go
@@ -318,7 +318,7 @@ func (c applicationsClient) CreateApplication(input *CreateApplicationInput) (*C
 		Origin: resultOrigin,
 	}
 
-	resources, err := c.processResources(charmsAPIClient, resourcesAPIClient, charmID, input.ApplicationName)
+	resources, err := c.processResources(charmsAPIClient, resourcesAPIClient, charmID, appName)
 	if err != nil {
 		return nil, err
 	}
@@ -378,7 +378,7 @@ func (c applicationsClient) CreateApplication(input *CreateApplicationInput) (*C
 
 	// If we have managed to deploy something, now we have
 	// to check if we have to expose something
-	err = c.processExpose(applicationAPIClient, input.ApplicationName, input.Expose)
+	err = c.processExpose(applicationAPIClient, appName, input.Expose)
 	return &CreateApplicationResponse{
 		AppName:  appName,
 		Revision: *origin.Revision,

--- a/internal/provider/resource_application_test.go
+++ b/internal/provider/resource_application_test.go
@@ -240,7 +240,6 @@ func testAccResourceApplicationUpdates_sdk2_framework_migrate(modelName string, 
           provider = oldjuju
 		  model = juju_model.this.name
 		  units = %d
-		  name = "test-app"
 		  charm {
 			name     = "jameinel-ubuntu-lite"
 		  }
@@ -264,7 +263,6 @@ func testAccResourceApplicationUpdates_sdk2_framework_migrate(modelName string, 
           provider = oldjuju
 		  model = juju_model.this.name
 		  units = %d
-		  name = "test-app"
 		  charm {
 			name     = "hello-kubecon"
 		  }


### PR DESCRIPTION

## Description

Fixes a bug where not providing an optional application name failed to expose or setup charm resources.

Fixes: 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Environment

- Juju controller version: 2.9.44

- Terraform version: 0.9.0+

## QA steps

1. terraform init   && terraform plan && terraform apply
2. terraform init   && terraform plan && terraform apply
The second time produces no changes.

The `juju-qa-test` charm has resources.

```tf
terraform {
  required_providers {
    juju = {
      version = ">= 0.7.0"
      source  = "juju/juju"
    }
  }
}

provider "juju" {
}

resource "juju_model" "testmodel" {
  name = "machinetest"
}

resource "juju_application" "application_example" {
  model = juju_model.testmodel.name
  charm {
    name = "juju-qa-test"
  }
  units = 2
  expose {}
}
```

