### PR TITLE
Remove sdk2 from provider & provider_tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.20
 require (
 	github.com/bflad/tfproviderlint v0.29.0
 	github.com/hashicorp/terraform-plugin-docs v0.16.0
-	github.com/hashicorp/terraform-plugin-sdk/v2 v2.28.0
 	// 2.9.43
 	github.com/juju/juju v0.0.0-20230601044333-3cb3f8beac4a
 
@@ -93,6 +92,7 @@ require (
 	github.com/hashicorp/raft v1.3.2-0.20210825230038-1a621031eb2b // indirect
 	github.com/hashicorp/terraform-exec v0.18.1 // indirect
 	github.com/hashicorp/terraform-json v0.17.1 // indirect
+	github.com/hashicorp/terraform-plugin-sdk/v2 v2.28.0 // indirect
 	github.com/hashicorp/terraform-registry-address v0.2.1 // indirect
 	github.com/hashicorp/terraform-svchost v0.1.1 // indirect
 	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
 	"github.com/juju/terraform-provider-juju/internal/juju"
 )
 

--- a/internal/provider/resource_model_test.go
+++ b/internal/provider/resource_model_test.go
@@ -13,8 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/juju/juju/api/client/modelconfig"
 	"github.com/juju/juju/rpc/params"
-
-	"github.com/juju/terraform-provider-juju/internal/juju"
 )
 
 func TestAcc_ResourceModel_Edge(t *testing.T) {
@@ -224,9 +222,7 @@ resource "juju_model" "this" {
 
 func testAccCheckDevelopmentConfigIsUnset(modelName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := Provider.Meta().(*juju.Client)
-
-		conn, err := client.Models.GetConnection(&modelName)
+		conn, err := TestClient.Models.GetConnection(&modelName)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Description

This takes out the sdk/v2 from `provider.go` and migrates the tests in the `provider_test.go`.

## Type of change

- Maintenance work (repository related, like Github actions, or revving the Go version, etc.)

## Environment

- Juju controller version: 2.9

- Terraform version: 1.5.6

## QA steps

No manual QA steps needed. All CI tests need to pass.

## Additional notes

JUJU-4584