### PR TITLE
Fix juju client logging and two other minor things.

### DIFF
--- a/internal/juju/client.go
+++ b/internal/juju/client.go
@@ -125,3 +125,7 @@ func (cf *ConnectionFactory) Tracef(msg string, additionalFields ...map[string]i
 func (cf *ConnectionFactory) Warnf(msg string, additionalFields ...map[string]interface{}) {
 	tflog.SubsystemWarn(cf.subCtx, LogJujuClient, msg, additionalFields...)
 }
+
+func getCurrentJujuUser(conn api.Connection) string {
+	return conn.AuthTag().Id()
+}

--- a/internal/juju/client.go
+++ b/internal/juju/client.go
@@ -46,9 +46,10 @@ type ConnectionFactory struct {
 	subCtx context.Context
 }
 
-func NewClient(config Configuration) (*Client, error) {
+func NewClient(ctx context.Context, config Configuration) (*Client, error) {
 	cf := ConnectionFactory{
 		config: config,
+		subCtx: tflog.NewSubsystem(ctx, LogJujuClient),
 	}
 
 	return &Client{
@@ -107,10 +108,6 @@ const LogJujuClient = "client"
 // and used with tflog here, for now, use context.Background.
 
 func (cf *ConnectionFactory) Debugf(msg string, additionalFields ...map[string]interface{}) {
-	if cf.subCtx == nil {
-		cf.subCtx = tflog.NewSubsystem(context.Background(), LogJujuClient)
-	}
-
 	//SubsystemTrace(subCtx, "my-subsystem", "hello, world", map[string]interface{}{"foo": 123})
 	// Output:
 	// {"@level":"trace","@message":"hello, world","@module":"provider.my-subsystem","foo":123}
@@ -118,22 +115,13 @@ func (cf *ConnectionFactory) Debugf(msg string, additionalFields ...map[string]i
 }
 
 func (cf *ConnectionFactory) Errorf(err error, msg string) {
-	if cf.subCtx == nil {
-		cf.subCtx = tflog.NewSubsystem(context.Background(), LogJujuClient)
-	}
 	tflog.SubsystemError(cf.subCtx, LogJujuClient, msg, map[string]interface{}{"error": err})
 }
 
 func (cf *ConnectionFactory) Tracef(msg string, additionalFields ...map[string]interface{}) {
-	if cf.subCtx == nil {
-		cf.subCtx = tflog.NewSubsystem(context.Background(), LogJujuClient)
-	}
 	tflog.SubsystemTrace(cf.subCtx, LogJujuClient, msg, additionalFields...)
 }
 
 func (cf *ConnectionFactory) Warnf(msg string, additionalFields ...map[string]interface{}) {
-	if cf.subCtx == nil {
-		cf.subCtx = tflog.NewSubsystem(context.Background(), LogJujuClient)
-	}
 	tflog.SubsystemWarn(cf.subCtx, LogJujuClient, msg, additionalFields...)
 }

--- a/internal/juju/credentials.go
+++ b/internal/juju/credentials.go
@@ -5,7 +5,6 @@ package juju
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/juju/errors"
 	cloudapi "github.com/juju/juju/api/client/cloud"
@@ -132,7 +131,7 @@ func (c *credentialsClient) CreateCredential(input CreateCredentialInput) (*Crea
 	client := cloudapi.NewClient(conn)
 	defer client.Close()
 
-	currentUser := strings.TrimPrefix(conn.AuthTag().String(), PrefixUser)
+	currentUser := getCurrentJujuUser(conn)
 
 	cloudCredTag, err := GetCloudCredentialTag(cloudName, currentUser, credentialName)
 	if err != nil {
@@ -253,7 +252,7 @@ func (c *credentialsClient) UpdateCredential(input UpdateCredentialInput) error 
 		return err
 	}
 
-	currentUser := strings.TrimPrefix(conn.AuthTag().String(), PrefixUser)
+	currentUser := getCurrentJujuUser(conn)
 
 	cloudCredTag, err := GetCloudCredentialTag(cloudName, currentUser, credentialName)
 	if err != nil {
@@ -323,7 +322,7 @@ func (c *credentialsClient) DestroyCredential(input DestroyCredentialInput) erro
 	client := cloudapi.NewClient(conn)
 	defer client.Close()
 
-	currentUser := strings.TrimPrefix(conn.AuthTag().String(), PrefixUser)
+	currentUser := getCurrentJujuUser(conn)
 
 	cloudCredTag, err := GetCloudCredentialTag(cloudName, currentUser, credentialName)
 	if err != nil {

--- a/internal/juju/models.go
+++ b/internal/juju/models.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/client/modelconfig"
 	"github.com/juju/juju/api/client/modelmanager"
@@ -99,10 +98,6 @@ func newModelsClient(cf ConnectionFactory) *modelsClient {
 	}
 }
 
-func (c *modelsClient) getCurrentUser(conn api.Connection) string {
-	return strings.TrimPrefix(conn.AuthTag().String(), PrefixUser)
-}
-
 func (c *modelsClient) resolveModelUUIDWithClient(client modelmanager.Client, name string, user string) (string, error) {
 	modelUUID := ""
 	modelSummaries, err := client.ListModelSummaries(user, false)
@@ -130,7 +125,7 @@ func (c *modelsClient) GetModelByName(name string) (*params.ModelInfo, error) {
 		return nil, err
 	}
 
-	currentUser := c.getCurrentUser(conn)
+	currentUser := getCurrentJujuUser(conn)
 	client := modelmanager.NewClient(conn)
 	defer client.Close()
 
@@ -164,7 +159,7 @@ func (c *modelsClient) ResolveModelUUID(name string) (string, error) {
 		return "", err
 	}
 
-	currentUser := c.getCurrentUser(conn)
+	currentUser := getCurrentJujuUser(conn)
 	client := modelmanager.NewClient(conn)
 	defer client.Close()
 
@@ -187,7 +182,7 @@ func (c *modelsClient) CreateModel(input CreateModelInput) (*CreateModelResponse
 		return nil, err
 	}
 
-	currentUser := strings.TrimPrefix(conn.AuthTag().String(), PrefixUser)
+	currentUser := getCurrentJujuUser(conn)
 
 	client := modelmanager.NewClient(conn)
 	defer client.Close()
@@ -321,7 +316,7 @@ func (c *modelsClient) UpdateModel(input UpdateModelInput) error {
 	if input.Credential != "" {
 		cloudName := input.CloudName
 		tag := names.NewModelTag(input.UUID)
-		currentUser := strings.TrimPrefix(conn.AuthTag().String(), PrefixUser)
+		currentUser := getCurrentJujuUser(conn)
 		cloudCredTag, err := GetCloudCredentialTag(cloudName, currentUser, input.Credential)
 		if err != nil {
 			return err

--- a/internal/juju/models.go
+++ b/internal/juju/models.go
@@ -223,6 +223,7 @@ func (c *modelsClient) CreateModel(input CreateModelInput) (*CreateModelResponse
 	}
 
 	modelClient := modelconfig.NewClient(connModel)
+	defer func() { _ = modelClient.Close() }()
 	err = modelClient.SetModelConstraints(input.Constraints)
 	if err != nil {
 		return nil, err

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -72,7 +72,7 @@ func New(version string) func() *schema.Provider {
 }
 
 func configure() func(context.Context, *schema.ResourceData) (interface{}, diag.Diagnostics) {
-	return func(_ context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
+	return func(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
 		var diags diag.Diagnostics
 
 		controllerAddresses := strings.Split(d.Get(JujuController).(string), ",")
@@ -140,7 +140,7 @@ func configure() func(context.Context, *schema.ResourceData) (interface{}, diag.
 			Password:            password,
 			CACert:              caCert,
 		}
-		client, err := juju.NewClient(config)
+		client, err := juju.NewClient(ctx, config)
 		if err != nil {
 			return nil, diag.FromErr(err)
 		}
@@ -272,7 +272,7 @@ func (p *jujuProvider) Configure(ctx context.Context, req frameworkprovider.Conf
 		Password:            data.Password.ValueString(),
 		CACert:              data.CACert.ValueString(),
 	}
-	client, err := juju.NewClient(config)
+	client, err := juju.NewClient(ctx, config)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create juju client, got error: %s", err))
 		return


### PR DESCRIPTION

## Description

3 small changes in one

- Close a connection to a juju client when no longer used.
- Pass the terraform context to the juju client for use with tflog package, the logging was broken.
- Use a juju tag's Id method rather than trimming from a tag string, that's what the method is for. 

## Type of change

- Maintenance work (repository related, like Github actions, or revving the Go version, etc.)

## QA steps

Mechanical change, all current tests should have no change. Test the logging with

1. export TF_LOG_PROVIDER=TRACE ; export TF_LOG_PATH=./terraform.log
2. terraform init && terraform plan && terraform apply
3.  grep "@module=juju\.client" terraform.log

## Additional notes

JUJU-4577
