### PR TITLE
Remove mux used for migration from sdk2 to framework

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/hashicorp/terraform-plugin-framework-validators v0.12.0
 	github.com/hashicorp/terraform-plugin-go v0.18.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
-	github.com/hashicorp/terraform-plugin-mux v0.11.2
 	github.com/hashicorp/terraform-plugin-testing v1.5.1
 	github.com/juju/charm/v8 v8.0.6
 	github.com/juju/clock v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -442,8 +442,6 @@ github.com/hashicorp/terraform-plugin-go v0.18.0 h1:IwTkOS9cOW1ehLd/rG0y+u/TGLK9
 github.com/hashicorp/terraform-plugin-go v0.18.0/go.mod h1:l7VK+2u5Kf2y+A+742GX0ouLut3gttudmvMgN0PA74Y=
 github.com/hashicorp/terraform-plugin-log v0.9.0 h1:i7hOA+vdAItN1/7UrfBqBwvYPQ9TFvymaRGZED3FCV0=
 github.com/hashicorp/terraform-plugin-log v0.9.0/go.mod h1:rKL8egZQ/eXSyDqzLUuwUYLVdlYeamldAHSxjUFADow=
-github.com/hashicorp/terraform-plugin-mux v0.11.2 h1:XMkAmWQN+6F+l4jwNeqdPom/8Vly6ZNDxHoKjiRHx5c=
-github.com/hashicorp/terraform-plugin-mux v0.11.2/go.mod h1:qjoF/pI49rILSNQzKIuDtU+ZX9mpQD0B8YNE1GceLPc=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.28.0 h1:gY4SG34ANc6ZSeWEKC9hDTChY0ZiN+Myon17fSA0Xgc=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.28.0/go.mod h1:deXEw/iJXtJxNV9d1c/OVJrvL7Zh0a++v7rzokW6wVY=
 github.com/hashicorp/terraform-plugin-testing v1.5.1 h1:T4aQh9JAhmWo4+t1A7x+rnxAJHCDIYW9kXyo4sVO92c=

--- a/internal/provider/data_source_machine_test.go
+++ b/internal/provider/data_source_machine_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
-func TestAcc_DataSourceMachine_sdk2_framework_migrate(t *testing.T) {
+func TestAcc_DataSourceMachine_Edge(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
@@ -19,34 +19,16 @@ func TestAcc_DataSourceMachine_sdk2_framework_migrate(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: muxProviderFactories,
+		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceMachine_sdk2_framework_migrate(modelName),
+				Config: testAccDataSourceMachine(modelName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.juju_machine.machine", "model", modelName),
 				),
 			},
 		},
 	})
-}
-
-func testAccDataSourceMachine_sdk2_framework_migrate(modelName string) string {
-	return fmt.Sprintf(`
-resource "juju_model" "model" {
-  name = %q
-}
-
-resource "juju_machine" "machine" {
-  model = juju_model.model.name
-  name = "machine"
-  series = "jammy"
-}
-
-data "juju_machine" "machine" {
-  model = juju_model.model.name
-  machine_id = juju_machine.machine.machine_id
-}`, modelName)
 }
 
 func TestAcc_DataSourceMachine_Stable(t *testing.T) {
@@ -65,7 +47,7 @@ func TestAcc_DataSourceMachine_Stable(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceMachine_Stable(modelName),
+				Config: testAccDataSourceMachine(modelName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.juju_machine.machine", "model", modelName),
 				),
@@ -74,7 +56,7 @@ func TestAcc_DataSourceMachine_Stable(t *testing.T) {
 	})
 }
 
