### PR TITLE
[JUJU-4171] Create machine data source in framework

### DIFF
--- a/docs/data-sources/machine.md
+++ b/docs/data-sources/machine.md
@@ -26,7 +26,3 @@ data "juju_machine" "this" {
 
 - `machine_id` (String) The Juju id of the machine.
 - `model` (String) The name of the model.
-
-### Read-Only
-
-- `id` (String) The ID of this resource.

--- a/internal/provider/data_source_machine.go
+++ b/internal/provider/data_source_machine.go
@@ -2,59 +2,126 @@ package provider
 
 import (
 	"context"
+	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	"github.com/juju/terraform-provider-juju/internal/juju"
 )
 
-func dataSourceMachine() *schema.Resource {
-	return &schema.Resource{
+// Ensure provider defined types fully satisfy framework interfaces.
+var _ datasource.DataSource = &machineDataSource{}
+
+func NewMachineDataSource() datasource.DataSourceWithConfigure {
+	return &machineDataSource{}
+}
+
+type machineDataSource struct {
+	client *juju.Client
+
+	// context for the logging subsystem.
+	subCtx context.Context
+}
+
+type machineDataSourceModel struct {
+	Model     types.String `tfsdk:"model"`
+	MachineID types.String `tfsdk:"machine_id"`
+}
+
+// Metadata returns the full data source name as used in terraform plans.
+func (d *machineDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_machine"
+}
+
+func (d *machineDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
 		Description: "A data source representing a Juju Machine.",
-		ReadContext: dataSourceMachineRead,
-		Schema: map[string]*schema.Schema{
-			"model": {
+		Attributes: map[string]schema.Attribute{
+			"model": schema.StringAttribute{
 				Description: "The name of the model.",
-				Type:        schema.TypeString,
 				Required:    true,
 			},
-			"machine_id": {
+			"machine_id": schema.StringAttribute{
 				Description: "The Juju id of the machine.",
-				Type:        schema.TypeString,
 				Required:    true,
 			},
 		},
 	}
 }
 
-func dataSourceMachineRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*juju.Client)
+// Configure enables provider-level data or clients to be set in the
+// provider-defined DataSource type. It is separately executed for each
+// ReadDataSource RPC.
+func (d *machineDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	// Prevent panic if the provider has not been configured.
+	if req.ProviderData == nil {
+		return
+	}
 
-	modelName := d.Get("model").(string)
-	machine_id := d.Get("machine_id").(string)
+	client, ok := req.ProviderData.(*juju.Client)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *juju.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
 
-	model, err := client.Models.GetModelByName(modelName)
+	d.client = client
+	d.subCtx = tflog.NewSubsystem(ctx, LogDataSourceMachine)
+}
+
+// Read is called when the provider must read data source values in
+// order to update state. Config values should be read from the
+// ReadRequest and new state values set on the ReadResponse.
+func (d *machineDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	// Prevent panic if the provider has not been configured.
+	if d.client == nil {
+		addDSClientNotConfiguredError(&resp.Diagnostics, "machine")
+		return
+	}
+
+	var data machineDataSourceModel
+
+	// Read Terraform configuration data into the model.
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Get current juju machine data source values.
+	model, err := d.client.Models.GetModelByName(data.Model.ValueString())
 	if err != nil {
-		return diag.FromErr(err)
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read model, got error: %s", err))
+		return
+	}
+	machine_id := data.MachineID.ValueString()
+	d.trace(fmt.Sprintf("reading juju machine %q data source", machine_id))
+
+	// Verify the machine exists in the model provided
+	if _, err = d.client.Machines.ReadMachine(
+		juju.ReadMachineInput{
+			ModelUUID: model.UUID,
+			MachineId: machine_id,
+		},
+	); err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read machine %q, got error: %s", machine_id, err))
+		return
 	}
 
-	machine, err := client.Machines.ReadMachine(&juju.ReadMachineInput{
-		ModelUUID: model.UUID,
-		MachineId: machine_id,
-	})
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
 
-	if err != nil {
-		return diag.FromErr(err)
+func (d *machineDataSource) trace(msg string, additionalFields ...map[string]interface{}) {
+	if d.subCtx == nil {
+		return
 	}
 
-	d.SetId(machine.MachineId)
-	if err = d.Set("model", model.Name); err != nil {
-		return diag.FromErr(err)
-	}
-	if err = d.Set("machine_id", machine.MachineId); err != nil {
-		return diag.FromErr(err)
-	}
-
-	return nil
+	//SubsystemTrace(subCtx, "datasource-machine", "hello, world", map[string]interface{}{"foo": 123})
+	// Output:
+	// {"@level":"trace","@message":"hello, world","@module":"juju.datasource-machine","foo":123}
+	tflog.SubsystemTrace(d.subCtx, LogDataSourceMachine, msg, additionalFields...)
 }

--- a/internal/provider/data_source_machine_test.go
+++ b/internal/provider/data_source_machine_test.go
@@ -19,7 +19,7 @@ func TestAcc_DataSourceMachine_sdk2_framework_migrate(t *testing.T) {
 		ProtoV6ProviderFactories: muxProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceMachine_sdk2_framework_migrate(t, modelName),
+				Config: testAccDataSourceMachine_sdk2_framework_migrate(modelName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.juju_machine.machine", "model", modelName),
 				),
@@ -28,7 +28,7 @@ func TestAcc_DataSourceMachine_sdk2_framework_migrate(t *testing.T) {
 	})
 }
 
-func testAccDataSourceMachine_sdk2_framework_migrate(t *testing.T, modelName string) string {
+func testAccDataSourceMachine_sdk2_framework_migrate(modelName string) string {
 	return fmt.Sprintf(`
 provider oldjuju {}
 
@@ -44,7 +44,6 @@ resource "juju_machine" "machine" {
 }
 
 data "juju_machine" "machine" {
-  provider = oldjuju
   model = juju_model.model.name
   machine_id = juju_machine.machine.machine_id
 }`, modelName)
@@ -66,7 +65,7 @@ func TestAcc_DataSourceMachine_Stable(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceMachine_Stable(t, modelName),
+				Config: testAccDataSourceMachine_Stable(modelName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.juju_machine.machine", "model", modelName),
 				),
@@ -75,7 +74,7 @@ func TestAcc_DataSourceMachine_Stable(t *testing.T) {
 	})
 }
 
-func testAccDataSourceMachine_Stable(t *testing.T, modelName string) string {
+func testAccDataSourceMachine_Stable(modelName string) string {
 	return fmt.Sprintf(`
 resource "juju_model" "model" {
   name = %q

--- a/internal/provider/helpers.go
+++ b/internal/provider/helpers.go
@@ -23,3 +23,11 @@ func addClientNotConfiguredError(diag *diag.Diagnostics, resource, method string
 			"Please report this issue to the provider developers.", method, resource),
 	)
 }
+
+func addDSClientNotConfiguredError(diag *diag.Diagnostics, dataSource string) {
+	diag.AddError(
+		"Provider Error, Client Not Configured",
+		fmt.Sprintf("Unable to read data source %s. Expected configured Juju Client. "+
+			"Please report this issue to the provider developers.", dataSource),
+	)
+}

--- a/internal/provider/helpers.go
+++ b/internal/provider/helpers.go
@@ -1,0 +1,25 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provider
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+)
+
+// model names for logging
+// @module=juju.<subsystem>
+// e.g.:
+//
+//	@module=juju.resource-application
+const LogDataSourceMachine = "datasource-machine"
+
+func addClientNotConfiguredError(diag *diag.Diagnostics, resource, method string) {
+	diag.AddError(
+		"Provider Error, Client Not Configured",
+		fmt.Sprintf("Unable to %s %s resource. Expected configured Juju Client. "+
+			"Please report this issue to the provider developers.", method, resource),
+	)
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -61,8 +61,7 @@ func New(version string) func() *schema.Provider {
 				},
 			},
 			DataSourcesMap: map[string]*schema.Resource{
-				"juju_machine": dataSourceMachine(),
-				"juju_offer":   dataSourceOffer(),
+				"juju_offer": dataSourceOffer(),
 			},
 			ResourcesMap: map[string]*schema.Resource{
 				"juju_application": resourceApplication(),
@@ -373,8 +372,8 @@ func (p *jujuProvider) Resources(ctx context.Context) []func() resource.Resource
 // the Metadata method. All data sources must have unique names.
 func (p *jujuProvider) DataSources(ctx context.Context) []func() datasource.DataSource {
 	return []func() datasource.DataSource{
+		func() datasource.DataSource { return NewMachineDataSource() },
 		func() datasource.DataSource { return NewModelDataSource() },
-		//func() datasource.DataSource { return NewMachineDataSource() },
 		//func() datasource.DataSource { return NewOfferDataSource() },
 	}
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -403,11 +403,3 @@ func checkClientErr(err error, config juju.Configuration) frameworkdiag.Diagnost
 	diags.AddError("Client Error", err.Error())
 	return diags
 }
-
-func addClientNotConfiguredError(diag *frameworkdiag.Diagnostics, resource, method string) {
-	diag.AddError(
-		"Provider Error, Client Not Configured",
-		fmt.Sprintf("Unable to %s %s resource. Expected configured Juju Client. "+
-			"Please report this issue to the provider developers.", method, resource),
-	)
-}

--- a/internal/provider/resource_machine.go
+++ b/internal/provider/resource_machine.go
@@ -318,15 +318,12 @@ func (r *machineResource) Read(ctx context.Context, req resource.ReadRequest, re
 		return
 	}
 
-	response, err := r.client.Machines.ReadMachine(&juju.ReadMachineInput{
+	response, err := r.client.Machines.ReadMachine(juju.ReadMachineInput{
 		ModelUUID: modelUUID,
 		MachineId: machineID,
 	})
 	if err != nil {
 		resp.Diagnostics.Append(handleMachineNotFoundError(ctx, err, &resp.State)...)
-		return
-	}
-	if response == nil {
 		return
 	}
 	tflog.Trace(ctx, fmt.Sprintf("read machine resource %q", machineID))


### PR DESCRIPTION

## Description

Update the machine data source to use the terraform framework rather than the sdk. Update logging to use the tflog subsystems. Updated the Read code of the juju client to not require pointer arguments, there is no need.

Added a helpers.go file for various methods and constants. Has overlap with a commit in #265. 

Fixes: 

## Type of change


- Maintenance work (repository related, like Github actions, or revving the Go version, etc.)

## Environment

- Juju controller version: 2.9.45

- Terraform version: 0.8.0+

## QA steps

1. juju add-model datatest
2. juju add-machine

```tf
terraform {
  required_providers {
    juju = {
      version = ">= 0.9.0"
      source  = "juju/juju"
    }
  }
}

provider "juju" {
}

data "juju_model" "testmodel" {
  name = "datatest"
}

resource "juju_application" "app" {
  model = data.juju_model.testmodel.name
  charm {
    name = "ubuntu"
    series = "focal"
  }
  placement = data.juju_machine.my-machine.machine_id
}

data "juju_machine" "my-machine" {
  model = data.juju_model.testmodel.name
  machine_id  = 1
}
```

