### PR TITLE
Fix remove integration with multiple consumers

### DIFF
--- a/.github/workflows/test_integration.yml
+++ b/.github/workflows/test_integration.yml
@@ -77,5 +77,5 @@ jobs:
       - env:
           TF_ACC: "1"
           TEST_CLOUD: ${{ matrix.cloud }}
-        run: go test -timeout 30m -v -cover ./internal/provider/
+        run: go test -timeout 40m -v -cover ./internal/provider/
         timeout-minutes: 40

--- a/internal/provider/resource_integration_test.go
+++ b/internal/provider/resource_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-testing/config"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -249,4 +250,145 @@ resource "juju_integration" "a" {
 	}
 }
 `, srcModelName, dstModelName, viaCIDRs)
+}
+
+func TestAcc_ResourceIntegrationWithMultipleConsumers_Edge(t *testing.T) {
+	if testingCloud != LXDCloudTesting {
+		t.Skip(t.Name() + " only runs with LXD")
+	}
+	srcModelName := acctest.RandomWithPrefix("tf-test-integration")
+	dstModelName := acctest.RandomWithPrefix("tf-test-integration-dst")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: frameworkProviderFactories,
+		CheckDestroy:             testAccCheckIntegrationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceIntegrationMultipleConsumers(srcModelName, dstModelName),
+				ConfigVariables: config.Variables{
+					"enable-b1-consumer": config.BoolVariable(true),
+					"enable-b2-consumer": config.BoolVariable(true),
+				},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("juju_integration.b1.0", "model", dstModelName),
+					resource.TestCheckResourceAttr("juju_integration.b1.0", "id", fmt.Sprintf("%v:%v:%v", dstModelName, "a:db-admin", "b1:backend-db-admin")),
+					resource.TestCheckResourceAttr("juju_integration.b1.0", "application.#", "2"),
+					resource.TestCheckTypeSetElemNestedAttrs("juju_integration.b1.0", "application.*", map[string]string{"name": "b1", "endpoint": "backend-db-admin"}),
+					resource.TestCheckResourceAttr("juju_integration.b2.0", "model", dstModelName),
+					resource.TestCheckResourceAttr("juju_integration.b2.0", "id", fmt.Sprintf("%v:%v:%v", dstModelName, "a:db-admin", "b2:backend-db-admin")),
+					resource.TestCheckResourceAttr("juju_integration.b2.0", "application.#", "2"),
+					resource.TestCheckTypeSetElemNestedAttrs("juju_integration.b2.0", "application.*", map[string]string{"name": "b2", "endpoint": "backend-db-admin"}),
+				),
+			},
+			{
+				Config: testAccResourceIntegrationMultipleConsumers(srcModelName, dstModelName),
+				ConfigVariables: config.Variables{
+					"enable-b1-consumer": config.BoolVariable(true),
+					"enable-b2-consumer": config.BoolVariable(false),
+				},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("juju_integration.b1.0", "model", dstModelName),
+					resource.TestCheckResourceAttr("juju_integration.b1.0", "id", fmt.Sprintf("%v:%v:%v", dstModelName, "a:db-admin", "b1:backend-db-admin")),
+					resource.TestCheckResourceAttr("juju_integration.b1.0", "application.#", "2"),
+					resource.TestCheckTypeSetElemNestedAttrs("juju_integration.b1.0", "application.*", map[string]string{"name": "b1", "endpoint": "backend-db-admin"}),
+				),
+			},
+			{
+				Config: testAccResourceIntegrationMultipleConsumers(srcModelName, dstModelName),
+				ConfigVariables: config.Variables{
+					"enable-b1-consumer": config.BoolVariable(false),
+					"enable-b2-consumer": config.BoolVariable(false),
+				},
+			},
+		},
+	})
+}
+
+// testAccResourceIntegrationWithMultipleConusmers generates a plan where a
+// two pgbouncer applications relates to postgresql:db-admin offer.
+func testAccResourceIntegrationMultipleConsumers(srcModelName string, dstModelName string) string {
+	return fmt.Sprintf(`
+resource "juju_model" "a" {
+        name = %q
+}
+
+resource "juju_application" "a" {
+        model = juju_model.a.name
+        name  = "a"
+
+        charm {
+                name    = "postgresql"
+                series  = "jammy"
+        }
+}
+
+resource "juju_offer" "a" {
+        model            = juju_model.a.name
+        application_name = juju_application.a.name
+        endpoint         = "db-admin"
+}
+
+resource "juju_model" "b" {
+        name = %q
+}
+
+resource "juju_application" "b1" {
+        model = juju_model.b.name
+        name  = "b1"
+
+        charm {
+                name   = "pgbouncer"
+                series = "focal"
+        }
+}
+
+resource "juju_integration" "b1" {
+	count = var.enable-b1-consumer ? 1 : 0
+        model = juju_model.b.name
+
+        application {
+                name     = juju_application.b1.name
+                endpoint = "backend-db-admin"
+        }
+
+        application {
+                offer_url = juju_offer.a.url
+        }
+}
+
+resource "juju_application" "b2" {
+        model = juju_model.b.name
+        name  = "b2"
+
+        charm {
+                name   = "pgbouncer"
+                series = "focal"
+        }
+}
+
+resource "juju_integration" "b2" {
+	count = var.enable-b2-consumer ? 1 : 0
+        model = juju_model.b.name
+
+        application {
+                name     = juju_application.b2.name
+                endpoint = "backend-db-admin"
+        }
+
+        application {
+                offer_url = juju_offer.a.url
+        }
+}
+
+variable "enable-b1-consumer" {
+	description = "Enable integration for b1 with offer"
+	default     = false
+}
+
+variable "enable-b2-consumer" {
+        description = "Enable integration for b2 with offer"
+        default     = false
+}
+`, srcModelName, dstModelName)
 }


### PR DESCRIPTION
For an offer with multiple consumers, if the integration for one consumer is removed, the offer is removed on consumer/remote side. This leads to removal of integrations for rest of the consumers.
Use DestroyIntegration even for relations with offers as endpoint instead of deletion of remoteoffer.

Fixes: #308



## Description

If integration having endpoint of type offer is removed, the remote-consumer offer is removed. This resulted in break of other applications that are consuming the offer.

Fixes: #308 

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Environment

- Juju controller version: 3.1.5

- Terraform version: v1.5.7

## QA steps

Manual QA steps should be done to test this PR.

Steps are mentioned in #308 

## Additional notes

