### PR TITLE
Add tests which have only required schema elements in the plan.

### DIFF
--- a/internal/provider/resource_machine_test.go
+++ b/internal/provider/resource_machine_test.go
@@ -54,6 +54,47 @@ resource "juju_machine" "this" {
 `, modelName)
 }
 
+func TestAcc_ResourceMachine_Minimal(t *testing.T) {
+	if testingCloud != LXDCloudTesting {
+		t.Skip(t.Name() + " only runs with LXD")
+	}
+	modelName := acctest.RandomWithPrefix("tf-test-machine")
+	resourceName := "juju_machine.testmachine"
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: muxProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceMachineBasicMinimal(modelName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "model", modelName),
+					resource.TestCheckResourceAttr(resourceName, "machine_id", "0"),
+				),
+			},
+			{
+				ImportStateVerify: true,
+				ImportState:       true,
+				ResourceName:      resourceName,
+			},
+		},
+	})
+}
+
+func testAccResourceMachineBasicMinimal(modelName string) string {
+	return fmt.Sprintf(`
+provider oldjuju {}
+
+resource "juju_model" "this" {
+    provider = oldjuju
+	name = %q
+}
+
+resource "juju_machine" "testmachine" {
+	model = juju_model.this.name
+}
+`, modelName)
+}
+
 func TestAcc_ResourceMachine_Stable(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")

--- a/internal/provider/resource_model_test.go
+++ b/internal/provider/resource_model_test.go
@@ -109,6 +109,28 @@ resource "juju_model" "this" {
 	})
 }
 
+func TestAcc_ResourceModel_Minimal(t *testing.T) {
+	modelName := acctest.RandomWithPrefix("tf-test-model")
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: muxProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+provider oldjuju {}
+
+resource "juju_model" "testmodel" {
+  provider = oldjuju
+  name = %q
+}`, modelName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("juju_model.testmodel", "name", modelName),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckDevelopmentConfigIsUnsetMigrate(modelName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		client := Provider.Meta().(*juju.Client)


### PR DESCRIPTION
## Description

Application, Machine and Model resources have only one required element in their schemas. Add tests which create resources with only those minimal values, after bugs found in specifying only the charm name for an application.

## Type of change

- Change in tests (one or several tests have been changed)


## QA steps

The new acceptance tests should run to success in the GitHub actions.

## Additional notes

JUJU-4561