-func testAccDataSourceMachine_Stable(modelName string) string {
+func testAccDataSourceMachine(modelName string) string {
 	return fmt.Sprintf(`
 resource "juju_model" "model" {
   name = %q

--- a/internal/provider/data_source_model_test.go
+++ b/internal/provider/data_source_model_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
-func TestAcc_DataSourceModel_sdk2_framework_migrate(t *testing.T) {
+func TestAcc_DataSourceModel_Edge(t *testing.T) {
 	modelName := acctest.RandomWithPrefix("tf-datasource-model-test")
 
 	resource.Test(t, resource.TestCase{
@@ -19,7 +19,7 @@ func TestAcc_DataSourceModel_sdk2_framework_migrate(t *testing.T) {
 		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFrameworkDataSourceModel_sdk2_framework_migrate(t, modelName),
+				Config: testAccFrameworkDataSourceModel(modelName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.juju_model.test-model", "name", modelName),
 					resource.TestCheckResourceAttrSet("data.juju_model.test-model", "uuid"),
@@ -27,17 +27,6 @@ func TestAcc_DataSourceModel_sdk2_framework_migrate(t *testing.T) {
 			},
 		},
 	})
-}
-
-func testAccFrameworkDataSourceModel_sdk2_framework_migrate(t *testing.T, modelName string) string {
-	return fmt.Sprintf(`
-resource "juju_model" "test-model" {
-	name = %q
-}
-
-data "juju_model" "test-model" {
-	name = juju_model.test-model.name
-}`, modelName)
 }
 
 func TestAcc_DataSourceModel_Stable(t *testing.T) {
@@ -53,7 +42,7 @@ func TestAcc_DataSourceModel_Stable(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFrameworkDataSourceModel_Stable(t, modelName),
+				Config: testAccFrameworkDataSourceModel(modelName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.juju_model.test-model", "name", modelName),
 					resource.TestCheckResourceAttrSet("data.juju_model.test-model", "uuid"),
@@ -63,7 +52,7 @@ func TestAcc_DataSourceModel_Stable(t *testing.T) {
 	})
 }
 
-func testAccFrameworkDataSourceModel_Stable(t *testing.T, modelName string) string {
+func testAccFrameworkDataSourceModel(modelName string) string {
 	return fmt.Sprintf(`
 resource "juju_model" "test-model" {
 	name = %q

--- a/internal/provider/data_source_model_test.go
+++ b/internal/provider/data_source_model_test.go
@@ -16,7 +16,7 @@ func TestAcc_DataSourceModel_sdk2_framework_migrate(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: muxProviderFactories,
+		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccFrameworkDataSourceModel_sdk2_framework_migrate(t, modelName),

--- a/internal/provider/data_source_offer_test.go
+++ b/internal/provider/data_source_offer_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
-func TestAcc_DataSourceOffer_sdk2_framework_migrate(t *testing.T) {
+func TestAcc_DataSourceOffer_Edge(t *testing.T) {
 	modelName := acctest.RandomWithPrefix("tf-datasource-offer-test-model")
 	// ...-test-[0-9]+ is not a valid offer name, need to remove the dash before numbers
 	offerName := fmt.Sprintf("tf-datasource-offer-test%d", acctest.RandInt())
@@ -21,7 +21,7 @@ func TestAcc_DataSourceOffer_sdk2_framework_migrate(t *testing.T) {
 		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceOffer_sdk2_framework_migrate(modelName, offerName),
+				Config: testAccDataSourceOffer(modelName, offerName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.juju_offer.this", "model", modelName),
 					resource.TestCheckResourceAttr("data.juju_offer.this", "name", offerName),
@@ -29,35 +29,6 @@ func TestAcc_DataSourceOffer_sdk2_framework_migrate(t *testing.T) {
 			},
 		},
 	})
-}
-
-func testAccDataSourceOffer_sdk2_framework_migrate(modelName string, offerName string) string {
-	return fmt.Sprintf(`
-resource "juju_model" "this" {
-	name = %q
-}
-
-resource "juju_application" "this" {
-	model = juju_model.this.name
-	name  = "this"
-
-	charm {
-		name = "postgresql"
-		series = "focal"
-	}
-}
-
-resource "juju_offer" "this" {
-	model            = juju_model.this.name
-	application_name = juju_application.this.name
-	endpoint         = "db"
-	name             = %q
-}
-
-data "juju_offer" "this" {
-	url = juju_offer.this.url
-}
-`, modelName, offerName)
 }
 
 func TestAcc_DataSourceOffer_Stable(t *testing.T) {
@@ -75,7 +46,7 @@ func TestAcc_DataSourceOffer_Stable(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceOffer_Stable(modelName, offerName),
+				Config: testAccDataSourceOffer(modelName, offerName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.juju_offer.this", "model", modelName),
 					resource.TestCheckResourceAttr("data.juju_offer.this", "name", offerName),
@@ -85,7 +56,7 @@ func TestAcc_DataSourceOffer_Stable(t *testing.T) {
 	})
 }
 
-func testAccDataSourceOffer_Stable(modelName string, offerName string) string {
+func testAccDataSourceOffer(modelName string, offerName string) string {
 	return fmt.Sprintf(`
 resource "juju_model" "this" {
 	name = %q

--- a/internal/provider/data_source_offer_test.go
+++ b/internal/provider/data_source_offer_test.go
@@ -18,7 +18,7 @@ func TestAcc_DataSourceOffer_sdk2_framework_migrate(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: muxProviderFactories,
+		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceOffer_sdk2_framework_migrate(modelName, offerName),

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -12,19 +12,13 @@ import (
 	frameworkprovider "github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
-	"github.com/hashicorp/terraform-plugin-mux/tf5to6server"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/assert"
 )
 
 const TestProviderStableVersion = "0.8.0"
-
-// muxProviderFactories are used to instantiate the SDK provider and Framework provider
-// during acceptance testing.
-var muxProviderFactories map[string]func() (tfprotov6.ProviderServer, error)
 
 // frameworkProviderFactories are used to instantiate the Framework provider during
 // acceptance testing.
@@ -36,21 +30,6 @@ var Provider *schema.Provider
 
 func init() {
 	Provider = New("dev")()
-
-	upgradedSdkProvider, err := tf5to6server.UpgradeServer(
-		context.Background(),
-		Provider.GRPCProvider,
-	)
-	if err != nil {
-		log.Fatal().Msgf("Provider test init() failed with : %v", err.Error())
-	}
-
-	muxProviderFactories = map[string]func() (tfprotov6.ProviderServer, error){
-		"juju": providerserver.NewProtocol6WithError(NewJujuProvider("dev")),
-		"oldjuju": func() (tfprotov6.ProviderServer, error) {
-			return upgradedSdkProvider, err
-		},
-	}
 
 	frameworkProviderFactories = map[string]func() (tfprotov6.ProviderServer, error){
 		"juju": providerserver.NewProtocol6WithError(NewJujuProvider("dev")),

--- a/internal/provider/resource_access_model_test.go
+++ b/internal/provider/resource_access_model_test.go
@@ -25,7 +25,7 @@ func TestAcc_ResourceAccessModel_sdk2_framework_migrate(t *testing.T) {
 	resourceName := "juju_access_model.test"
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: muxProviderFactories,
+		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccResourceAccessModel_sdk2_framework_migrate(userName, userPassword, modelName1, accessFail),

--- a/internal/provider/resource_access_model_test.go
+++ b/internal/provider/resource_access_model_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
-func TestAcc_ResourceAccessModel_sdk2_framework_migrate(t *testing.T) {
+func TestAcc_ResourceAccessModel_Edge(t *testing.T) {
 	userName := acctest.RandomWithPrefix("tfuser")
 	userPassword := acctest.RandomWithPrefix("tf-test-user")
 	userName2 := acctest.RandomWithPrefix("tfuser")
@@ -28,11 +28,11 @@ func TestAcc_ResourceAccessModel_sdk2_framework_migrate(t *testing.T) {
 		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccResourceAccessModel_sdk2_framework_migrate(userName, userPassword, modelName1, accessFail),
+				Config:      testAccResourceAccessModel(userName, userPassword, modelName1, accessFail),
 				ExpectError: regexp.MustCompile("Error running pre-apply refresh.*"),
 			},
 			{
-				Config: testAccResourceAccessModel_sdk2_framework_migrate(userName, userPassword, modelName1, accessSuccess),
+				Config: testAccResourceAccessModel(userName, userPassword, modelName1, accessSuccess),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "model", modelName1),
 					resource.TestCheckResourceAttr(resourceName, "access", accessSuccess),
@@ -47,7 +47,7 @@ func TestAcc_ResourceAccessModel_sdk2_framework_migrate(t *testing.T) {
 				ResourceName:      resourceName,
 			},
 			{
-				Config: testAccFrameworkResourceAccessModel_sdk2_framework_migrate(t, userName2, userPassword2,
+				Config: testAccResourceAccessModel(userName2, userPassword2,
 					modelName2, accessSuccess),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "access", accessSuccess),
@@ -64,42 +64,6 @@ func TestAcc_ResourceAccessModel_sdk2_framework_migrate(t *testing.T) {
 			},
 		},
 	})
-}
-
-func testAccResourceAccessModel_sdk2_framework_migrate(userName, userPassword, modelName, access string) string {
-	return fmt.Sprintf(`
-resource "juju_user" "this" {
-  name = %q
-  password = %q
-}
-
-resource "juju_model" "this" {
-  name = %q
-}
-
-resource "juju_access_model" "test" {
-  access = %q
-  model = juju_model.this.name
-  users = [juju_user.this.name]
-}`, userName, userPassword, modelName, access)
-}
-
-func testAccFrameworkResourceAccessModel_sdk2_framework_migrate(t *testing.T, userName, userPassword, modelName, access string) string {
-	return fmt.Sprintf(`
-resource "juju_user" "test-user" {
-  name = %q
-  password = %q
-}
-
-resource "juju_model" "test-model" {
-  name = %q
-}
-
-resource "juju_access_model" "test" {
-  access = %q
-  model = juju_model.test-model.name
-  users = [juju_user.test-user.name]
-}`, userName, userPassword, modelName, access)
 }
 
 func TestAcc_ResourceAccessModel_Stable(t *testing.T) {
@@ -120,7 +84,7 @@ func TestAcc_ResourceAccessModel_Stable(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccResourceAccessModel_Stable(userName, userPassword, modelName, accessFail),
+				Config:      testAccResourceAccessModel(userName, userPassword, modelName, accessFail),
 				ExpectError: regexp.MustCompile("Error running pre-apply refresh.*"),
 			},
 			{
@@ -130,7 +94,7 @@ func TestAcc_ResourceAccessModel_Stable(t *testing.T) {
 				SkipFunc: func() (bool, error) {
 					return testingCloud != LXDCloudTesting, nil
 				},
-				Config: testAccResourceAccessModel_Stable(userName, userPassword, modelName, access),
+				Config: testAccResourceAccessModel(userName, userPassword, modelName, access),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "access", access),
 					resource.TestCheckResourceAttr(resourceName, "model", modelName),
@@ -150,7 +114,7 @@ func TestAcc_ResourceAccessModel_Stable(t *testing.T) {
 	})
 }
 
-func testAccResourceAccessModel_Stable(userName, userPassword, modelName, access string) string {
+func testAccResourceAccessModel(userName, userPassword, modelName, access string) string {
 	return fmt.Sprintf(`
 resource "juju_user" "test-user" {
   name = %q

--- a/internal/provider/resource_application_test.go
+++ b/internal/provider/resource_application_test.go
@@ -19,7 +19,7 @@ func TestAcc_ResourceApplication_sdk2_framework_migrate(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: muxProviderFactories,
+		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				// Mind that ExpectError should be the first step
@@ -123,7 +123,7 @@ func TestAcc_ResourceApplication_Updates_sdk2_framework_migrate(t *testing.T) {
 	}
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: muxProviderFactories,
+		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccResourceApplicationUpdates_sdk2_framework_migrate(modelName, 1, true, "machinename"),
@@ -181,7 +181,7 @@ func TestAcc_CharmUpdates_sdk2_framework_migrate(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: muxProviderFactories,
+		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccResourceApplicationUpdatesCharm_sdk2_framework_migrate(modelName, "latest/stable"),
@@ -419,7 +419,7 @@ func TestAcc_ResourceApplication_Minimal(t *testing.T) {
 	resourceName := "juju_application.testapp"
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: muxProviderFactories,
+		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccResourceApplicationBasic_Minimal(modelName, charmName),

--- a/internal/provider/resource_application_test.go
+++ b/internal/provider/resource_application_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
-func TestAcc_ResourceApplication_sdk2_framework_migrate(t *testing.T) {
+func TestAcc_ResourceApplication_Edge(t *testing.T) {
 	modelName := acctest.RandomWithPrefix("tf-test-application")
 	appName := "test-app"
 	appInvalidName := "test_app"
@@ -25,11 +25,11 @@ func TestAcc_ResourceApplication_sdk2_framework_migrate(t *testing.T) {
 				// Mind that ExpectError should be the first step
 				// "When tests have an ExpectError[...]; this results in any previous state being cleared. "
 				// https://github.com/hashicorp/terraform-plugin-sdk/issues/118
-				Config:      testAccResourceApplicationBasic_sdk2_framework_migrate(modelName, appInvalidName),
+				Config:      testAccResourceApplicationBasic(modelName, appInvalidName),
 				ExpectError: regexp.MustCompile(fmt.Sprintf("Unable to create application, got error: invalid application name %q,\nunexpected character _", appInvalidName)),
 			},
 			{
-				Config: testAccResourceApplicationBasic_sdk2_framework_migrate(modelName, appName),
+				Config: testAccResourceApplicationBasic(modelName, appName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("juju_application.this", "model", modelName),
 					resource.TestCheckResourceAttr("juju_application.this", "name", appName),
@@ -57,7 +57,7 @@ func TestAcc_ResourceApplication_sdk2_framework_migrate(t *testing.T) {
 					return true, nil
 					//return testingCloud != LXDCloudTesting, nil
 				},
-				Config: testAccResourceApplicationConstraints_sdk2_framework_migrate(modelName, "arch=amd64 cores=1 mem=4096M"),
+				Config: testAccResourceApplicationConstraints(modelName, "arch=amd64 cores=1 mem=4096M"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("juju_application.this", "model", modelName),
 					resource.TestCheckResourceAttr("juju_application.this", "constraints", "arch=amd64 cores=1 mem=4096M"),
@@ -78,7 +78,7 @@ func TestAcc_ResourceApplication_sdk2_framework_migrate(t *testing.T) {
 					return true, nil
 					//return testingCloud != MicroK8sTesting, nil
 				},
-				Config: testAccResourceApplicationConstraints_sdk2_framework_migrate(modelName, "arch=amd64 mem=4096M"),
+				Config: testAccResourceApplicationConstraints(modelName, "arch=amd64 mem=4096M"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("juju_application.this", "model", modelName),
 					resource.TestCheckResourceAttr("juju_application.this", "constraints", "arch=amd64 mem=4096M"),
@@ -98,7 +98,7 @@ func TestAcc_ResourceApplication_sdk2_framework_migrate(t *testing.T) {
 					return true, nil
 					//return testingCloud != LXDCloudTesting, nil
 				},
-				Config: testAccResourceApplicationConstraintsSubordinate_sdk2_framework_migrate(modelName, "arch=amd64 cores=1 mem=4096M"),
+				Config: testAccResourceApplicationConstraintsSubordinate(modelName, "arch=amd64 cores=1 mem=4096M"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("juju_application.this", "model", modelName),
 					resource.TestCheckResourceAttr("juju_application.this", "constraints", "arch=amd64 cores=1 mem=4096M"),
@@ -115,7 +115,7 @@ func TestAcc_ResourceApplication_sdk2_framework_migrate(t *testing.T) {
 	})
 }
 
-func TestAcc_ResourceApplication_Updates_sdk2_framework_migrate(t *testing.T) {
+func TestAcc_ResourceApplication_Updates_Edge(t *testing.T) {
 	modelName := acctest.RandomWithPrefix("tf-test-application")
 	appName := "jameinel-ubuntu-lite"
 	if testingCloud != LXDCloudTesting {
@@ -126,7 +126,7 @@ func TestAcc_ResourceApplication_Updates_sdk2_framework_migrate(t *testing.T) {
 		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceApplicationUpdates_sdk2_framework_migrate(modelName, 1, true, "machinename"),
+				Config: testAccResourceApplicationUpdates(modelName, 1, true, "machinename"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("juju_application.this", "model", modelName),
 					resource.TestCheckResourceAttr("juju_application.this", "charm.#", "1"),
@@ -142,29 +142,29 @@ func TestAcc_ResourceApplication_Updates_sdk2_framework_migrate(t *testing.T) {
 				SkipFunc: func() (bool, error) {
 					return testingCloud != LXDCloudTesting, nil
 				},
-				Config: testAccResourceApplicationUpdates_sdk2_framework_migrate(modelName, 2, true, "machinename"),
+				Config: testAccResourceApplicationUpdates(modelName, 2, true, "machinename"),
 				Check:  resource.TestCheckResourceAttr("juju_application.this", "units", "2"),
 			},
 			{
 				SkipFunc: func() (bool, error) {
 					return testingCloud != LXDCloudTesting, nil
 				},
-				Config: testAccResourceApplicationUpdates_sdk2_framework_migrate(modelName, 2, true, "machinename"),
+				Config: testAccResourceApplicationUpdates(modelName, 2, true, "machinename"),
 				Check:  resource.TestCheckResourceAttr("juju_application.this", "charm.0.revision", "10"),
 			},
 			{
 				SkipFunc: func() (bool, error) {
 					return testingCloud != MicroK8sTesting, nil
 				},
-				Config: testAccResourceApplicationUpdates_sdk2_framework_migrate(modelName, 2, true, "machinename"),
+				Config: testAccResourceApplicationUpdates(modelName, 2, true, "machinename"),
 				Check:  resource.TestCheckResourceAttr("juju_application.this", "charm.0.revision", "19"),
 			},
 			{
-				Config: testAccResourceApplicationUpdates_sdk2_framework_migrate(modelName, 2, false, "machinename"),
+				Config: testAccResourceApplicationUpdates(modelName, 2, false, "machinename"),
 				Check:  resource.TestCheckResourceAttr("juju_application.this", "expose.#", "0"),
 			},
 			{
-				Config: testAccResourceApplicationUpdates_sdk2_framework_migrate(modelName, 2, true, "machinename"),
+				Config: testAccResourceApplicationUpdates(modelName, 2, true, "machinename"),
 				Check:  resource.TestCheckResourceAttr("juju_application.this", "expose.#", "1"),
 			},
 			{
@@ -176,7 +176,7 @@ func TestAcc_ResourceApplication_Updates_sdk2_framework_migrate(t *testing.T) {
 	})
 }
 
-func TestAcc_CharmUpdates_sdk2_framework_migrate(t *testing.T) {
+func TestAcc_CharmUpdates_Edge(t *testing.T) {
 	modelName := acctest.RandomWithPrefix("tf-test-charmupdates")
 
 	resource.Test(t, resource.TestCase{
@@ -184,228 +184,27 @@ func TestAcc_CharmUpdates_sdk2_framework_migrate(t *testing.T) {
 		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceApplicationUpdatesCharm_sdk2_framework_migrate(modelName, "latest/stable"),
+				Config: testAccResourceApplicationUpdatesCharm(modelName, "latest/stable"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("juju_application.this", "charm.0.channel", "latest/stable"),
 				),
 			},
 			{
 				// move to latest/edge
-				Config: testAccResourceApplicationUpdatesCharm_sdk2_framework_migrate(modelName, "latest/edge"),
+				Config: testAccResourceApplicationUpdatesCharm(modelName, "latest/edge"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("juju_application.this", "charm.0.channel", "latest/edge"),
 				),
 			},
 			{
 				// move back to latest/stable
-				Config: testAccResourceApplicationUpdatesCharm_sdk2_framework_migrate(modelName, "latest/stable"),
+				Config: testAccResourceApplicationUpdatesCharm(modelName, "latest/stable"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("juju_application.this", "charm.0.channel", "latest/stable"),
 				),
 			},
 		},
 	})
-}
-
-func testAccResourceApplicationBasic_sdk2_framework_migrate(modelName, appInvalidName string) string {
-	if testingCloud == LXDCloudTesting {
-		return fmt.Sprintf(`
-        resource "juju_model" "this" {
-          name = %q
-		}
-		
-		resource "juju_application" "this" {
-		  model = juju_model.this.name
-		  name = %q
-		  charm {
-			name = "jameinel-ubuntu-lite"
-		  }
-		  trust = true
-		  expose{}
-		}
-		`, modelName, appInvalidName)
-	} else {
-		// if we have a K8s deployment we need the machine hostname
-		return fmt.Sprintf(`
-        resource "juju_model" "this" {
-          name = %q
-		}
-		
-		resource "juju_application" "this" {
-		  model = juju_model.this.name
-		  name = %q
-		  charm {
-			name = "jameinel-ubuntu-lite"
-		  }
-		  trust = true
-		  expose{}
-		  config = {
-			juju-external-hostname="myhostname"
-		  }
-		}
-		`, modelName, appInvalidName)
-	}
-}
-
-func testAccResourceApplicationUpdates_sdk2_framework_migrate(modelName string, units int, expose bool, hostname string) string {
-	exposeStr := "expose{}"
-	if !expose {
-		exposeStr = ""
-	}
-
-	if testingCloud == LXDCloudTesting {
-		return fmt.Sprintf(`
-        resource "juju_model" "this" {
-          name = %q
-		}
-		
-		resource "juju_application" "this" {
-		  model = juju_model.this.name
-		  units = %d
-		  charm {
-			name     = "jameinel-ubuntu-lite"
-		  }
-		  trust = true
-		  %s
-		  # config = {
-		  #	 hostname = "%s"
-		  # }
-		}
-		`, modelName, units, exposeStr, hostname)
-	} else {
-		return fmt.Sprintf(`
-        resource "juju_model" "this" {
-          name = %q
-		}
-		
-		resource "juju_application" "this" {
-		  model = juju_model.this.name
-		  units = %d
-		  charm {
-			name     = "hello-kubecon"
-		  }
-		  trust = true
-		  %s
-		  config = {
-		  	# hostname = "%s"
-			juju-external-hostname="myhostname"
-		  }
-		}
-		`, modelName, units, exposeStr, hostname)
-	}
-}
-
-func testAccResourceApplicationUpdatesCharm_sdk2_framework_migrate(modelName string, channel string) string {
-	if testingCloud == LXDCloudTesting {
-		return fmt.Sprintf(`
-        resource "juju_model" "this" {
-          name = %q
-		}
-		
-		resource "juju_application" "this" {
-		  model = juju_model.this.name
-		  name = "test-app"
-		  charm {
-			name     = "ubuntu"
-			channel = %q
-		  }
-		}
-		`, modelName, channel)
-	} else {
-		return fmt.Sprintf(`
-        resource "juju_model" "this" {
-          name = %q
-		}
-		
-		resource "juju_application" "this" {
-		  model = juju_model.this.name
-		  name = "test-app"
-		  charm {
-			name     = "hello-kubecon"
-			channel = %q
-		  }
-		}
-		`, modelName, channel)
-	}
-}
-
-// testAccResourceApplicationConstraints will return two set for constraint
-// applications. The version to be used in K8s sets the juju-external-hostname
-// because we set the expose parameter.
-func testAccResourceApplicationConstraints_sdk2_framework_migrate(modelName string, constraints string) string {
-	if testingCloud == LXDCloudTesting {
-		return fmt.Sprintf(`
-resource "juju_model" "this" {
-   name = %q
-}
-
-resource "juju_application" "this" {
-  model = juju_model.this.name
-  units = 0
-  name = "test-app"
-  charm {
-    name     = "jameinel-ubuntu-lite"
-    revision = 10
-  }
-  
-  trust = true 
-  expose{}
-  constraints = "%s"
-}
-`, modelName, constraints)
-	} else {
-		return fmt.Sprintf(`
-resource "juju_model" "this" {
-  name = %q
-}
-
-resource "juju_application" "this" {
-  model = juju_model.this.name
-  name = "test-app"
-  charm {
-    name     = "jameinel-ubuntu-lite"
-	revision = 10
-  }
-  trust = true
-  expose{}
-  constraints = "%s"
-  config = {
-    juju-external-hostname="myhostname"
-  }
-}
-`, modelName, constraints)
-	}
-}
-
-func testAccResourceApplicationConstraintsSubordinate_sdk2_framework_migrate(modelName string, constraints string) string {
-	return fmt.Sprintf(`
-resource "juju_model" "this" {
-  name = %q
-}
-
-resource "juju_application" "this" {
-  model = juju_model.this.name
-  units = 0
-  name = "test-app"
-  charm {
-    name     = "jameinel-ubuntu-lite"
-    revision = 10
-  }
-  trust = true
-  expose{}
-  constraints = "%s"
-}
-
-resource "juju_application" "subordinate" {
-  model = juju_model.this.name
-  units = 0
-  name = "test-subordinate"
-  charm {
-    name = "nrpe"
-    revision = 96
-    }
-} 
-`, modelName, constraints)
 }
 
 func TestAcc_ResourceApplication_Minimal(t *testing.T) {
@@ -458,11 +257,11 @@ func TestAcc_ResourceApplication_Stable(t *testing.T) {
 				// Mind that ExpectError should be the first step
 				// "When tests have an ExpectError[...]; this results in any previous state being cleared. "
 				// https://github.com/hashicorp/terraform-plugin-sdk/issues/118
-				Config:      testAccResourceApplicationBasic_Stable(modelName, appInvalidName),
+				Config:      testAccResourceApplicationBasic(modelName, appInvalidName),
 				ExpectError: regexp.MustCompile(fmt.Sprintf("Error: invalid application name \"%s\", unexpected character _", appInvalidName)),
 			},
 			{
-				Config: testAccResourceApplicationBasic_Stable(modelName, appName),
+				Config: testAccResourceApplicationBasic(modelName, appName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("juju_application.this", "model", modelName),
 					resource.TestCheckResourceAttr("juju_application.this", "name", appName),
@@ -478,7 +277,7 @@ func TestAcc_ResourceApplication_Stable(t *testing.T) {
 					// cores constraint is not valid in K8s
 					return testingCloud != LXDCloudTesting, nil
 				},
-				Config: testAccResourceApplicationConstraints_Stable(modelName, "arch=amd64 cores=1 mem=4096M"),
+				Config: testAccResourceApplicationConstraints(modelName, "arch=amd64 cores=1 mem=4096M"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("juju_application.this", "model", modelName),
 					resource.TestCheckResourceAttr("juju_application.this", "constraints", "arch=amd64 cores=1 mem=4096M"),
@@ -489,7 +288,7 @@ func TestAcc_ResourceApplication_Stable(t *testing.T) {
 				SkipFunc: func() (bool, error) {
 					return testingCloud != MicroK8sTesting, nil
 				},
-				Config: testAccResourceApplicationConstraints_Stable(modelName, "arch=amd64 mem=4096M"),
+				Config: testAccResourceApplicationConstraints(modelName, "arch=amd64 mem=4096M"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("juju_application.this", "model", modelName),
 					resource.TestCheckResourceAttr("juju_application.this", "constraints", "arch=amd64 mem=4096M"),
@@ -500,7 +299,7 @@ func TestAcc_ResourceApplication_Stable(t *testing.T) {
 					// skip if we are not in lxd environment
 					return testingCloud != LXDCloudTesting, nil
 				},
-				Config: testAccResourceApplicationConstraintsSubordinate_Stable(modelName, "arch=amd64 cores=1 mem=4096M"),
+				Config: testAccResourceApplicationConstraintsSubordinate(modelName, "arch=amd64 cores=1 mem=4096M"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("juju_application.this", "model", modelName),
 					resource.TestCheckResourceAttr("juju_application.this", "constraints", "arch=amd64 cores=1 mem=4096M"),
@@ -533,7 +332,7 @@ func TestAcc_ResourceApplication_Updates_Stable(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceApplicationUpdates_Stable(modelName, 1, true, "machinename"),
+				Config: testAccResourceApplicationUpdates(modelName, 1, true, "machinename"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("juju_application.this", "model", modelName),
 					resource.TestCheckResourceAttr("juju_application.this", "charm.#", "1"),
@@ -549,29 +348,29 @@ func TestAcc_ResourceApplication_Updates_Stable(t *testing.T) {
 				SkipFunc: func() (bool, error) {
 					return testingCloud != LXDCloudTesting, nil
 				},
-				Config: testAccResourceApplicationUpdates_Stable(modelName, 2, true, "machinename"),
+				Config: testAccResourceApplicationUpdates(modelName, 2, true, "machinename"),
 				Check:  resource.TestCheckResourceAttr("juju_application.this", "units", "2"),
 			},
 			{
 				SkipFunc: func() (bool, error) {
 					return testingCloud != LXDCloudTesting, nil
 				},
-				Config: testAccResourceApplicationUpdates_Stable(modelName, 2, true, "machinename"),
+				Config: testAccResourceApplicationUpdates(modelName, 2, true, "machinename"),
 				Check:  resource.TestCheckResourceAttr("juju_application.this", "charm.0.revision", "10"),
 			},
 			{
 				SkipFunc: func() (bool, error) {
 					return testingCloud != MicroK8sTesting, nil
 				},
-				Config: testAccResourceApplicationUpdates_Stable(modelName, 2, true, "machinename"),
+				Config: testAccResourceApplicationUpdates(modelName, 2, true, "machinename"),
 				Check:  resource.TestCheckResourceAttr("juju_application.this", "charm.0.revision", "19"),
 			},
 			{
-				Config: testAccResourceApplicationUpdates_Stable(modelName, 2, false, "machinename"),
+				Config: testAccResourceApplicationUpdates(modelName, 2, false, "machinename"),
 				Check:  resource.TestCheckResourceAttr("juju_application.this", "expose.#", "0"),
 			},
 			{
-				Config: testAccResourceApplicationUpdates_Stable(modelName, 2, true, "machinename"),
+				Config: testAccResourceApplicationUpdates(modelName, 2, true, "machinename"),
 				Check:  resource.TestCheckResourceAttr("juju_application.this", "expose.#", "1"),
 			},
 			{
@@ -611,21 +410,21 @@ func TestAcc_CharmUpdates_Stable(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceApplicationUpdatesCharm_Stable(modelName, "latest/stable"),
+				Config: testAccResourceApplicationUpdatesCharm(modelName, "latest/stable"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("juju_application.this", "charm.0.channel", "latest/stable"),
 				),
 			},
 			{
 				// move to latest/edge
-				Config: testAccResourceApplicationUpdatesCharm_Stable(modelName, "latest/edge"),
+				Config: testAccResourceApplicationUpdatesCharm(modelName, "latest/edge"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("juju_application.this", "charm.0.channel", "latest/edge"),
 				),
 			},
 			{
 				// move back to latest/stable
-				Config: testAccResourceApplicationUpdatesCharm_Stable(modelName, "latest/stable"),
+				Config: testAccResourceApplicationUpdatesCharm(modelName, "latest/stable"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("juju_application.this", "charm.0.channel", "latest/stable"),
 				),
@@ -649,7 +448,7 @@ func testAccResourceApplicationBasic_Minimal(modelName, charmName string) string
 		`, modelName, charmName)
 }
 
-func testAccResourceApplicationBasic_Stable(modelName, appInvalidName string) string {
+func testAccResourceApplicationBasic(modelName, appInvalidName string) string {
 	if testingCloud == LXDCloudTesting {
 		return fmt.Sprintf(`
 		resource "juju_model" "this" {
@@ -689,7 +488,7 @@ func testAccResourceApplicationBasic_Stable(modelName, appInvalidName string) st
 	}
 }
 
-func testAccResourceApplicationUpdates_Stable(modelName string, units int, expose bool, hostname string) string {
+func testAccResourceApplicationUpdates(modelName string, units int, expose bool, hostname string) string {
 	exposeStr := "expose{}"
 	if !expose {
 		exposeStr = ""
@@ -739,7 +538,7 @@ func testAccResourceApplicationUpdates_Stable(modelName string, units int, expos
 	}
 }
 
-func testAccResourceApplicationUpdatesCharm_Stable(modelName string, channel string) string {
+func testAccResourceApplicationUpdatesCharm(modelName string, channel string) string {
 	if testingCloud == LXDCloudTesting {
 		return fmt.Sprintf(`
 		resource "juju_model" "this" {
@@ -776,7 +575,7 @@ func testAccResourceApplicationUpdatesCharm_Stable(modelName string, channel str
 // testAccResourceApplicationConstraints will return two set for constraint
 // applications. The version to be used in K8s sets the juju-external-hostname
 // because we set the expose parameter.
-func testAccResourceApplicationConstraints_Stable(modelName string, constraints string) string {
+func testAccResourceApplicationConstraints(modelName string, constraints string) string {
 	if testingCloud == LXDCloudTesting {
 		return fmt.Sprintf(`
 resource "juju_model" "this" {
@@ -821,7 +620,7 @@ resource "juju_application" "this" {
 	}
 }
 
-func testAccResourceApplicationConstraintsSubordinate_Stable(modelName string, constraints string) string {
+func testAccResourceApplicationConstraintsSubordinate(modelName string, constraints string) string {
 	return fmt.Sprintf(`
 resource "juju_model" "this" {
   name = %q

--- a/internal/provider/resource_credential_test.go
+++ b/internal/provider/resource_credential_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
-func TestAcc_ResourceCredential_sdk2_framework_migrate(t *testing.T) {
+func TestAcc_ResourceCredential_Edge(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
@@ -31,24 +31,24 @@ func TestAcc_ResourceCredential_sdk2_framework_migrate(t *testing.T) {
 				// Mind that ExpectError should be the first step
 				// "When tests have an ExpectError[...]; this results in any previous state being cleared. "
 				// https://github.com/hashicorp/terraform-plugin-sdk/issues/118
-				Config:      testAccResourceCredential_sdk2_framework_migrate(t, credentialName, authTypeInvalid),
+				Config:      testAccResourceCredential(credentialName, authTypeInvalid),
 				ExpectError: regexp.MustCompile(fmt.Sprintf("%q not supported", authTypeInvalid)),
 				PreConfig:   func() { testAccPreCheck(t) },
 			},
 			{
-				Config: testAccResourceCredential_sdk2_framework_migrate(t, credentialInvalidName, authType),
+				Config: testAccResourceCredential(credentialInvalidName, authType),
 				ExpectError: regexp.MustCompile(fmt.Sprintf(".*%q is not\na valid credential name.*",
 					credentialInvalidName)),
 			},
 			{
-				Config: testAccResourceCredential_sdk2_framework_migrate(t, credentialName, authType),
+				Config: testAccResourceCredential(credentialName, authType),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", credentialName),
 					resource.TestCheckResourceAttr(resourceName, "auth_type", authType),
 				),
 			},
 			{
-				Config: testAccResourceCredentialToken_sdk2_framework_migrate(t, credentialName, authType, token),
+				Config: testAccResourceCredentialToken(credentialName, authType, token),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", credentialName),
 					resource.TestCheckResourceAttr(resourceName, "auth_type", authType),
@@ -67,36 +67,6 @@ func TestAcc_ResourceCredential_sdk2_framework_migrate(t *testing.T) {
 			},
 		},
 	})
-}
-
-func testAccResourceCredential_sdk2_framework_migrate(t *testing.T, credentialName string, authType string) string {
-	return fmt.Sprintf(`
-resource "juju_credential" "test-credential" {
-  name = %q
-
-  cloud {
-   name   = "localhost"
-  }
-
-  auth_type = "%s"
-}`, credentialName, authType)
-}
-
-func testAccResourceCredentialToken_sdk2_framework_migrate(t *testing.T, credentialName, authType, token string) string {
-	return fmt.Sprintf(`
-resource "juju_credential" "test-credential" {
-  name = %q
-
-  cloud {
-   name   = "localhost"
-  }
-
-  auth_type = "%s"
-
-  attributes = {
-	token = "%s"
-  }
-}`, credentialName, authType, token)
 }
 
 func TestAcc_ResourceCredential_Stable(t *testing.T) {
@@ -123,22 +93,22 @@ func TestAcc_ResourceCredential_Stable(t *testing.T) {
 				// Mind that ExpectError should be the first step
 				// "When tests have an ExpectError[...]; this results in any previous state being cleared. "
 				// https://github.com/hashicorp/terraform-plugin-sdk/issues/118
-				Config:      testAccResourceCredential_Stable(t, credentialName, authTypeInvalid),
+				Config:      testAccResourceCredential(credentialName, authTypeInvalid),
 				ExpectError: regexp.MustCompile(fmt.Sprintf("Error: supported auth-types (.*), \"%s\" not supported", authTypeInvalid)),
 			},
 			{
-				Config:      testAccResourceCredential_Stable(t, credentialInvalidName, authType),
+				Config:      testAccResourceCredential(credentialInvalidName, authType),
 				ExpectError: regexp.MustCompile(fmt.Sprintf("Error: \"%s\" is not a valid credential name", credentialInvalidName)),
 			},
 			{
-				Config: testAccResourceCredential_Stable(t, credentialName, authType),
+				Config: testAccResourceCredential(credentialName, authType),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", credentialName),
 					resource.TestCheckResourceAttr(resourceName, "auth_type", authType),
 				),
 			},
 			{
-				Config: testAccResourceCredentialToken_Stable(t, credentialName, authType, token),
+				Config: testAccResourceCredentialToken(credentialName, authType, token),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", credentialName),
 					resource.TestCheckResourceAttr(resourceName, "auth_type", authType),
@@ -158,7 +128,7 @@ func TestAcc_ResourceCredential_Stable(t *testing.T) {
 	})
 }
 
-func testAccResourceCredential_Stable(t *testing.T, credentialName string, authType string) string {
+func testAccResourceCredential(credentialName string, authType string) string {
 	return fmt.Sprintf(`
 resource "juju_credential" "test-credential" {
   name = %q
@@ -171,7 +141,7 @@ resource "juju_credential" "test-credential" {
 }`, credentialName, authType)
 }
 
-func testAccResourceCredentialToken_Stable(t *testing.T, credentialName, authType, token string) string {
+func testAccResourceCredentialToken(credentialName, authType, token string) string {
 	return fmt.Sprintf(`
 resource "juju_credential" "test-credential" {
   name = %q

--- a/internal/provider/resource_credential_test.go
+++ b/internal/provider/resource_credential_test.go
@@ -25,7 +25,7 @@ func TestAcc_ResourceCredential_sdk2_framework_migrate(t *testing.T) {
 	resourceName := "juju_credential.test-credential"
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: muxProviderFactories,
+		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				// Mind that ExpectError should be the first step

--- a/internal/provider/resource_integration_test.go
+++ b/internal/provider/resource_integration_test.go
@@ -20,7 +20,7 @@ func TestAcc_ResourceIntegration_sdk2_framework_migrate(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: muxProviderFactories,
+		ProtoV6ProviderFactories: frameworkProviderFactories,
 		CheckDestroy:             testAccCheckIntegrationDestroy_Stable,
 		Steps: []resource.TestStep{
 			{
@@ -107,7 +107,7 @@ func TestAcc_ResourceIntegrationWithViaCIDRs_sdk2_framework_migrate(t *testing.T
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: muxProviderFactories,
+		ProtoV6ProviderFactories: frameworkProviderFactories,
 		CheckDestroy:             testAccCheckIntegrationDestroy_sdk2_framework_migrate,
 		Steps: []resource.TestStep{
 			{

--- a/internal/provider/resource_integration_test.go
+++ b/internal/provider/resource_integration_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
-func TestAcc_ResourceIntegration_sdk2_framework_migrate(t *testing.T) {
+func TestAcc_ResourceIntegration_Edge(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
@@ -21,10 +21,10 @@ func TestAcc_ResourceIntegration_sdk2_framework_migrate(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: frameworkProviderFactories,
-		CheckDestroy:             testAccCheckIntegrationDestroy_Stable,
+		CheckDestroy:             testAccCheckIntegrationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceIntegration_sdk2_framework_migrate(modelName, "two"),
+				Config: testAccResourceIntegration(modelName, "two"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("juju_integration.this", "model", modelName),
 					resource.TestCheckResourceAttr("juju_integration.this", "id", fmt.Sprintf("%v:%v:%v", modelName, "two:db-admin", "one:backend-db-admin")),
@@ -38,7 +38,7 @@ func TestAcc_ResourceIntegration_sdk2_framework_migrate(t *testing.T) {
 				ResourceName:      "juju_integration.this",
 			},
 			{
-				Config: testAccResourceIntegration_sdk2_framework_migrate(modelName, "two"),
+				Config: testAccResourceIntegration(modelName, "two"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("juju_integration.this", "model", modelName),
 					resource.TestCheckResourceAttr("juju_integration.this", "id", fmt.Sprintf("%v:%v:%v", modelName, "two:db-admin", "one:backend-db-admin")),
@@ -49,69 +49,21 @@ func TestAcc_ResourceIntegration_sdk2_framework_migrate(t *testing.T) {
 	})
 }
 
-func testAccCheckIntegrationDestroy_sdk2_framework_migrate(s *terraform.State) error {
-	return nil
-}
-
-func testAccResourceIntegration_sdk2_framework_migrate(modelName string, integrationName string) string {
-	return fmt.Sprintf(`
-resource "juju_model" "this" {
-	name = %q
-}
-
-resource "juju_application" "one" {
-	model = juju_model.this.name
-	name  = "one" 
-	
-	charm {
-		name = "pgbouncer"
-		series = "focal"
-	}
-}
-
-resource "juju_application" "two" {
- 	model = juju_model.this.name
-	name  = "two"
-
-	charm {
-		name = "postgresql"
-		series = "focal"
-	}
-}
-
-resource "juju_integration" "this" {
-	model = juju_model.this.name
-
-	application {
-		name     = juju_application.%s.name
-		endpoint = "db-admin"
-	}
-
-	application {
-		name = juju_application.one.name
-		endpoint = "backend-db-admin"
-	}
-}
-`, modelName, integrationName)
-}
-
-func TestAcc_ResourceIntegrationWithViaCIDRs_sdk2_framework_migrate(t *testing.T) {
+func TestAcc_ResourceIntegrationWithViaCIDRs_Edge(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
 	srcModelName := acctest.RandomWithPrefix("tf-test-integration")
 	dstModelName := acctest.RandomWithPrefix("tf-test-integration-dst")
-	// srcModelName := "modela"
-	// dstModelName := "modelb"
 	via := "127.0.0.1/32,127.0.0.3/32"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: frameworkProviderFactories,
-		CheckDestroy:             testAccCheckIntegrationDestroy_sdk2_framework_migrate,
+		CheckDestroy:             testAccCheckIntegrationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceIntegrationWithVia_sdk2_framework_migrate(srcModelName, dstModelName, via),
+				Config: testAccResourceIntegrationWithVia(srcModelName, dstModelName, via),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("juju_integration.a", "model", srcModelName),
 					resource.TestCheckResourceAttr("juju_integration.a", "id", fmt.Sprintf("%v:%v:%v", srcModelName, "a:db-admin", "b:backend-db-admin")),
@@ -122,61 +74,6 @@ func TestAcc_ResourceIntegrationWithViaCIDRs_sdk2_framework_migrate(t *testing.T
 			},
 		},
 	})
-}
-
-// testAccResourceIntegrationWithVia generates a plan where a
-// postgresql:db-admin relates to a pgbouncer:backend-db-admin using
-// and offer of pgbouncer.
-func testAccResourceIntegrationWithVia_sdk2_framework_migrate(srcModelName string, dstModelName string, viaCIDRs string) string {
-	return fmt.Sprintf(`
-resource "juju_model" "a" {
-	name = %q
-}
-
-resource "juju_application" "a" {
- 	model = juju_model.a.name
-	name  = "a" 
-	
-	charm {
-		name = "postgresql"
-		series = "focal"
-	}
-}
-
-resource "juju_model" "b" {
-	name = %q
-}
-
-resource "juju_application" "b" {
- 	model = juju_model.b.name
-	name  = "b"
-	
-	charm {
-		name = "pgbouncer"
-		series = "focal"
-	}
-}
-
-resource "juju_offer" "b" {
-	model            = juju_model.b.name
-	application_name = juju_application.b.name
-	endpoint         = "backend-db-admin"
-}
-
-resource "juju_integration" "a" {
-	model = juju_model.a.name
-	via = %q
-
-	application {
-		name = juju_application.a.name
-		endpoint = "db-admin"
-	}
-	
-	application {
-		offer_url = juju_offer.b.url
-	}
-}
-`, srcModelName, dstModelName, viaCIDRs)
 }
 
 func TestAcc_ResourceIntegration_Stable(t *testing.T) {
@@ -193,10 +90,10 @@ func TestAcc_ResourceIntegration_Stable(t *testing.T) {
 				Source:            "juju/juju",
 			},
 		},
-		CheckDestroy: testAccCheckIntegrationDestroy_Stable,
+		CheckDestroy: testAccCheckIntegrationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceIntegration_Stable(modelName, "two"),
+				Config: testAccResourceIntegration(modelName, "two"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("juju_integration.this", "model", modelName),
 					resource.TestCheckResourceAttr("juju_integration.this", "id", fmt.Sprintf("%v:%v:%v", modelName, "two:db-admin", "one:backend-db-admin")),
@@ -210,7 +107,7 @@ func TestAcc_ResourceIntegration_Stable(t *testing.T) {
 				ResourceName:      "juju_integration.this",
 			},
 			{
-				Config: testAccResourceIntegration_Stable(modelName, "two"),
+				Config: testAccResourceIntegration(modelName, "two"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("juju_integration.this", "model", modelName),
 					resource.TestCheckResourceAttr("juju_integration.this", "id", fmt.Sprintf("%v:%v:%v", modelName, "two:db-admin", "one:backend-db-admin")),
@@ -221,11 +118,11 @@ func TestAcc_ResourceIntegration_Stable(t *testing.T) {
 	})
 }
 
-func testAccCheckIntegrationDestroy_Stable(s *terraform.State) error {
+func testAccCheckIntegrationDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccResourceIntegration_Stable(modelName string, integrationName string) string {
+func testAccResourceIntegration(modelName string, integrationName string) string {
 	return fmt.Sprintf(`
 resource "juju_model" "this" {
 	name = %q
@@ -273,8 +170,6 @@ func TestAcc_ResourceIntegrationWithViaCIDRs_Stable(t *testing.T) {
 	}
 	srcModelName := acctest.RandomWithPrefix("tf-test-integration")
 	dstModelName := acctest.RandomWithPrefix("tf-test-integration-dst")
-	// srcModelName := "modela"
-	// dstModelName := "modelb"
 	via := "127.0.0.1/32,127.0.0.3/32"
 
 	resource.Test(t, resource.TestCase{
@@ -285,10 +180,10 @@ func TestAcc_ResourceIntegrationWithViaCIDRs_Stable(t *testing.T) {
 				Source:            "juju/juju",
 			},
 		},
-		CheckDestroy: testAccCheckIntegrationDestroy_Stable,
+		CheckDestroy: testAccCheckIntegrationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceIntegrationWithVia_Stable(srcModelName, dstModelName, via),
+				Config: testAccResourceIntegrationWithVia(srcModelName, dstModelName, via),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("juju_integration.a", "model", srcModelName),
 					resource.TestCheckResourceAttr("juju_integration.a", "id", fmt.Sprintf("%v:%v:%v", srcModelName, "a:db-admin", "b:backend-db-admin")),
@@ -304,7 +199,7 @@ func TestAcc_ResourceIntegrationWithViaCIDRs_Stable(t *testing.T) {
 // testAccResourceIntegrationWithVia generates a plan where a
 // postgresql:db-admin relates to a pgbouncer:backend-db-admin using
 // and offer of pgbouncer.
-func testAccResourceIntegrationWithVia_Stable(srcModelName string, dstModelName string, viaCIDRs string) string {
+func testAccResourceIntegrationWithVia(srcModelName string, dstModelName string, viaCIDRs string) string {
 	return fmt.Sprintf(`
 resource "juju_model" "a" {
 	name = %q

--- a/internal/provider/resource_machine_test.go
+++ b/internal/provider/resource_machine_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
-func TestAcc_ResourceMachine_sdk2_framework_migrate(t *testing.T) {
+func TestAcc_ResourceMachine_Edge(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
@@ -21,7 +21,7 @@ func TestAcc_ResourceMachine_sdk2_framework_migrate(t *testing.T) {
 		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceMachineBasicMigrate(modelName),
+				Config: testAccResourceMachine(modelName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("juju_machine.this", "model", modelName),
 					resource.TestCheckResourceAttr("juju_machine.this", "name", "this_machine"),
@@ -35,20 +35,6 @@ func TestAcc_ResourceMachine_sdk2_framework_migrate(t *testing.T) {
 			},
 		},
 	})
-}
-
-func testAccResourceMachineBasicMigrate(modelName string) string {
-	return fmt.Sprintf(`
-resource "juju_model" "this" {
-	name = %q
-}
-
-resource "juju_machine" "this" {
-	name = "this_machine"
-	model = juju_model.this.name
-	series = "focal"
-}
-`, modelName)
 }
 
 func TestAcc_ResourceMachine_Minimal(t *testing.T) {
@@ -104,7 +90,7 @@ func TestAcc_ResourceMachine_Stable(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceMachineStable(modelName),
+				Config: testAccResourceMachine(modelName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("juju_machine.this", "model", modelName),
 					resource.TestCheckResourceAttr("juju_machine.this", "name", "this_machine"),
@@ -120,7 +106,7 @@ func TestAcc_ResourceMachine_Stable(t *testing.T) {
 	})
 }
 
-func testAccResourceMachineStable(modelName string) string {
+func testAccResourceMachine(modelName string) string {
 	return fmt.Sprintf(`
 resource "juju_model" "this" {
 	name = %q
@@ -134,7 +120,7 @@ resource "juju_machine" "this" {
 `, modelName)
 }
 
-func TestAcc_ResourceMachine_AddMachine_sdk2_framework_migrate(t *testing.T) {
+func TestAcc_ResourceMachine_AddMachine_Edge(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
@@ -151,7 +137,7 @@ func TestAcc_ResourceMachine_AddMachine_sdk2_framework_migrate(t *testing.T) {
 		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceMachineAddMachineMigrate(modelName, testAddMachineIP, testSSHPubKeyPath,
+				Config: testAccResourceMachineAddMachine(modelName, testAddMachineIP, testSSHPubKeyPath,
 					testSSHPrivKeyPath),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("juju_machine.this_machine", "model", modelName),
@@ -169,7 +155,7 @@ func TestAcc_ResourceMachine_AddMachine_sdk2_framework_migrate(t *testing.T) {
 	})
 }
 
-func testAccResourceMachineAddMachineMigrate(modelName string, IP string, pubKeyPath string, privKeyPath string) string {
+func testAccResourceMachineAddMachine(modelName string, IP string, pubKeyPath string, privKeyPath string) string {
 	return fmt.Sprintf(`
 resource "juju_model" "this_model" {
 	name = %q

--- a/internal/provider/resource_machine_test.go
+++ b/internal/provider/resource_machine_test.go
@@ -18,7 +18,7 @@ func TestAcc_ResourceMachine_sdk2_framework_migrate(t *testing.T) {
 	modelName := acctest.RandomWithPrefix("tf-test-machine")
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: muxProviderFactories,
+		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccResourceMachineBasicMigrate(modelName),
@@ -59,7 +59,7 @@ func TestAcc_ResourceMachine_Minimal(t *testing.T) {
 	resourceName := "juju_machine.testmachine"
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: muxProviderFactories,
+		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccResourceMachineBasicMinimal(modelName),
@@ -148,7 +148,7 @@ func TestAcc_ResourceMachine_AddMachine_sdk2_framework_migrate(t *testing.T) {
 	modelName := acctest.RandomWithPrefix("tf-test-machine-ssh-address")
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: muxProviderFactories,
+		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccResourceMachineAddMachineMigrate(modelName, testAddMachineIP, testSSHPubKeyPath,

--- a/internal/provider/resource_model_test.go
+++ b/internal/provider/resource_model_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/juju/terraform-provider-juju/internal/juju"
 )
 
-func TestAcc_ResourceModel_sdk2_framework_migrate(t *testing.T) {
+func TestAcc_ResourceModel_Edge(t *testing.T) {
 	modelName := acctest.RandomWithPrefix("tf-test-model")
 	modelInvalidName := acctest.RandomWithPrefix("tf_test_model")
 	logLevelInfo := "INFO"
@@ -32,26 +32,26 @@ func TestAcc_ResourceModel_sdk2_framework_migrate(t *testing.T) {
 				// Mind that ExpectError should be the first step
 				// "When tests have an ExpectError[...]; this results in any previous state being cleared. "
 				// https://github.com/hashicorp/terraform-plugin-sdk/issues/118
-				Config: testAccResourceModelMigrate(modelInvalidName, testingCloud.CloudName(), logLevelInfo),
+				Config: testAccResourceModel(modelInvalidName, testingCloud.CloudName(), logLevelInfo),
 				ExpectError: regexp.MustCompile(fmt.Sprintf(
 					"Unable to create model, got error: \"%s\" is not *\na valid name: model names may only contain lowercase letters, digits and *\nhyphens", modelInvalidName)),
 			},
 
 			{
-				Config: testAccResourceModelMigrate(modelName, testingCloud.CloudName(), logLevelInfo),
+				Config: testAccResourceModel(modelName, testingCloud.CloudName(), logLevelInfo),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", modelName),
 					resource.TestCheckResourceAttr(resourceName, "config.logging-config", fmt.Sprintf("<root>=%s", logLevelInfo)),
 				),
 			},
 			{
-				Config: testAccResourceModelMigrate(modelName, testingCloud.CloudName(), logLevelDebug),
+				Config: testAccResourceModel(modelName, testingCloud.CloudName(), logLevelDebug),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "config.logging-config", fmt.Sprintf("<root>=%s", logLevelDebug)),
 				),
 			},
 			{
-				Config: testAccConstraintsModelMigrate(modelName, testingCloud.CloudName(), "cores=1 mem=1024M"),
+				Config: testAccConstraintsModel(modelName, testingCloud.CloudName(), "cores=1 mem=1024M"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "constraints", "cores=1 mem=1024M"),
 				),
@@ -69,7 +69,7 @@ func TestAcc_ResourceModel_sdk2_framework_migrate(t *testing.T) {
 	})
 }
 
-func TestAcc_ResourceModel_UnsetConfig_sdk2_framework_migrate(t *testing.T) {
+func TestAcc_ResourceModel_UnsetConfig_Edge(t *testing.T) {
 	modelName := acctest.RandomWithPrefix("tf-test-model")
 
 	resourceName := "juju_model.this"
@@ -99,7 +99,7 @@ resource "juju_model" "this" {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", modelName),
 					resource.TestCheckNoResourceAttr(resourceName, "config.development"),
-					testAccCheckDevelopmentConfigIsUnsetMigrate(modelName),
+					testAccCheckDevelopmentConfigIsUnset(modelName),
 				),
 			},
 		},
@@ -125,76 +125,6 @@ resource "juju_model" "testmodel" {
 	})
 }
 
-func testAccCheckDevelopmentConfigIsUnsetMigrate(modelName string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		client := Provider.Meta().(*juju.Client)
-
-		uuid, err := client.Models.ResolveModelUUID(modelName)
-		if err != nil {
-			return err
-		}
-
-		conn, err := client.Models.GetConnection(&uuid)
-		if err != nil {
-			return err
-		}
-
-		// TODO: consider adding to client so we don't expose this layer (even in tests)
-		modelconfigClient := modelconfig.NewClient(conn)
-		defer modelconfigClient.Close()
-
-		metadata, err := modelconfigClient.ModelGetWithMetadata()
-		if err != nil {
-			return err
-		}
-
-		for k, actual := range metadata {
-			if k == "development" {
-				expected := params.ConfigValue{
-					Value:  false,
-					Source: "default",
-				}
-
-				if actual.Value != expected.Value || actual.Source != expected.Source {
-					return fmt.Errorf("expecting 'development' config for model: %s (%s), to be %#v but was: %#v",
-						modelName, uuid, expected, actual)
-				}
-			}
-		}
-		return nil
-	}
-}
-
-func testAccResourceModelMigrate(modelName string, cloudName string, logLevel string) string {
-	return fmt.Sprintf(`
-resource "juju_model" "model" {
-  name = %q
-
-  cloud {
-   name   = %q
-   region = "localhost"
-  }
-
-  config = {
-    logging-config = "<root>=%s"
-  }
-}`, modelName, cloudName, logLevel)
-}
-
-func testAccConstraintsModelMigrate(modelName string, cloudName string, constraints string) string {
-	return fmt.Sprintf(`
-resource "juju_model" "model" {
-  name = %q
-
-  cloud {
-   name   = %q
-   region = "localhost"
-  }
-
-  constraints = "%s"
-}`, modelName, cloudName, constraints)
-}
-
 func TestAcc_ResourceModel_Stable(t *testing.T) {
 	modelName := acctest.RandomWithPrefix("tf-test-model")
 	modelInvalidName := acctest.RandomWithPrefix("tf_test_model")
@@ -215,24 +145,24 @@ func TestAcc_ResourceModel_Stable(t *testing.T) {
 				// Mind that ExpectError should be the first step
 				// "When tests have an ExpectError[...]; this results in any previous state being cleared. "
 				// https://github.com/hashicorp/terraform-plugin-sdk/issues/118
-				Config:      testAccResourceModelStable(modelInvalidName, testingCloud.CloudName(), logLevelInfo),
+				Config:      testAccResourceModel(modelInvalidName, testingCloud.CloudName(), logLevelInfo),
 				ExpectError: regexp.MustCompile(fmt.Sprintf("Error: \"%s\" is not a valid name: model names may only contain lowercase letters, digits and hyphens", modelInvalidName)),
 			},
 			{
-				Config: testAccResourceModelStable(modelName, testingCloud.CloudName(), logLevelInfo),
+				Config: testAccResourceModel(modelName, testingCloud.CloudName(), logLevelInfo),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", modelName),
 					resource.TestCheckResourceAttr(resourceName, "config.logging-config", fmt.Sprintf("<root>=%s", logLevelInfo)),
 				),
 			},
 			{
-				Config: testAccResourceModelStable(modelName, testingCloud.CloudName(), logLevelDebug),
+				Config: testAccResourceModel(modelName, testingCloud.CloudName(), logLevelDebug),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "config.logging-config", fmt.Sprintf("<root>=%s", logLevelDebug)),
 				),
 			},
 			{
-				Config: testAccConstraintsModelStable(modelName, testingCloud.CloudName(), "cores=1 mem=1024M"),
+				Config: testAccConstraintsModel(modelName, testingCloud.CloudName(), "cores=1 mem=1024M"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "constraints", "cores=1 mem=1024M"),
 				),
@@ -285,14 +215,14 @@ resource "juju_model" "this" {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", modelName),
 					resource.TestCheckNoResourceAttr(resourceName, "config.development"),
-					testAccCheckDevelopmentConfigIsUnsetStable(modelName),
+					testAccCheckDevelopmentConfigIsUnset(modelName),
 				),
 			},
 		},
 	})
 }
 
-func testAccCheckDevelopmentConfigIsUnsetStable(modelName string) resource.TestCheckFunc {
+func testAccCheckDevelopmentConfigIsUnset(modelName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		client := Provider.Meta().(*juju.Client)
 
@@ -332,7 +262,7 @@ func testAccCheckDevelopmentConfigIsUnsetStable(modelName string) resource.TestC
 	}
 }
 
-func testAccResourceModelStable(modelName string, cloudName string, logLevel string) string {
+func testAccResourceModel(modelName string, cloudName string, logLevel string) string {
 	return fmt.Sprintf(`
 resource "juju_model" "model" {
   name = %q
@@ -348,7 +278,7 @@ resource "juju_model" "model" {
 }`, modelName, cloudName, logLevel)
 }
 
-func testAccConstraintsModelStable(modelName string, cloudName string, constraints string) string {
+func testAccConstraintsModel(modelName string, cloudName string, constraints string) string {
 	return fmt.Sprintf(`
 resource "juju_model" "model" {
   name = %q

--- a/internal/provider/resource_model_test.go
+++ b/internal/provider/resource_model_test.go
@@ -26,7 +26,7 @@ func TestAcc_ResourceModel_sdk2_framework_migrate(t *testing.T) {
 	resourceName := "juju_model.model"
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: muxProviderFactories,
+		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				// Mind that ExpectError should be the first step
@@ -75,7 +75,7 @@ func TestAcc_ResourceModel_UnsetConfig_sdk2_framework_migrate(t *testing.T) {
 	resourceName := "juju_model.this"
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: muxProviderFactories,
+		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`
@@ -110,7 +110,7 @@ func TestAcc_ResourceModel_Minimal(t *testing.T) {
 	modelName := acctest.RandomWithPrefix("tf-test-model")
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: muxProviderFactories,
+		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`

--- a/internal/provider/resource_offer_test.go
+++ b/internal/provider/resource_offer_test.go
@@ -21,7 +21,7 @@ func TestAcc_ResourceOffer_sdk2_framework_migrate(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: muxProviderFactories,
+		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccResourceOfferMigrate(modelName),

--- a/internal/provider/resource_offer_test.go
+++ b/internal/provider/resource_offer_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
-func TestAcc_ResourceOffer_sdk2_framework_migrate(t *testing.T) {
+func TestAcc_ResourceOffer_Edge(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
@@ -24,7 +24,7 @@ func TestAcc_ResourceOffer_sdk2_framework_migrate(t *testing.T) {
 		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceOfferMigrate(modelName),
+				Config: testAccResourceOffer(modelName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("juju_offer.this", "model", modelName),
 					resource.TestCheckResourceAttr("juju_offer.this", "url", fmt.Sprintf("%v/%v.%v", "admin", modelName, "this")),
@@ -32,7 +32,7 @@ func TestAcc_ResourceOffer_sdk2_framework_migrate(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccResourceOfferXIntegrationMigrate(modelName2, destModelName),
+				Config: testAccResourceOfferXIntegration(modelName2, destModelName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("juju_integration.int", "model", destModelName),
 
@@ -54,31 +54,7 @@ func TestAcc_ResourceOffer_sdk2_framework_migrate(t *testing.T) {
 	})
 }
 
-func testAccResourceOfferMigrate(modelName string) string {
-	return fmt.Sprintf(`
-resource "juju_model" "this" {
-	name = %q
-}
-
-resource "juju_application" "this" {
- 	model = juju_model.this.name
-	name  = "this"
-
-	charm {
-		name = "postgresql"
-		series = "focal"
-	}
-}
-
-resource "juju_offer" "this" {
-	model            = juju_model.this.name
-	application_name = juju_application.this.name
-	endpoint         = "db"
-}
-`, modelName)
-}
-
-func testAccResourceOfferXIntegrationMigrate(srcModelName string, destModelName string) string {
+func testAccResourceOfferXIntegration(srcModelName string, destModelName string) string {
 	return fmt.Sprintf(`
 resource "juju_model" "modelone" {
 	name = %q
@@ -144,7 +120,7 @@ func TestAcc_ResourceOffer_Stable(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceOfferStable(modelName),
+				Config: testAccResourceOffer(modelName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("juju_offer.this", "model", modelName),
 					resource.TestCheckResourceAttr("juju_offer.this", "url", fmt.Sprintf("%v/%v.%v", "admin", modelName, "this")),
@@ -160,7 +136,7 @@ func TestAcc_ResourceOffer_Stable(t *testing.T) {
 	})
 }
 
-func testAccResourceOfferStable(modelName string) string {
+func testAccResourceOffer(modelName string) string {
 	return fmt.Sprintf(`
 resource "juju_model" "this" {
 	name = %q

--- a/internal/provider/resource_ssh_key_test.go
+++ b/internal/provider/resource_ssh_key_test.go
@@ -22,7 +22,7 @@ func TestAcc_ResourceSSHKey_sdk2_framework_migrate(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: muxProviderFactories,
+		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccResourceSSHKeyMigrate(modelName, sshKey1),
@@ -50,7 +50,7 @@ func TestAcc_ResourceSSHKey_ED25519_sdk2_framework_migrate(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: muxProviderFactories,
+		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccResourceSSHKeyMigrate(modelName, sshKey1),

--- a/internal/provider/resource_ssh_key_test.go
+++ b/internal/provider/resource_ssh_key_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
-func TestAcc_ResourceSSHKey_sdk2_framework_migrate(t *testing.T) {
+func TestAcc_ResourceSSHKey_Edge(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
@@ -25,14 +25,14 @@ func TestAcc_ResourceSSHKey_sdk2_framework_migrate(t *testing.T) {
 		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceSSHKeyMigrate(modelName, sshKey1),
+				Config: testAccResourceSSHKey(modelName, sshKey1),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("juju_ssh_key.this", "model", modelName),
 					resource.TestCheckResourceAttr("juju_ssh_key.this", "payload", sshKey1)),
 			},
 			// we update the key
 			{
-				Config: testAccResourceSSHKeyMigrate(modelName, sshKey2),
+				Config: testAccResourceSSHKey(modelName, sshKey2),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("juju_ssh_key.this", "model", modelName),
 					resource.TestCheckResourceAttr("juju_ssh_key.this", "payload", sshKey2)),
@@ -41,7 +41,7 @@ func TestAcc_ResourceSSHKey_sdk2_framework_migrate(t *testing.T) {
 	})
 }
 
-func TestAcc_ResourceSSHKey_ED25519_sdk2_framework_migrate(t *testing.T) {
+func TestAcc_ResourceSSHKey_ED25519_Edge(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
@@ -53,26 +53,13 @@ func TestAcc_ResourceSSHKey_ED25519_sdk2_framework_migrate(t *testing.T) {
 		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceSSHKeyMigrate(modelName, sshKey1),
+				Config: testAccResourceSSHKey(modelName, sshKey1),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("juju_ssh_key.this", "model", modelName),
 					resource.TestCheckResourceAttr("juju_ssh_key.this", "payload", sshKey1)),
 			},
 		},
 	})
-}
-
-func testAccResourceSSHKeyMigrate(modelName string, sshKey string) string {
-	return fmt.Sprintf(`
-resource "juju_model" "this" {
-	name = %q
-}
-
-resource "juju_ssh_key" "this" {
-	model = juju_model.this.name
-	payload= %q
-}
-`, modelName, sshKey)
 }
 
 func TestAcc_ResourceSSHKey_Stable(t *testing.T) {
@@ -94,14 +81,14 @@ func TestAcc_ResourceSSHKey_Stable(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceSSHKeyStable(modelName, sshKey1),
+				Config: testAccResourceSSHKey(modelName, sshKey1),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("juju_ssh_key.this", "model", modelName),
 					resource.TestCheckResourceAttr("juju_ssh_key.this", "payload", sshKey1)),
 			},
 			// we update the key
 			{
-				Config: testAccResourceSSHKeyStable(modelName, sshKey2),
+				Config: testAccResourceSSHKey(modelName, sshKey2),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("juju_ssh_key.this", "model", modelName),
 					resource.TestCheckResourceAttr("juju_ssh_key.this", "payload", sshKey2)),
@@ -127,7 +114,7 @@ func TestAcc_ResourceSSHKey_ED25519_Stable(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceSSHKeyStable(modelName, sshKey1),
+				Config: testAccResourceSSHKey(modelName, sshKey1),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("juju_ssh_key.this", "model", modelName),
 					resource.TestCheckResourceAttr("juju_ssh_key.this", "payload", sshKey1)),
@@ -136,7 +123,7 @@ func TestAcc_ResourceSSHKey_ED25519_Stable(t *testing.T) {
 	})
 }
 
-func testAccResourceSSHKeyStable(modelName string, sshKey string) string {
+func testAccResourceSSHKey(modelName string, sshKey string) string {
 	return fmt.Sprintf(`
 resource "juju_model" "this" {
 	name = %q

--- a/internal/provider/resource_user_test.go
+++ b/internal/provider/resource_user_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
-func TestAcc_ResourceUser_sdk2_framework_migrate(t *testing.T) {
+func TestAcc_ResourceUser_Edge(t *testing.T) {
 	userName := acctest.RandomWithPrefix("tfuser")
 	userPassword := acctest.RandomWithPrefix("tf-test-user")
 

--- a/main.go
+++ b/main.go
@@ -34,7 +34,6 @@ var (
 )
 
 func main() {
-
 	var debugMode bool
 
 	flag.BoolVar(&debugMode, "debug", false, "set to true to run the provider with support for debuggers like delve")


### PR DESCRIPTION
## Description

This concludes the migration of the juju provider from sdk2 to provider framework. 

In particular it does two main things:

1. Takes out the `muxProviderFactories` that allowed us to use the `oldjuju` (sdk2) provider alongside with the `juju` (framework) provider during the migration. 
2. Cleans up the tests. This part involves two main changes in itself. i) keeps the migration test as `_Edge` tests along
with the `Stable` tests (which download and use the upstream stable release of the provider). ii) During the migration, we had to duplicate the plans used in tests to be able to have some resources be provided by the "oldjuju". This removes those duplicate plans, and have both the Edge and Stable tests run the same configuration.

## Type of change

- Maintenance work (repository related, like Github actions, or revving the Go version, etc.)

## Environment

- Juju controller version: 2.9

- Terraform version: 1.5.4

## QA steps

No behavior changes.

## Additional notes

JUJU-4183
