### PR TITLE
Cache model UUID and type

### DIFF
--- a/internal/juju/applications.go
+++ b/internal/juju/applications.go
@@ -54,10 +54,9 @@ type applicationsClient struct {
 	SharedClient
 }
 
-// ConfigEntry is an auxiliar struct to
-// keep information about juju config entries.
-// Specially, we want to know if they have the
-// default value.
+// ConfigEntry is an auxiliar struct to keep information about
+// juju application config entries. Specially, we want to know
+// if they have the default value.
 type ConfigEntry struct {
 	Value     interface{}
 	IsDefault bool
@@ -94,7 +93,7 @@ func ConfigEntryToString(input interface{}) string {
 
 type CreateApplicationInput struct {
 	ApplicationName string
-	ModelUUID       string
+	ModelName       string
 	CharmName       string
 	CharmChannel    string
 	CharmSeries     string
@@ -114,8 +113,7 @@ type CreateApplicationResponse struct {
 }
 
 type ReadApplicationInput struct {
-	ModelUUID string
-	ModelType string
+	ModelName string
 	AppName   string
 }
 
@@ -134,8 +132,7 @@ type ReadApplicationResponse struct {
 }
 
 type UpdateApplicationInput struct {
-	ModelUUID string
-	ModelType string
+	ModelName string
 	ModelInfo *params.ModelInfo
 	AppName   string
 	//Channel   string // TODO: Unsupported for now
@@ -155,7 +152,7 @@ type UpdateApplicationInput struct {
 
 type DestroyApplicationInput struct {
 	ApplicationName string
-	ModelUUID       string
+	ModelName       string
 }
 
 func newApplicationClient(sc SharedClient) *applicationsClient {
@@ -186,7 +183,7 @@ func (c applicationsClient) CreateApplication(input *CreateApplicationInput) (*C
 		return nil, err
 	}
 
-	conn, err := c.GetConnection(&input.ModelUUID)
+	conn, err := c.GetConnection(&input.ModelName)
 	if err != nil {
 		return nil, err
 	}
@@ -530,7 +527,7 @@ func (c applicationsClient) ReadApplicationWithRetryOnNotFound(ctx context.Conte
 }
 
 func (c applicationsClient) ReadApplication(input *ReadApplicationInput) (*ReadApplicationResponse, error) {
-	conn, err := c.GetConnection(&input.ModelUUID)
+	conn, err := c.GetConnection(&input.ModelName)
 	if err != nil {
 		return nil, err
 	}
@@ -595,7 +592,11 @@ func (c applicationsClient) ReadApplication(input *ReadApplicationInput) (*ReadA
 
 	unitCount := len(appStatus.Units)
 	// if we have a CAAS we use scale instead of units length
-	if input.ModelType == model.CAAS.String() {
+	modelType, err := c.ModelType(input.ModelName)
+	if err != nil {
+		return nil, err
+	}
+	if modelType == model.CAAS {
 		unitCount = appStatus.Scale
 	}
 
@@ -715,7 +716,7 @@ func removeDefaultCidrs(cidrs []string) []string {
 }
 
 func (c applicationsClient) UpdateApplication(input *UpdateApplicationInput) error {
-	conn, err := c.GetConnection(&input.ModelUUID)
+	conn, err := c.GetConnection(&input.ModelName)
 	if err != nil {
 		return err
 	}
@@ -787,7 +788,11 @@ func (c applicationsClient) UpdateApplication(input *UpdateApplicationInput) err
 
 	if input.Units != nil {
 		// TODO: Refactor this to a separate function
-		if input.ModelType == model.CAAS.String() {
+		modelType, err := c.ModelType(input.ModelName)
+		if err != nil {
+			return err
+		}
+		if modelType == model.CAAS {
 			_, err := applicationAPIClient.ScaleApplication(apiapplication.ScaleApplicationParams{
 				ApplicationName: input.AppName,
 				Scale:           *input.Units,
@@ -858,7 +863,7 @@ func (c applicationsClient) UpdateApplication(input *UpdateApplicationInput) err
 }
 
 func (c applicationsClient) DestroyApplication(input *DestroyApplicationInput) error {
-	conn, err := c.GetConnection(&input.ModelUUID)
+	conn, err := c.GetConnection(&input.ModelName)
 	if err != nil {
 		return err
 	}

--- a/internal/juju/applications.go
+++ b/internal/juju/applications.go
@@ -51,7 +51,7 @@ func (ae *applicationNotFoundError) Error() string {
 }
 
 type applicationsClient struct {
-	ConnectionFactory
+	SharedClient
 }
 
 // ConfigEntry is an auxiliar struct to
@@ -158,9 +158,9 @@ type DestroyApplicationInput struct {
 	ModelUUID       string
 }
 
-func newApplicationClient(cf ConnectionFactory) *applicationsClient {
+func newApplicationClient(sc SharedClient) *applicationsClient {
 	return &applicationsClient{
-		ConnectionFactory: cf,
+		SharedClient: sc,
 	}
 }
 

--- a/internal/juju/client.go
+++ b/internal/juju/client.go
@@ -5,11 +5,16 @@ package juju
 
 import (
 	"context"
+	"fmt"
+	"sync"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/juju/errors"
 	"github.com/juju/juju/api"
+	"github.com/juju/juju/api/client/modelmanager"
 	"github.com/juju/juju/api/connector"
+	"github.com/juju/juju/core/model"
 )
 
 const (
@@ -40,8 +45,21 @@ type Client struct {
 	Users        usersClient
 }
 
+type jujuModel struct {
+	uuid      string
+	modelType model.ModelType
+}
+
+func (j jujuModel) String() string {
+	return fmt.Sprintf("uuid(%s) type(%s)", j.uuid, j.modelType.String())
+}
+
 type SharedClient interface {
+	AddModel(modelName, modelUUID string, modelType model.ModelType)
 	GetConnection(modelName *string) (api.Connection, error)
+	ModelType(modelName string) (model.ModelType, error)
+	ModelUUID(modelName string) (string, error)
+	RemoveModel(modelUUID string)
 
 	Debugf(msg string, additionalFields ...map[string]interface{})
 	Errorf(err error, msg string)
@@ -52,13 +70,23 @@ type SharedClient interface {
 type sharedClient struct {
 	controllerConfig ControllerConfiguration
 
+	modelUUIDcache map[string]jujuModel
+	modelUUIDmu    sync.Mutex
+
 	// subCtx is the context created with the new tflog subsystem for applications.
 	subCtx context.Context
 }
 
+// NewClient returns a client which can talk to the juju controller
+// represented by controllerConfig. A context is required for logging in the
+// terraform framework.
 func NewClient(ctx context.Context, config ControllerConfiguration) (*Client, error) {
+	if ctx == nil {
+		return nil, errors.NotValidf("missing context")
+	}
 	sc := &sharedClient{
 		controllerConfig: config,
+		modelUUIDcache:   make(map[string]jujuModel),
 		subCtx:           tflog.NewSubsystem(ctx, LogJujuClient),
 	}
 
@@ -74,10 +102,16 @@ func NewClient(ctx context.Context, config ControllerConfiguration) (*Client, er
 	}, nil
 }
 
-func (sc *sharedClient) GetConnection(model *string) (api.Connection, error) {
-	modelUUID := ""
-	if model != nil {
-		modelUUID = *model
+// GetConnection returns a juju connection for use creating juju
+// api clients given the provided model name.
+func (sc *sharedClient) GetConnection(modelName *string) (api.Connection, error) {
+	var modelUUID string
+	if modelName != nil {
+		var err error
+		modelUUID, err = sc.ModelUUID(*modelName)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	dialOptions := func(do *api.DialOpts) {
@@ -106,16 +140,97 @@ func (sc *sharedClient) GetConnection(model *string) (api.Connection, error) {
 	return conn, nil
 }
 
+func (sc *sharedClient) ModelUUID(modelName string) (string, error) {
+	sc.modelUUIDmu.Lock()
+	defer sc.modelUUIDmu.Unlock()
+	dataMap := make(map[string]interface{})
+	// How to tell if logging level is Trace?
+	for k, v := range sc.modelUUIDcache {
+		dataMap[k] = v.String()
+	}
+	sc.Tracef(fmt.Sprintf("ModelUUID cache looking for %q", modelName), dataMap)
+	if modelWithName, ok := sc.modelUUIDcache[modelName]; ok {
+		sc.Tracef(fmt.Sprintf("Found uuid for %q in cache", modelName))
+		return modelWithName.uuid, nil
+	}
+	if err := sc.fillModelCache(); err != nil {
+		return "", err
+	}
+	if modelWithName, ok := sc.modelUUIDcache[modelName]; ok {
+		sc.Tracef(fmt.Sprintf("Found uuid for %q in cache on 2nd attempt", modelName))
+		return modelWithName.uuid, nil
+	}
+	return "", errors.NotFoundf("model %q", modelName)
+}
+
+// fillModelCache checks with the juju controller for all
+// models and puts the relevant data in the model info cache.
+// Callers are expected to hold the modelUUIDmu lock.
+func (sc *sharedClient) fillModelCache() error {
+	conn, err := sc.GetConnection(nil)
+	if err != nil {
+		return err
+	}
+
+	client := modelmanager.NewClient(conn)
+	defer func() { _ = client.Close() }()
+
+	// Calling ListModelSummaries because other Model endpoints require
+	// the UUID, here we're trying to get the model UUID for other calls.
+	modelSummaries, err := client.ListModelSummaries(conn.AuthTag().Id(), false)
+	if err != nil {
+		return err
+	}
+	for _, modelSummary := range modelSummaries {
+		modelWithName := jujuModel{
+			uuid:      modelSummary.UUID,
+			modelType: modelSummary.Type,
+		}
+		sc.modelUUIDcache[modelSummary.Name] = modelWithName
+	}
+	return nil
+}
+
+func (sc *sharedClient) ModelType(modelName string) (model.ModelType, error) {
+	sc.modelUUIDmu.Lock()
+	defer sc.modelUUIDmu.Unlock()
+	if modelWithName, ok := sc.modelUUIDcache[modelName]; ok {
+		return modelWithName.modelType, nil
+	}
+
+	return model.ModelType(""), errors.NotFoundf("type for model %q", modelName)
+}
+
+func (sc *sharedClient) RemoveModel(modelUUID string) {
+	sc.modelUUIDmu.Lock()
+	var modelName string
+	for k, v := range sc.modelUUIDcache {
+		if v.uuid == modelUUID {
+			modelName = k
+			break
+		}
+	}
+	if modelName != "" {
+		delete(sc.modelUUIDcache, modelName)
+	}
+	sc.modelUUIDmu.Unlock()
+}
+
+func (sc *sharedClient) AddModel(modelName, modelUUID string, modelType model.ModelType) {
+	sc.modelUUIDmu.Lock()
+	sc.modelUUIDcache[modelName] = jujuModel{
+		uuid:      modelUUID,
+		modelType: modelType,
+	}
+	sc.modelUUIDmu.Unlock()
+}
+
 // module names for logging
 // @module=juju.<subsystem>
 // e.g.:
 //
 //	@module=juju.client
 const LogJujuClient = "client"
-
-// TODO hml 04-Aug-2023
-// Investigate if the context from terraform can be passed in
-// and used with tflog here, for now, use context.Background.
 
 func (sc *sharedClient) Debugf(msg string, additionalFields ...map[string]interface{}) {
 	//SubsystemTrace(subCtx, "my-subsystem", "hello, world", map[string]interface{}{"foo": 123})

--- a/internal/juju/credentials.go
+++ b/internal/juju/credentials.go
@@ -14,7 +14,7 @@ import (
 )
 
 type credentialsClient struct {
-	ConnectionFactory
+	SharedClient
 }
 
 type CreateCredentialInput struct {
@@ -58,9 +58,9 @@ type DestroyCredentialInput struct {
 	Name                 string
 }
 
-func newCredentialsClient(cf ConnectionFactory) *credentialsClient {
+func newCredentialsClient(sc SharedClient) *credentialsClient {
 	return &credentialsClient{
-		ConnectionFactory: cf,
+		SharedClient: sc,
 	}
 }
 

--- a/internal/juju/integrations.go
+++ b/internal/juju/integrations.go
@@ -39,7 +39,7 @@ func (ie *noIntegrationFoundError) Error() string {
 }
 
 type integrationsClient struct {
-	ConnectionFactory
+	SharedClient
 }
 
 type Application struct {
@@ -79,9 +79,9 @@ type UpdateIntegrationInput struct {
 	ViaCIDRs     string
 }
 
-func newIntegrationsClient(cf ConnectionFactory) *integrationsClient {
+func newIntegrationsClient(sc SharedClient) *integrationsClient {
 	return &integrationsClient{
-		ConnectionFactory: cf,
+		SharedClient: sc,
 	}
 }
 

--- a/internal/juju/integrations.go
+++ b/internal/juju/integrations.go
@@ -54,7 +54,7 @@ type Offer struct {
 }
 
 type IntegrationInput struct {
-	ModelUUID string
+	ModelName string
 	Apps      []string
 	Endpoints []string
 	ViaCIDRs  string
@@ -73,7 +73,7 @@ type UpdateIntegrationResponse struct {
 }
 
 type UpdateIntegrationInput struct {
-	ModelUUID    string
+	ModelName    string
 	Endpoints    []string
 	OldEndpoints []string
 	ViaCIDRs     string
@@ -86,7 +86,7 @@ func newIntegrationsClient(sc SharedClient) *integrationsClient {
 }
 
 func (c integrationsClient) CreateIntegration(input *IntegrationInput) (*CreateIntegrationResponse, error) {
-	conn, err := c.GetConnection(&input.ModelUUID)
+	conn, err := c.GetConnection(&input.ModelName)
 	if err != nil {
 		return nil, err
 	}
@@ -126,7 +126,7 @@ func (c integrationsClient) CreateIntegration(input *IntegrationInput) (*CreateI
 }
 
 func (c integrationsClient) ReadIntegration(input *IntegrationInput) (*ReadIntegrationResponse, error) {
-	conn, err := c.GetConnection(&input.ModelUUID)
+	conn, err := c.GetConnection(&input.ModelName)
 	if err != nil {
 		return nil, err
 	}
@@ -139,7 +139,11 @@ func (c integrationsClient) ReadIntegration(input *IntegrationInput) (*ReadInteg
 	integrations := status.Relations
 	var integration params.RelationStatus
 	if len(integrations) == 0 {
-		return nil, &noIntegrationFoundError{ModelUUID: input.ModelUUID}
+		modelUUID, thisModel := conn.ModelTag()
+		if !thisModel {
+			return nil, errors.Errorf("Unable to get model uuid for %q", input.ModelName)
+		}
+		return nil, &noIntegrationFoundError{ModelUUID: modelUUID.Id()}
 	}
 
 	apps := make([][]string, 0, len(input.Endpoints))
@@ -182,7 +186,7 @@ func (c integrationsClient) ReadIntegration(input *IntegrationInput) (*ReadInteg
 }
 
 func (c integrationsClient) UpdateIntegration(input *UpdateIntegrationInput) (*UpdateIntegrationResponse, error) {
-	conn, err := c.GetConnection(&input.ModelUUID)
+	conn, err := c.GetConnection(&input.ModelName)
 	if err != nil {
 		return nil, err
 	}
@@ -232,7 +236,7 @@ func (c integrationsClient) UpdateIntegration(input *UpdateIntegrationInput) (*U
 }
 
 func (c integrationsClient) DestroyIntegration(input *IntegrationInput) error {
-	conn, err := c.GetConnection(&input.ModelUUID)
+	conn, err := c.GetConnection(&input.ModelName)
 	if err != nil {
 		return err
 	}

--- a/internal/juju/machines.go
+++ b/internal/juju/machines.go
@@ -30,7 +30,7 @@ type machinesClient struct {
 }
 
 type CreateMachineInput struct {
-	ModelUUID   string
+	ModelName   string
 	Constraints string
 	Disks       string
 	Series      string
@@ -53,7 +53,7 @@ type CreateMachineResponse struct {
 }
 
 type ReadMachineInput struct {
-	ModelUUID string
+	ModelName string
 	MachineId string
 }
 
@@ -63,7 +63,7 @@ type ReadMachineResponse struct {
 }
 
 type DestroyMachineInput struct {
-	ModelUUID string
+	ModelName string
 	MachineId string
 }
 
@@ -74,7 +74,7 @@ func newMachinesClient(sc SharedClient) *machinesClient {
 }
 
 func (c machinesClient) CreateMachine(input *CreateMachineInput) (*CreateMachineResponse, error) {
-	conn, err := c.GetConnection(&input.ModelUUID)
+	conn, err := c.GetConnection(&input.ModelName)
 	if err != nil {
 		return nil, err
 	}
@@ -216,7 +216,7 @@ func manualProvision(client manual.ProvisioningClientAPI,
 
 func (c machinesClient) ReadMachine(input ReadMachineInput) (ReadMachineResponse, error) {
 	var response ReadMachineResponse
-	conn, err := c.GetConnection(&input.ModelUUID)
+	conn, err := c.GetConnection(&input.ModelName)
 	if err != nil {
 		return response, err
 	}
@@ -242,7 +242,7 @@ func (c machinesClient) ReadMachine(input ReadMachineInput) (ReadMachineResponse
 }
 
 func (c machinesClient) DestroyMachine(input *DestroyMachineInput) error {
-	conn, err := c.GetConnection(&input.ModelUUID)
+	conn, err := c.GetConnection(&input.ModelName)
 	if err != nil {
 		return err
 	}

--- a/internal/juju/machines.go
+++ b/internal/juju/machines.go
@@ -26,7 +26,7 @@ import (
 )
 
 type machinesClient struct {
-	ConnectionFactory
+	SharedClient
 }
 
 type CreateMachineInput struct {
@@ -67,9 +67,9 @@ type DestroyMachineInput struct {
 	MachineId string
 }
 
-func newMachinesClient(cf ConnectionFactory) *machinesClient {
+func newMachinesClient(sc SharedClient) *machinesClient {
 	return &machinesClient{
-		ConnectionFactory: cf,
+		SharedClient: sc,
 	}
 }
 

--- a/internal/juju/models.go
+++ b/internal/juju/models.go
@@ -4,11 +4,11 @@
 package juju
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 	"time"
 
+	"github.com/juju/errors"
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/client/modelconfig"
 	"github.com/juju/juju/api/client/modelmanager"
@@ -25,7 +25,7 @@ type modelNotFoundError struct {
 }
 
 func (me *modelNotFoundError) Error() string {
-	toReturn := "model %s was not found"
+	toReturn := "model %q was not found"
 	if me.name != "" {
 		return fmt.Sprintf(toReturn, me.name)
 	}
@@ -37,9 +37,9 @@ type modelsClient struct {
 }
 
 type GrantModelInput struct {
-	User       string
-	Access     string
-	ModelUUIDs []string
+	User      string
+	Access    string
+	ModelName string
 }
 
 type CreateModelInput struct {
@@ -55,10 +55,6 @@ type CreateModelResponse struct {
 	ModelInfo base.ModelInfo
 }
 
-type ReadModelInput struct {
-	UUID string
-}
-
 type ReadModelResponse struct {
 	ModelInfo        params.ModelInfo
 	ModelConfig      map[string]interface{}
@@ -66,7 +62,7 @@ type ReadModelResponse struct {
 }
 
 type UpdateModelInput struct {
-	UUID        string
+	Name        string
 	CloudName   string
 	Config      map[string]string
 	Unset       []string
@@ -98,26 +94,6 @@ func newModelsClient(sc SharedClient) *modelsClient {
 	}
 }
 
-func (c *modelsClient) resolveModelUUIDWithClient(client modelmanager.Client, name string, user string) (string, error) {
-	modelUUID := ""
-	modelSummaries, err := client.ListModelSummaries(user, false)
-	if err != nil {
-		return "", err
-	}
-	for _, modelSummary := range modelSummaries {
-		if modelSummary.Name == name {
-			modelUUID = modelSummary.UUID
-			break
-		}
-	}
-
-	if modelUUID == "" {
-		return "", fmt.Errorf("model not found for defined user")
-	}
-
-	return modelUUID, nil
-}
-
 // GetModelByName retrieves a model by name
 func (c *modelsClient) GetModelByName(name string) (*params.ModelInfo, error) {
 	conn, err := c.GetConnection(nil)
@@ -125,15 +101,13 @@ func (c *modelsClient) GetModelByName(name string) (*params.ModelInfo, error) {
 		return nil, err
 	}
 
-	currentUser := getCurrentJujuUser(conn)
 	client := modelmanager.NewClient(conn)
 	defer client.Close()
 
-	modelUUID, err := c.resolveModelUUIDWithClient(*client, name, currentUser)
+	modelUUID, err := c.ModelUUID(name)
 	if err != nil {
 		return nil, err
 	}
-
 	modelTag := names.NewModelTag(modelUUID)
 
 	results, err := client.ModelInfo([]names.ModelTag{
@@ -152,25 +126,6 @@ func (c *modelsClient) GetModelByName(name string) (*params.ModelInfo, error) {
 	return modelInfo, nil
 }
 
-// ResolveModelUUID retrieves a model's using its name
-func (c *modelsClient) ResolveModelUUID(name string) (string, error) {
-	conn, err := c.GetConnection(nil)
-	if err != nil {
-		return "", err
-	}
-
-	currentUser := getCurrentJujuUser(conn)
-	client := modelmanager.NewClient(conn)
-	defer client.Close()
-
-	modelUUID, err := c.resolveModelUUIDWithClient(*client, name, currentUser)
-	if err != nil {
-		return "", nil
-	}
-
-	return modelUUID, nil
-}
-
 func (c *modelsClient) CreateModel(input CreateModelInput) (*CreateModelResponse, error) {
 	modelName := input.Name
 	if !names.IsValidModelName(modelName) {
@@ -185,7 +140,7 @@ func (c *modelsClient) CreateModel(input CreateModelInput) (*CreateModelResponse
 	currentUser := getCurrentJujuUser(conn)
 
 	client := modelmanager.NewClient(conn)
-	defer client.Close()
+	defer func() { _ = client.Close() }()
 
 	cloudName := input.CloudName
 	cloudRegion := input.CloudRegion
@@ -217,7 +172,7 @@ func (c *modelsClient) CreateModel(input CreateModelInput) (*CreateModelResponse
 
 	// we have to set constraints ...
 	// establish a new connection with the created model through the modelconfig api to set constraints
-	connModel, err := c.GetConnection(&modelInfo.UUID)
+	connModel, err := c.GetConnection(&modelName)
 	if err != nil {
 		return nil, err
 	}
@@ -229,18 +184,21 @@ func (c *modelsClient) CreateModel(input CreateModelInput) (*CreateModelResponse
 		return nil, err
 	}
 
+	// Add the model to the client cache of jujuModel
+	c.AddModel(modelInfo.Name, modelInfo.UUID, modelInfo.Type)
+
 	return &CreateModelResponse{ModelInfo: modelInfo}, nil
 }
 
-func (c *modelsClient) ReadModel(uuid string) (*ReadModelResponse, error) {
+func (c *modelsClient) ReadModel(name string) (*ReadModelResponse, error) {
 	modelmanagerConn, err := c.GetConnection(nil)
 	if err != nil {
 		return nil, err
 	}
 
-	modelconfigConn, err := c.GetConnection(&uuid)
+	modelconfigConn, err := c.GetConnection(&name)
 	if err != nil {
-		return nil, errors.Join(err, &modelNotFoundError{uuid: uuid})
+		return nil, errors.Wrap(err, &modelNotFoundError{uuid: name})
 	}
 
 	modelmanagerClient := modelmanager.NewClient(modelmanagerConn)
@@ -249,16 +207,20 @@ func (c *modelsClient) ReadModel(uuid string) (*ReadModelResponse, error) {
 	modelconfigClient := modelconfig.NewClient(modelconfigConn)
 	defer modelconfigClient.Close()
 
-	models, err := modelmanagerClient.ModelInfo([]names.ModelTag{names.NewModelTag(uuid)})
+	modelUUIDTag, modelOk := modelconfigConn.ModelTag()
+	if !modelOk {
+		return nil, errors.Errorf("Not connected to model %q", name)
+	}
+	models, err := modelmanagerClient.ModelInfo([]names.ModelTag{modelUUIDTag})
 	if err != nil {
 		return nil, err
 	}
 
 	if len(models) > 1 {
-		return nil, fmt.Errorf("more than one model returned for UUID: %s", uuid)
+		return nil, fmt.Errorf("more than one model returned for UUID: %s", modelUUIDTag.Id())
 	}
 	if len(models) < 1 {
-		return nil, &modelNotFoundError{uuid: uuid}
+		return nil, &modelNotFoundError{uuid: modelUUIDTag.Id()}
 	}
 
 	modelInfo := *models[0].Result
@@ -281,7 +243,7 @@ func (c *modelsClient) ReadModel(uuid string) (*ReadModelResponse, error) {
 }
 
 func (c *modelsClient) UpdateModel(input UpdateModelInput) error {
-	conn, err := c.GetConnection(&input.UUID)
+	conn, err := c.GetConnection(&input.Name)
 	if err != nil {
 		return err
 	}
@@ -316,7 +278,6 @@ func (c *modelsClient) UpdateModel(input UpdateModelInput) error {
 
 	if input.Credential != "" {
 		cloudName := input.CloudName
-		tag := names.NewModelTag(input.UUID)
 		currentUser := getCurrentJujuUser(conn)
 		cloudCredTag, err := GetCloudCredentialTag(cloudName, currentUser, input.Credential)
 		if err != nil {
@@ -327,9 +288,13 @@ func (c *modelsClient) UpdateModel(input UpdateModelInput) error {
 		if err != nil {
 			return err
 		}
+		modelUUIDTag, modelOk := conn.ModelTag()
+		if !modelOk {
+			return errors.Errorf("Not connected to model %q", input.Name)
+		}
 		clientModelManager := modelmanager.NewClient(connModelManager)
 		defer clientModelManager.Close()
-		if err := clientModelManager.ChangeModelCredential(tag, *cloudCredTag); err != nil {
+		if err := clientModelManager.ChangeModelCredential(modelUUIDTag, *cloudCredTag); err != nil {
 			return err
 		}
 	}
@@ -359,6 +324,7 @@ func (c *modelsClient) DestroyModel(input DestroyModelInput) error {
 		return err
 	}
 
+	c.RemoveModel(input.UUID)
 	return nil
 }
 
@@ -371,7 +337,12 @@ func (c *modelsClient) GrantModel(input GrantModelInput) error {
 	client := modelmanager.NewClient(conn)
 	defer client.Close()
 
-	err = client.GrantModel(input.User, input.Access, input.ModelUUIDs...)
+	modelUUID, err := c.ModelUUID(input.ModelName)
+	if err != nil {
+		return err
+	}
+
+	err = client.GrantModel(input.User, input.Access, modelUUID)
 	if err != nil {
 		return err
 	}
@@ -386,7 +357,7 @@ func (c *modelsClient) UpdateAccessModel(input UpdateAccessModelInput) error {
 	model := input.ModelName
 	access := input.OldAccess
 
-	uuid, err := c.ResolveModelUUID(model)
+	uuid, err := c.ModelUUID(model)
 	if err != nil {
 		return err
 	}
@@ -423,7 +394,7 @@ func (c *modelsClient) DestroyAccessModel(input DestroyAccessModelInput) error {
 	id := strings.Split(input.Model, ":")
 	model := id[0]
 
-	uuid, err := c.ResolveModelUUID(model)
+	uuid, err := c.ModelUUID(model)
 	if err != nil {
 		return err
 	}

--- a/internal/juju/models.go
+++ b/internal/juju/models.go
@@ -33,7 +33,7 @@ func (me *modelNotFoundError) Error() string {
 }
 
 type modelsClient struct {
-	ConnectionFactory
+	SharedClient
 }
 
 type GrantModelInput struct {
@@ -92,9 +92,9 @@ type DestroyAccessModelInput struct {
 	Access string
 }
 
-func newModelsClient(cf ConnectionFactory) *modelsClient {
+func newModelsClient(sc SharedClient) *modelsClient {
 	return &modelsClient{
-		ConnectionFactory: cf,
+		SharedClient: sc,
 	}
 }
 

--- a/internal/juju/offers.go
+++ b/internal/juju/offers.go
@@ -29,7 +29,7 @@ const (
 )
 
 type offersClient struct {
-	ConnectionFactory
+	SharedClient
 }
 
 type CreateOfferInput struct {
@@ -76,9 +76,9 @@ type RemoveRemoteOfferInput struct {
 	OfferURL  string
 }
 
-func newOffersClient(cf ConnectionFactory) *offersClient {
+func newOffersClient(sc SharedClient) *offersClient {
 	return &offersClient{
-		ConnectionFactory: cf,
+		SharedClient: sc,
 	}
 }
 

--- a/internal/juju/offers.go
+++ b/internal/juju/offers.go
@@ -36,7 +36,6 @@ type CreateOfferInput struct {
 	ApplicationName string
 	Endpoint        string
 	ModelName       string
-	ModelUUID       string
 	ModelOwner      string
 	Name            string
 }
@@ -63,7 +62,7 @@ type DestroyOfferInput struct {
 }
 
 type ConsumeRemoteOfferInput struct {
-	ModelUUID string
+	ModelName string
 	OfferURL  string
 }
 
@@ -72,7 +71,7 @@ type ConsumeRemoteOfferResponse struct {
 }
 
 type RemoveRemoteOfferInput struct {
-	ModelUUID string
+	ModelName string
 	OfferURL  string
 }
 
@@ -99,7 +98,7 @@ func (c offersClient) CreateOffer(input *CreateOfferInput) (*CreateOfferResponse
 	}
 
 	// connect to the corresponding model
-	modelConn, err := c.GetConnection(&input.ModelUUID)
+	modelConn, err := c.GetConnection(&input.ModelName)
 	if err != nil {
 		return nil, append(errs, err)
 	}
@@ -116,7 +115,11 @@ func (c offersClient) CreateOffer(input *CreateOfferInput) (*CreateOfferResponse
 		return nil, append(errs, errors.New("the application was not available to be offered"))
 	}
 
-	result, err := client.Offer(input.ModelUUID, input.ApplicationName, []string{input.Endpoint}, "admin", offerName, "")
+	modelUUID, err := c.ModelUUID(input.ModelName)
+	if err != nil {
+		return nil, append(errs, err)
+	}
+	result, err := client.Offer(modelUUID, input.ApplicationName, []string{input.Endpoint}, "admin", offerName, "")
 	if err != nil {
 		return nil, append(errs, err)
 	}
@@ -252,7 +255,7 @@ func parseModelFromURL(url string) (result string, success bool) {
 
 // This function allows the integration resource to consume the offers managed by the offer resource
 func (c offersClient) ConsumeRemoteOffer(input *ConsumeRemoteOfferInput) (*ConsumeRemoteOfferResponse, error) {
-	modelConn, err := c.GetConnection(&input.ModelUUID)
+	modelConn, err := c.GetConnection(&input.ModelName)
 	if err != nil {
 		return nil, err
 	}
@@ -320,7 +323,7 @@ func (c offersClient) ConsumeRemoteOffer(input *ConsumeRemoteOfferInput) (*Consu
 // This function allows the integration resource to destroy the offers managed by the offer resource
 func (c offersClient) RemoveRemoteOffer(input *RemoveRemoteOfferInput) []error {
 	var errors []error
-	conn, err := c.GetConnection(&input.ModelUUID)
+	conn, err := c.GetConnection(&input.ModelName)
 	if err != nil {
 		errors = append(errors, err)
 		return errors

--- a/internal/juju/sshKeys.go
+++ b/internal/juju/sshKeys.go
@@ -18,13 +18,11 @@ type sshKeysClient struct {
 
 type CreateSSHKeyInput struct {
 	ModelName string
-	ModelUUID string
 	Payload   string
 }
 
 type ReadSSHKeyInput struct {
 	ModelName     string
-	ModelUUID     string
 	KeyIdentifier string
 }
 
@@ -35,7 +33,6 @@ type ReadSSHKeyOutput struct {
 
 type DeleteSSHKeyInput struct {
 	ModelName     string
-	ModelUUID     string
 	KeyIdentifier string
 }
 
@@ -46,7 +43,7 @@ func newSSHKeysClient(sc SharedClient) *sshKeysClient {
 }
 
 func (c *sshKeysClient) CreateSSHKey(input *CreateSSHKeyInput) error {
-	conn, err := c.GetConnection(&input.ModelUUID)
+	conn, err := c.GetConnection(&input.ModelName)
 	if err != nil {
 		return err
 	}
@@ -78,7 +75,7 @@ func (c *sshKeysClient) CreateSSHKey(input *CreateSSHKeyInput) error {
 }
 
 func (c *sshKeysClient) ReadSSHKey(input *ReadSSHKeyInput) (*ReadSSHKeyOutput, error) {
-	conn, err := c.GetConnection(&input.ModelUUID)
+	conn, err := c.GetConnection(&input.ModelName)
 	if err != nil {
 		return nil, err
 	}
@@ -108,7 +105,7 @@ func (c *sshKeysClient) ReadSSHKey(input *ReadSSHKeyInput) (*ReadSSHKeyOutput, e
 }
 
 func (c *sshKeysClient) DeleteSSHKey(input *DeleteSSHKeyInput) error {
-	conn, err := c.GetConnection(&input.ModelUUID)
+	conn, err := c.GetConnection(&input.ModelName)
 	if err != nil {
 		return err
 	}

--- a/internal/juju/sshKeys.go
+++ b/internal/juju/sshKeys.go
@@ -13,7 +13,7 @@ import (
 )
 
 type sshKeysClient struct {
-	ConnectionFactory
+	SharedClient
 }
 
 type CreateSSHKeyInput struct {
@@ -39,9 +39,9 @@ type DeleteSSHKeyInput struct {
 	KeyIdentifier string
 }
 
-func newSSHKeysClient(cf ConnectionFactory) *sshKeysClient {
+func newSSHKeysClient(sc SharedClient) *sshKeysClient {
 	return &sshKeysClient{
-		ConnectionFactory: cf,
+		SharedClient: sc,
 	}
 }
 

--- a/internal/juju/users.go
+++ b/internal/juju/users.go
@@ -101,7 +101,7 @@ func (c *usersClient) ReadUser(name string) (*ReadUserResponse, error) {
 	}, nil
 }
 
-func (c *usersClient) ModelUserInfo(uuid string) (*ReadModelUserResponse, error) {
+func (c *usersClient) ModelUserInfo(modelName string) (*ReadModelUserResponse, error) {
 	usermanagerConn, err := c.GetConnection(nil)
 	if err != nil {
 		return nil, err
@@ -109,6 +109,11 @@ func (c *usersClient) ModelUserInfo(uuid string) (*ReadModelUserResponse, error)
 
 	usermanagerClient := usermanager.NewClient(usermanagerConn)
 	defer usermanagerClient.Close()
+
+	uuid, err := c.ModelUUID(modelName)
+	if err != nil {
+		return nil, err
+	}
 
 	users, err := usermanagerClient.ModelUserInfo(uuid)
 	if err != nil {

--- a/internal/juju/users.go
+++ b/internal/juju/users.go
@@ -12,7 +12,7 @@ import (
 )
 
 type usersClient struct {
-	ConnectionFactory
+	SharedClient
 }
 
 type CreateUserInput struct {
@@ -50,9 +50,9 @@ type DestroyUserInput struct {
 	Name string
 }
 
-func newUsersClient(cf ConnectionFactory) *usersClient {
+func newUsersClient(sc SharedClient) *usersClient {
 	return &usersClient{
-		ConnectionFactory: cf,
+		SharedClient: sc,
 	}
 }
 

--- a/internal/juju/utils.go
+++ b/internal/juju/utils.go
@@ -56,7 +56,7 @@ var singleQuery sync.Once
 // GetLocalControllerConfig runs the locally installed juju command,
 // if available, to get the current controller configuration.
 func GetLocalControllerConfig() (map[string]string, error) {
-	// populate the controller config information only once
+	// populate the controller controllerConfig information only once
 	singleQuery.Do(populateControllerConfig)
 
 	// if empty something went wrong
@@ -95,7 +95,7 @@ func populateControllerConfig() {
 		// now v is a map[string]interface{} type
 		marshalled, err := json.Marshal(v)
 		if err != nil {
-			tflog.Error(context.TODO(), "error marshalling provider config", map[string]interface{}{"error": err})
+			tflog.Error(context.TODO(), "error marshalling provider controllerConfig", map[string]interface{}{"error": err})
 			return
 		}
 		// now we have a controllerConfig type
@@ -113,7 +113,7 @@ func populateControllerConfig() {
 	localProviderConfig["JUJU_USERNAME"] = controllerConfig.Account.User
 	localProviderConfig["JUJU_PASSWORD"] = controllerConfig.Account.Password
 
-	tflog.Debug(context.TODO(), "local provider config was set", map[string]interface{}{"localProviderConfig": fmt.Sprintf("%#v", localProviderConfig)})
+	tflog.Debug(context.TODO(), "local provider controllerConfig was set", map[string]interface{}{"localProviderConfig": fmt.Sprintf("%#v", localProviderConfig)})
 }
 
 // WaitForAppAvailable blocks the execution flow and waits until all the

--- a/internal/provider/data_source_machine.go
+++ b/internal/provider/data_source_machine.go
@@ -105,18 +105,13 @@ func (d *machineDataSource) Read(ctx context.Context, req datasource.ReadRequest
 	// "id" matches previous provider values however is not
 	// unique and is only used for tests. Data sources cannot
 	// be imported by terraform.
-	model, err := d.client.Models.GetModelByName(data.Model.ValueString())
-	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read model, got error: %s", err))
-		return
-	}
 	machine_id := data.MachineID.ValueString()
 	d.trace(fmt.Sprintf("reading juju machine %q data source", machine_id))
 
 	// Verify the machine exists in the model provided
-	if _, err = d.client.Machines.ReadMachine(
+	if _, err := d.client.Machines.ReadMachine(
 		juju.ReadMachineInput{
-			ModelUUID: model.UUID,
+			ModelName: data.Model.ValueString(),
 			MachineId: machine_id,
 		},
 	); err != nil {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -134,7 +134,7 @@ func configure() func(context.Context, *schema.ResourceData) (interface{}, diag.
 			return nil, diags
 		}
 
-		config := juju.Configuration{
+		config := juju.ControllerConfiguration{
 			ControllerAddresses: controllerAddresses,
 			Username:            username,
 			Password:            password,
@@ -266,7 +266,7 @@ func (p *jujuProvider) Configure(ctx context.Context, req frameworkprovider.Conf
 		return
 	}
 
-	config := juju.Configuration{
+	config := juju.ControllerConfiguration{
 		ControllerAddresses: strings.Split(data.ControllerAddrs.ValueString(), ","),
 		Username:            data.UserName.ValueString(),
 		Password:            data.Password.ValueString(),
@@ -377,7 +377,7 @@ func (p *jujuProvider) DataSources(_ context.Context) []func() datasource.DataSo
 	}
 }
 
-func checkClientErr(err error, config juju.Configuration) frameworkdiag.Diagnostics {
+func checkClientErr(err error, config juju.ControllerConfiguration) frameworkdiag.Diagnostics {
 	var errDetail string
 	var diags frameworkdiag.Diagnostics
 

--- a/internal/provider/resource_access_model.go
+++ b/internal/provider/resource_access_model.go
@@ -130,21 +130,13 @@ func (a *accessModelResource) Create(ctx context.Context, req resource.CreateReq
 	}
 
 	modelNameStr := plan.Model.ValueString()
-	// Get the modelUUID to call Models.GrantModel
-	uuid, err := a.client.Models.ResolveModelUUID(modelNameStr)
-	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to get model uuid, got error: %s", err))
-		return
-	}
-	modelUUIDs := []string{uuid}
-
 	accessStr := plan.Access.ValueString()
 	// Call Models.GrantModel
 	for _, user := range users {
 		err := a.client.Models.GrantModel(juju.GrantModelInput{
-			User:       user,
-			Access:     accessStr,
-			ModelUUIDs: modelUUIDs,
+			User:      user,
+			Access:    accessStr,
+			ModelName: modelNameStr,
 		})
 		if err != nil {
 			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create access model resource, got error: %s", err))
@@ -176,13 +168,7 @@ func (a *accessModelResource) Read(ctx context.Context, req resource.ReadRequest
 		return
 	}
 
-	modelUUID, err := a.client.Models.ResolveModelUUID(modelName)
-	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to get model uuid, got error: %s", err))
-		return
-	}
-
-	response, err := a.client.Users.ModelUserInfo(modelUUID)
+	response, err := a.client.Users.ModelUserInfo(modelName)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read access model resource, got error: %s", err))
 		return

--- a/internal/provider/resource_model_test.go
+++ b/internal/provider/resource_model_test.go
@@ -226,12 +226,7 @@ func testAccCheckDevelopmentConfigIsUnset(modelName string) resource.TestCheckFu
 	return func(s *terraform.State) error {
 		client := Provider.Meta().(*juju.Client)
 
-		uuid, err := client.Models.ResolveModelUUID(modelName)
-		if err != nil {
-			return err
-		}
-
-		conn, err := client.Models.GetConnection(&uuid)
+		conn, err := client.Models.GetConnection(&modelName)
 		if err != nil {
 			return err
 		}
@@ -253,8 +248,8 @@ func testAccCheckDevelopmentConfigIsUnset(modelName string) resource.TestCheckFu
 				}
 
 				if actual.Value != expected.Value || actual.Source != expected.Source {
-					return fmt.Errorf("expecting 'development' config for model: %s (%s), to be %#v but was: %#v",
-						modelName, uuid, expected, actual)
+					return fmt.Errorf("expecting 'development' config for model: %s, to be %#v but was: %#v",
+						modelName, expected, actual)
 				}
 			}
 		}

--- a/internal/provider/resource_offer.go
+++ b/internal/provider/resource_offer.go
@@ -121,7 +121,6 @@ func (o *offerResource) Create(ctx context.Context, req resource.CreateRequest, 
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to get model %q, got error: %s", modelName, err))
 		return
 	}
-	modelUUID := modelInfo.UUID
 	// TODO (cderici): Leaking Juju info here:
 	// 1 - GetModelByName above returns *params.ModelInfo
 	// 2 - we don't return tag trimmed so provider has to know juju.PrefixUser etc. Make a Tag type and have a Tag.
@@ -136,7 +135,6 @@ func (o *offerResource) Create(ctx context.Context, req resource.CreateRequest, 
 
 	response, errs := o.client.Offers.CreateOffer(&juju.CreateOfferInput{
 		ModelName:       modelName,
-		ModelUUID:       modelUUID,
 		ModelOwner:      modelOwner,
 		Name:            offerName,
 		ApplicationName: plan.ApplicationName.ValueString(),

--- a/internal/provider/resource_ssh_key.go
+++ b/internal/provider/resource_ssh_key.go
@@ -120,18 +120,11 @@ func (s *sshKeyResource) Create(ctx context.Context, req resource.CreateRequest,
 	}
 
 	modelName := plan.ModelName.ValueString()
-	modelUUID, err := s.client.Models.ResolveModelUUID(modelName)
-	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to resolve model UUID, got error: %s", err))
-		return
-	}
 
-	err = s.client.SSHKeys.CreateSSHKey(&juju.CreateSSHKeyInput{
+	if err := s.client.SSHKeys.CreateSSHKey(&juju.CreateSSHKeyInput{
 		ModelName: modelName,
-		ModelUUID: modelUUID,
 		Payload:   payload,
-	})
-	if err != nil {
+	}); err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create ssh_key, got error %s", err))
 		return
 	}
@@ -179,15 +172,8 @@ func (s *sshKeyResource) Read(ctx context.Context, req resource.ReadRequest, res
 		return
 	}
 
-	modelUUID, err := s.client.Models.ResolveModelUUID(modelName)
-	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to resolve model UUID, got error: %s", err))
-		return
-	}
-
 	result, err := s.client.SSHKeys.ReadSSHKey(&juju.ReadSSHKeyInput{
 		ModelName:     modelName,
-		ModelUUID:     modelUUID,
 		KeyIdentifier: keyIdentifier,
 	})
 	if err != nil {
@@ -232,39 +218,22 @@ func (s *sshKeyResource) Update(ctx context.Context, req resource.UpdateRequest,
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	modelUUID, err := s.client.Models.ResolveModelUUID(modelName)
-	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to resolve model UUID, got error: %s", err))
-		return
-	}
 
 	// Delete the key
-	err = s.client.SSHKeys.DeleteSSHKey(&juju.DeleteSSHKeyInput{
+	if err := s.client.SSHKeys.DeleteSSHKey(&juju.DeleteSSHKeyInput{
 		ModelName:     modelName,
-		ModelUUID:     modelUUID,
 		KeyIdentifier: keyIdentifier,
-	})
-	if err != nil {
+	}); err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete ssh key for updating, got error: %s", err))
 		return
 	}
 	s.trace(fmt.Sprintf("ssh key deleted : %q", state.ID.ValueString()))
 
-	// Get the model name from the plan because it might have changed
-	newModelName := plan.ModelName.ValueString()
-	newModelUUID, err := s.client.Models.ResolveModelUUID(newModelName)
-	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to resolve model UUID, got error: %s", err))
-		return
-	}
-
 	// Create a new key
-	err = s.client.SSHKeys.CreateSSHKey(&juju.CreateSSHKeyInput{
-		ModelName: newModelName,
-		ModelUUID: newModelUUID,
+	if err := s.client.SSHKeys.CreateSSHKey(&juju.CreateSSHKeyInput{
+		ModelName: plan.ModelName.ValueString(),
 		Payload:   plan.Payload.ValueString(),
-	})
-	if err != nil {
+	}); err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create ssh key for updating, got error: %s", err))
 		return
 	}
@@ -302,19 +271,12 @@ func (s *sshKeyResource) Delete(ctx context.Context, req resource.DeleteRequest,
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	modelUUID, err := s.client.Models.ResolveModelUUID(modelName)
-	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to resolve model UUID, got error: %s", err))
-		return
-	}
 
 	// Delete the key
-	err = s.client.SSHKeys.DeleteSSHKey(&juju.DeleteSSHKeyInput{
+	if err := s.client.SSHKeys.DeleteSSHKey(&juju.DeleteSSHKeyInput{
 		ModelName:     modelName,
-		ModelUUID:     modelUUID,
 		KeyIdentifier: keyIdentifier,
-	})
-	if err != nil {
+	}); err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete ssh key during delete, got error: %s", err))
 		return
 	}


### PR DESCRIPTION
## Description

Improve the separation of concerns between the provider and internal juju client. The provider has no need to know the model uuid nor type in all but a few cases. Move the knowledge back into the internal juju client.

For all Create, Read and Update call by resources and data sources, the provider gets the model UUID from the juju controller first. There are two problems with this. One, the model uuid is unrelated to what the provider is doing, and should be done in the internal/juju package. Two, the model uuid is immutable once created, there is no need to keep getting the same data over and over. 

Resolve this by caching model name, uuid and type inside of the internal juju client for use within the juju client which is shared between resources and data sources. As well as removing the provider dependency on knowing the model uuid before other juju client calls. 

The internal juju client is short lived, however may terraform plans can be large so this saves n-1 calls to ListModelSummaries where n is the number of resources and data sources in the plan.

## Type of change

- Maintenance work (repository related, like Github actions, or revving the Go version, etc.)


## QA steps

Run the acceptance tests and any plan you wish.

## Additional notes

JUJU-4578
