### PR TITLE
fix leak of concerns from one package to another

### DIFF
--- a/internal/juju/models.go
+++ b/internal/juju/models.go
@@ -175,6 +175,9 @@ func (c *modelsClient) CreateModel(input CreateModelInput) (CreateModelResponse,
 	resp.Type = modelInfo.Type.String()
 	resp.UUID = modelInfo.UUID
 
+	// Add the model to the client cache of jujuModel
+	c.AddModel(modelInfo.Name, modelInfo.UUID, modelInfo.Type)
+
 	// set constraints when required
 	if input.Constraints.String() == "" {
 		return resp, nil
@@ -193,9 +196,6 @@ func (c *modelsClient) CreateModel(input CreateModelInput) (CreateModelResponse,
 	if err != nil {
 		return resp, err
 	}
-
-	// Add the model to the client cache of jujuModel
-	c.AddModel(modelInfo.Name, modelInfo.UUID, modelInfo.Type)
 
 	return resp, nil
 }

--- a/internal/juju/models.go
+++ b/internal/juju/models.go
@@ -5,7 +5,6 @@ package juju
 
 import (
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/juju/errors"
@@ -86,9 +85,9 @@ type DestroyModelInput struct {
 }
 
 type DestroyAccessModelInput struct {
-	Model  string
-	Revoke []string
-	Access string
+	ModelName string
+	Revoke    []string
+	Access    string
 }
 
 func newModelsClient(sc SharedClient) *modelsClient {
@@ -402,21 +401,18 @@ func (c *modelsClient) UpdateAccessModel(input UpdateAccessModelInput) error {
 // If a user has had `write`, then removing that access would decrease their
 // access to `read` and the user will remain part of the model access.
 func (c *modelsClient) DestroyAccessModel(input DestroyAccessModelInput) error {
-	id := strings.Split(input.Model, ":")
-	model := id[0]
-
-	uuid, err := c.ModelUUID(model)
-	if err != nil {
-		return err
-	}
-
 	conn, err := c.GetConnection(nil)
 	if err != nil {
 		return err
 	}
 
 	client := modelmanager.NewClient(conn)
-	defer client.Close()
+	defer func() { _ = client.Close() }()
+
+	uuid, err := c.ModelUUID(input.ModelName)
+	if err != nil {
+		return err
+	}
 
 	for _, user := range input.Revoke {
 		err := client.RevokeModel(user, "read", uuid)

--- a/internal/provider/resource_access_model.go
+++ b/internal/provider/resource_access_model.go
@@ -313,9 +313,9 @@ func (a *accessModelResource) Delete(ctx context.Context, req resource.DeleteReq
 	}
 
 	err := a.client.Models.DestroyAccessModel(juju.DestroyAccessModelInput{
-		Model:  plan.ID.ValueString(),
-		Revoke: stateUsers,
-		Access: plan.Access.ValueString(),
+		ModelName: plan.Model.ValueString(),
+		Revoke:    stateUsers,
+		Access:    plan.Access.ValueString(),
 	})
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete access model resource, got error: %s", err))


### PR DESCRIPTION

## Description

Fix a TODO left over from migration to the provider framework. A terraform ID was leaking into the internal juju package code which had no reason for the full data, just need the model name. Model name is available from other data, so not parsing is necessary. 

A small fix for the cache of model name/uuid/type. Add a model to it before looking at constraints, which are optional to begin with.

The existing AC tests will cover the changes.

## Type of change

- Maintenance work (repository related, like Github actions, or revving the Go version, etc.)

## Additional notes

JUJU-4344