### PR TITLE
Migrate offer datasource from sdk to framework.

### DIFF
--- a/internal/provider/data_source_offer.go
+++ b/internal/provider/data_source_offer.go
@@ -2,76 +2,141 @@ package provider
 
 import (
 	"context"
+	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	"github.com/juju/terraform-provider-juju/internal/juju"
 )
 
-func dataSourceOffer() *schema.Resource {
-	return &schema.Resource{
+// Ensure provider defined types fully satisfy framework interfaces.
+var _ datasource.DataSourceWithConfigure = &offerDataSource{}
+
+func NewOfferDataSource() datasource.DataSource {
+	return &offerDataSource{}
+}
+
+type offerDataSource struct {
+	client *juju.Client
+
+	// context for the logging subsystem.
+	subCtx context.Context
+}
+
+// offerDataSourceModel is the juju data stored by terraform.
+// tfsdk must match offer data source schema attribute names.
+type offerDataSourceModel struct {
+	ApplicationName types.String `tfsdk:"application_name"`
+	Endpoint        types.String `tfsdk:"endpoint"`
+	ModelName       types.String `tfsdk:"model"`
+	OfferName       types.String `tfsdk:"name"`
+	OfferURL        types.String `tfsdk:"url"`
+	// ID required by the testing framework
+	ID types.String `tfsdk:"id"`
+}
+
+func (d *offerDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_offer"
+}
+
+func (d *offerDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
 		Description: "A data source representing a Juju Offer.",
-		ReadContext: dataSourceOfferRead,
-		Schema: map[string]*schema.Schema{
-			"url": {
+		Attributes: map[string]schema.Attribute{
+			"url": schema.StringAttribute{
 				Description: "The offer URL.",
-				Type:        schema.TypeString,
 				Required:    true,
 			},
-			"model": {
+			"model": schema.StringAttribute{
 				Description: "The name of the model to operate in.",
-				Type:        schema.TypeString,
 				Computed:    true,
+				// TODO hml 21-aug-2023
+				// Is model necessary at all?
 			},
-			"name": {
+			"name": schema.StringAttribute{
 				Description: "The name of the offer.",
-				Type:        schema.TypeString,
 				Computed:    true,
 			},
-			"application_name": {
+			"application_name": schema.StringAttribute{
 				Description: "The name of the application.",
-				Type:        schema.TypeString,
 				Computed:    true,
 			},
-			"endpoint": {
+			"endpoint": schema.StringAttribute{
 				Description: "The endpoint name.",
-				Type:        schema.TypeString,
 				Computed:    true,
+			},
+			// ID required by the testing framework
+			"id": schema.StringAttribute{
+				Computed: true,
 			},
 		},
 	}
 }
 
-func dataSourceOfferRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*juju.Client)
+func (d *offerDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	// Prevent panic if the provider has not been configured.
+	if req.ProviderData == nil {
+		return
+	}
 
-	offerUrl := d.Get("url").(string)
+	client, ok := req.ProviderData.(*juju.Client)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *http.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
 
-	offer, err := client.Offers.ReadOffer(&juju.ReadOfferInput{
-		OfferURL: offerUrl,
+	d.client = client
+	d.subCtx = tflog.NewSubsystem(ctx, LogDataSourceOffer)
+}
+
+func (d *offerDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	// Prevent panic if the provider has not been configured.
+	if d.client == nil {
+		addDSClientNotConfiguredError(&resp.Diagnostics, "offer")
+		return
+	}
+
+	var data offerDataSourceModel
+
+	// Read Terraform configuration data into the model
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Get current juju machine data source values .
+	offer, err := d.client.Offers.ReadOffer(&juju.ReadOfferInput{
+		OfferURL: data.OfferURL.ValueString(),
 	})
-
 	if err != nil {
-		return diag.FromErr(err)
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read offer, got error: %s", err))
+		return
+	}
+	d.trace(fmt.Sprintf("read juju offer %q data source", data.OfferName))
+
+	// Save data into Terraform state
+	data.ApplicationName = types.StringValue(offer.ApplicationName)
+	data.Endpoint = types.StringValue(offer.Endpoint)
+	data.ModelName = types.StringValue(offer.ModelName)
+	data.OfferName = types.StringValue(offer.Name)
+	data.OfferURL = types.StringValue(offer.OfferURL)
+	data.ID = types.StringValue(offer.OfferURL)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (d *offerDataSource) trace(msg string, additionalFields ...map[string]interface{}) {
+	if d.subCtx == nil {
+		return
 	}
 
-	d.SetId(offer.OfferURL)
-	if err = d.Set("url", offer.OfferURL); err != nil {
-		return diag.FromErr(err)
-	}
-	if err = d.Set("model", offer.ModelName); err != nil {
-		return diag.FromErr(err)
-	}
-	if err = d.Set("name", offer.Name); err != nil {
-		return diag.FromErr(err)
-	}
-	if err = d.Set("application_name", offer.ApplicationName); err != nil {
-		return diag.FromErr(err)
-	}
-	if err = d.Set("endpoint", offer.Endpoint); err != nil {
-		return diag.FromErr(err)
-	}
-
-	return nil
+	//SubsystemTrace(subCtx, "datasource-offer", "hello, world", map[string]interface{}{"foo": 123})
+	// Output:
+	// {"@level":"trace","@message":"hello, world","@module":"juju.datasource-offer","foo":123}
+	tflog.SubsystemTrace(d.subCtx, LogDataSourceOffer, msg, additionalFields...)
 }

--- a/internal/provider/data_source_offer_test.go
+++ b/internal/provider/data_source_offer_test.go
@@ -18,7 +18,7 @@ func TestAcc_DataSourceOffer_sdk2_framework_migrate(t *testing.T) {
 		ProtoV6ProviderFactories: muxProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceOffer_sdk2_framework_migrate(t, modelName, offerName),
+				Config: testAccDataSourceOffer_sdk2_framework_migrate(modelName, offerName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.juju_offer.this", "model", modelName),
 					resource.TestCheckResourceAttr("data.juju_offer.this", "name", offerName),
@@ -28,7 +28,7 @@ func TestAcc_DataSourceOffer_sdk2_framework_migrate(t *testing.T) {
 	})
 }
 
-func testAccDataSourceOffer_sdk2_framework_migrate(t *testing.T, modelName string, offerName string) string {
+func testAccDataSourceOffer_sdk2_framework_migrate(modelName string, offerName string) string {
 	return fmt.Sprintf(`
 provider oldjuju {}
 
@@ -56,7 +56,6 @@ resource "juju_offer" "this" {
 }
 
 data "juju_offer" "this" {
-    provider = oldjuju
 	url = juju_offer.this.url
 }
 `, modelName, offerName)
@@ -77,7 +76,7 @@ func TestAcc_DataSourceOffer_Stable(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceOffer_Stable(t, modelName, offerName),
+				Config: testAccDataSourceOffer_Stable(modelName, offerName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.juju_offer.this", "model", modelName),
 					resource.TestCheckResourceAttr("data.juju_offer.this", "name", offerName),
@@ -87,7 +86,7 @@ func TestAcc_DataSourceOffer_Stable(t *testing.T) {
 	})
 }
 
-func testAccDataSourceOffer_Stable(t *testing.T, modelName string, offerName string) string {
+func testAccDataSourceOffer_Stable(modelName string, offerName string) string {
 	return fmt.Sprintf(`
 resource "juju_model" "this" {
 	name = %q

--- a/internal/provider/helpers.go
+++ b/internal/provider/helpers.go
@@ -15,6 +15,7 @@ import (
 //
 //	@module=juju.resource-application
 const LogDataSourceMachine = "datasource-machine"
+const LogDataSourceOffer = "datasource-offer"
 
 func addClientNotConfiguredError(diag *diag.Diagnostics, resource, method string) {
 	diag.AddError(

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -60,9 +60,6 @@ func New(version string) func() *schema.Provider {
 					Optional:    true,
 				},
 			},
-			DataSourcesMap: map[string]*schema.Resource{
-				"juju_offer": dataSourceOffer(),
-			},
 			ResourcesMap: map[string]*schema.Resource{
 				"juju_application": resourceApplication(),
 				"juju_integration": resourceIntegration(),
@@ -374,7 +371,7 @@ func (p *jujuProvider) DataSources(_ context.Context) []func() datasource.DataSo
 	return []func() datasource.DataSource{
 		func() datasource.DataSource { return NewMachineDataSource() },
 		func() datasource.DataSource { return NewModelDataSource() },
-		//func() datasource.DataSource { return NewOfferDataSource() },
+		func() datasource.DataSource { return NewOfferDataSource() },
 	}
 }
 


### PR DESCRIPTION

## Description

Migrate the offer data source from the terraform sdk to framework. There is no change in schema or behavior. Change to use a tflog subsystem "datasource-offer" for logging.

## Type of change

- Maintenance work (repository related, like Github actions, or revving the Go version, etc.)

## Environment

- Juju controller version: 2.9.43

- Terraform version: 1.5.5

## QA steps

Note: data sources cannot be imported.

1. juju add-model six
2. juju deploy ubuntu
3. juju offer ubuntu:juju-info
4. write the following plan
```tf
terraform {
  required_providers {
    juju = {
      version = ">= 0.7.0"
      source  = "juju/juju"
    }
  }
}

provider "juju" {
}

resource "juju_model" "testmodel" {
  name = "offertest"
}

data "juju_offer" "juju_info" {
  url = "admin/six.ubuntu"
}

```
5. terraform init  && terraform plan && terraform apply
6. check the offer data is correct in the terraform.tfstate file

## Additional notes

JUJU-4173