### PR TITLE
Housekeeping: use tflog Subsystems.

### DIFF
--- a/internal/provider/helpers.go
+++ b/internal/provider/helpers.go
@@ -16,8 +16,14 @@ const (
 	LogDataSourceMachine = "datasource-machine"
 	LogDataSourceModel   = "datasource-model"
 	LogDataSourceOffer   = "datasource-offer"
-  
-  LogResourceApplication = "resource-application"
+
+	LogResourceApplication = "resource-application"
+	LogResourceAccessModel = "resource-assess-model"
+	LogResourceCredential  = "resource-credential"
+	LogResourceMachine     = "resource-machine"
+	LogResourceOffer       = "resource-offer"
+	LogResourceSSHKey      = "resource-sshkey"
+	LogResourceUser        = "resource-user"
 )
 
 func addClientNotConfiguredError(diag *diag.Diagnostics, resource, method string) {


### PR DESCRIPTION
## Description

Each resource and datasource should have it's own tflog subsystem for easier identification in the logs. Add these in where not used yet among the framework resources. New migrations to the framework will include them already.

## Type of change

- Maintenance work (repository related, like Github actions, or revving the Go version, etc.)

## QA steps

1. export TF_LOG_PROVIDER=DEBUG ; export TF_LOG_PATH=./terraform.log
2. terraform init && terraform plan && terraform apply
3. grep "@module=juju" terraform.log
