### PR TITLE
Update model offer - use recent patterns

### DIFF
--- a/internal/provider/data_source_model.go
+++ b/internal/provider/data_source_model.go
@@ -105,7 +105,7 @@ func (d *modelDataSource) Read(ctx context.Context, req datasource.ReadRequest, 
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read model, got error: %s", err))
 		return
 	}
-	tflog.Trace(ctx, fmt.Sprintf("read juju model %q data source", data.Name))
+	d.trace(fmt.Sprintf("read juju model %q data source", data.Name))
 
 	// Save data into Terraform state
 	data.Name = types.StringValue(model.Name)

--- a/internal/provider/data_source_model.go
+++ b/internal/provider/data_source_model.go
@@ -85,6 +85,12 @@ func (d *modelDataSource) Configure(ctx context.Context, req datasource.Configur
 // order to update state. Config values should be read from the
 // ReadRequest and new state values set on the ReadResponse.
 func (d *modelDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	// Prevent panic if the provider has not been configured.
+	if d.client == nil {
+		addDSClientNotConfiguredError(&resp.Diagnostics, "model")
+		return
+	}
+
 	var data modelDataSourceModel
 
 	// Read Terraform configuration data into the model.
@@ -93,7 +99,7 @@ func (d *modelDataSource) Read(ctx context.Context, req datasource.ReadRequest, 
 		return
 	}
 
-	// Get current juju machine data source values.
+	// Get current juju model data source values.
 	model, err := d.client.Models.GetModelByName(data.Name.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read model, got error: %s", err))
@@ -113,8 +119,8 @@ func (d *modelDataSource) trace(msg string, additionalFields ...map[string]inter
 		return
 	}
 
-	//SubsystemTrace(subCtx, "datasource-machine", "hello, world", map[string]interface{}{"foo": 123})
+	//SubsystemTrace(subCtx, "datasource-model", "hello, world", map[string]interface{}{"foo": 123})
 	// Output:
-	// {"@level":"trace","@message":"hello, world","@module":"juju.datasource-machine","foo":123}
+	// {"@level":"trace","@message":"hello, world","@module":"juju.datasource-model","foo":123}
 	tflog.SubsystemTrace(d.subCtx, LogDataSourceModel, msg, additionalFields...)
 }

--- a/internal/provider/data_source_model.go
+++ b/internal/provider/data_source_model.go
@@ -13,7 +13,7 @@ import (
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
-var _ datasource.DataSource = &modelDataSource{}
+var _ datasource.DataSourceWithConfigure = &modelDataSource{}
 
 func NewModelDataSource() datasource.DataSourceWithConfigure {
 	return &modelDataSource{}

--- a/internal/provider/helpers.go
+++ b/internal/provider/helpers.go
@@ -15,6 +15,7 @@ import (
 //
 //	@module=juju.resource-application
 const LogDataSourceMachine = "datasource-machine"
+const LogDataSourceModel = "datasource-model"
 
 func addClientNotConfiguredError(diag *diag.Diagnostics, resource, method string) {
 	diag.AddError(


### PR DESCRIPTION

## Description

Use new patterns for datasources and resources in the terraform framework.

- tflog subsystems
- verify client before using in methods.

## Type of change

- Maintenance work (repository related, like Github actions, or revving the Go version, etc.)

## QA steps

1. juju add-model testing-datasource
2. write the following plan
```
terraform {
  required_providers {
    juju = {
      version = ">= 0.7.0"
      source  = "juju/juju"
    }
  }
}

provider "juju" {
}

data "juju_model" "testmodel" {
  model = "testing-datasource"
}

resource "juju_application" "app" {
  model = data.juju_model.testmodel.name
  name = "ubuntu"
  charm {
    name = "ubuntu"
  }
}

```
3. terraform init  && terraform plan && terraform apply
4. see a unit of ubuntu created in the existing model
5. terraform plan && terraform apply
6. see no change


## Additional notes

JUJU-4524