### PR TITLE
[JUJU-4482] Remove unused clients

### DIFF
--- a/internal/juju/applications.go
+++ b/internal/juju/applications.go
@@ -187,9 +187,6 @@ func (c applicationsClient) CreateApplication(input *CreateApplicationInput) (*C
 	charmsAPIClient := apicharms.NewClient(conn)
 	defer charmsAPIClient.Close()
 
-	clientAPIClient := apiclient.NewClient(conn)
-	defer clientAPIClient.Close()
-
 	applicationAPIClient := apiapplication.NewClient(conn)
 	defer applicationAPIClient.Close()
 
@@ -508,9 +505,6 @@ func (c applicationsClient) ReadApplication(input *ReadApplicationInput) (*ReadA
 
 	applicationAPIClient := apiapplication.NewClient(conn)
 	defer applicationAPIClient.Close()
-
-	charmsAPIClient := apicharms.NewClient(conn)
-	defer charmsAPIClient.Close()
 
 	clientAPIClient := apiclient.NewClient(conn)
 	defer clientAPIClient.Close()

--- a/internal/juju/credentials.go
+++ b/internal/juju/credentials.go
@@ -250,9 +250,6 @@ func (c *credentialsClient) UpdateCredential(input UpdateCredentialInput) error 
 		return err
 	}
 
-	client := cloudapi.NewClient(conn)
-	defer client.Close()
-
 	currentUser := strings.TrimPrefix(conn.AuthTag().String(), PrefixUser)
 
 	cloudCredTag, err := GetCloudCredentialTag(cloudName, currentUser, credentialName)
@@ -274,6 +271,9 @@ func (c *credentialsClient) UpdateCredential(input UpdateCredentialInput) error 
 	}
 
 	if input.ControllerCredential {
+		client := cloudapi.NewClient(conn)
+		defer client.Close()
+
 		if _, err := client.UpdateCredentialsCheckModels(*cloudCredTag, cloudCredential); err != nil {
 			return err
 		}

--- a/internal/juju/integrations.go
+++ b/internal/juju/integrations.go
@@ -118,9 +118,6 @@ func (c integrationsClient) ReadIntegration(input *IntegrationInput) (*ReadInteg
 		return nil, err
 	}
 
-	client := apiapplication.NewClient(conn)
-	defer client.Close()
-
 	status, err := getStatus(conn)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION

## Description

Do not create juju clients and open connections to the juju controller, if they are never used. In one case, only create the client if it will be used. 

## Type of change


- Maintenance work (repository related, like Github actions, or revving the Go version, etc.)


## QA steps

A mechanical change which will be validated if the code compiles.