### PR TITLE
Fix application deploy and refresh internals

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/juju/charm/v8 v8.0.6
 	github.com/juju/clock v1.0.3
 	github.com/juju/cmd/v3 v3.0.13
+	github.com/juju/collections v1.0.2
 	github.com/juju/errors v1.0.0
 	github.com/juju/names/v4 v4.0.0
 	github.com/juju/retry v1.0.0
@@ -109,7 +110,6 @@ require (
 	github.com/juju/ansiterm v1.0.0 // indirect
 	github.com/juju/blobstore/v2 v2.0.0 // indirect
 	github.com/juju/charmrepo/v6 v6.0.3 // indirect
-	github.com/juju/collections v1.0.2 // indirect
 	github.com/juju/description/v3 v3.0.15 // indirect
 	github.com/juju/featureflag v1.0.0 // indirect
 	github.com/juju/gnuflag v1.0.0 // indirect

--- a/internal/juju/applications.go
+++ b/internal/juju/applications.go
@@ -248,7 +248,6 @@ func (c applicationsClient) CreateApplication(input *CreateApplicationInput) (*C
 	if resolvedOrigin.Type == "bundle" {
 		return nil, jujuerrors.NotSupportedf("deploying bundles")
 	}
-	c.Tracef("heather", map[string]interface{}{"resolved origin": resolvedOrigin, "supported series": supportedSeries})
 
 	seriesToUse, err := c.seriesToUse(modelconfigAPIClient, input.CharmSeries, resolvedOrigin.Series, set.NewStrings(supportedSeries...))
 	if err != nil {
@@ -896,8 +895,8 @@ func (c applicationsClient) UpdateApplication(input *UpdateApplicationInput) err
 		}
 	}
 
-	// use the revision, channel, and series info to create the
-	// corresponding SetCharm info
+	// Use the revision and channel info to create the
+	// corresponding SetCharm info.
 	if input.Revision != nil || input.Channel != "" {
 		setCharmConfig, err := c.computeSetCharmConfig(input, applicationAPIClient, charmsAPIClient)
 		if err != nil {

--- a/internal/juju/applications.go
+++ b/internal/juju/applications.go
@@ -248,11 +248,16 @@ func (c applicationsClient) CreateApplication(input *CreateApplicationInput) (*C
 	if resolvedOrigin.Type == "bundle" {
 		return nil, jujuerrors.NotSupportedf("deploying bundles")
 	}
+	c.Tracef("heather", map[string]interface{}{"resolved origin": resolvedOrigin, "supported series": supportedSeries})
 
 	seriesToUse, err := c.seriesToUse(modelconfigAPIClient, input.CharmSeries, resolvedOrigin.Series, set.NewStrings(supportedSeries...))
 	if err != nil {
 		return nil, err
 	}
+	if input.CharmSeries != "" && seriesToUse != input.CharmSeries {
+		return nil, jujuerrors.Errorf("juju controller bug (LP 2039179), deploy will have operating system different from request. ")
+	}
+
 	// Add the charm to the model
 	origin = resolvedOrigin.WithSeries(seriesToUse)
 	charmURL = resolvedURL.WithSeries(seriesToUse)

--- a/internal/juju/client.go
+++ b/internal/juju/client.go
@@ -171,9 +171,9 @@ func (sc *sharedClient) fillModelCache() error {
 	if err != nil {
 		return err
 	}
+	defer func() { _ = conn.Close() }()
 
 	client := modelmanager.NewClient(conn)
-	defer func() { _ = client.Close() }()
 
 	// Calling ListModelSummaries because other Model endpoints require
 	// the UUID, here we're trying to get the model UUID for other calls.

--- a/internal/juju/credentials.go
+++ b/internal/juju/credentials.go
@@ -89,9 +89,9 @@ func (c *credentialsClient) ValidateCredentialForCloud(cloudName, authTypeReceiv
 	if err != nil {
 		return err
 	}
+	defer func() { _ = conn.Close() }()
 
 	client := cloudapi.NewClient(conn)
-	defer client.Close()
 
 	cloudTag := names.NewCloudTag(cloudName)
 
@@ -127,9 +127,9 @@ func (c *credentialsClient) CreateCredential(input CreateCredentialInput) (*Crea
 	if err != nil {
 		return nil, err
 	}
+	defer func() { _ = conn.Close() }()
 
 	client := cloudapi.NewClient(conn)
-	defer client.Close()
 
 	currentUser := getCurrentJujuUser(conn)
 
@@ -170,9 +170,9 @@ func (c *credentialsClient) ReadCredential(input ReadCredentialInput) (*ReadCred
 	if err != nil {
 		return nil, err
 	}
+	defer func() { _ = conn.Close() }()
 
 	client := cloudapi.NewClient(conn)
-	defer client.Close()
 
 	var clientCredentialFound jujucloud.Credential
 	if clientCredential {
@@ -251,6 +251,7 @@ func (c *credentialsClient) UpdateCredential(input UpdateCredentialInput) error 
 	if err != nil {
 		return err
 	}
+	defer func() { _ = conn.Close() }()
 
 	currentUser := getCurrentJujuUser(conn)
 
@@ -274,7 +275,6 @@ func (c *credentialsClient) UpdateCredential(input UpdateCredentialInput) error 
 
 	if input.ControllerCredential {
 		client := cloudapi.NewClient(conn)
-		defer client.Close()
 
 		if _, err := client.UpdateCredentialsCheckModels(*cloudCredTag, cloudCredential); err != nil {
 			return err
@@ -318,9 +318,9 @@ func (c *credentialsClient) DestroyCredential(input DestroyCredentialInput) erro
 	if err != nil {
 		return err
 	}
+	defer func() { _ = conn.Close() }()
 
 	client := cloudapi.NewClient(conn)
-	defer client.Close()
 
 	currentUser := getCurrentJujuUser(conn)
 

--- a/internal/juju/integrations.go
+++ b/internal/juju/integrations.go
@@ -90,9 +90,9 @@ func (c integrationsClient) CreateIntegration(input *IntegrationInput) (*CreateI
 	if err != nil {
 		return nil, err
 	}
+	defer func() { _ = conn.Close() }()
 
 	client := apiapplication.NewClient(conn)
-	defer client.Close()
 
 	// wait for the apps to be available
 	ctx, cancel := context.WithTimeout(context.Background(), IntegrationAppAvailableTimeout)
@@ -130,6 +130,7 @@ func (c integrationsClient) ReadIntegration(input *IntegrationInput) (*ReadInteg
 	if err != nil {
 		return nil, err
 	}
+	defer func() { _ = conn.Close() }()
 
 	status, err := getStatus(conn)
 	if err != nil {
@@ -190,9 +191,9 @@ func (c integrationsClient) UpdateIntegration(input *UpdateIntegrationInput) (*U
 	if err != nil {
 		return nil, err
 	}
+	defer func() { _ = conn.Close() }()
 
 	client := apiapplication.NewClient(conn)
-	defer client.Close()
 
 	listViaCIDRs := splitCommaDelimitedList(input.ViaCIDRs)
 	response, err := client.AddRelation(
@@ -240,9 +241,9 @@ func (c integrationsClient) DestroyIntegration(input *IntegrationInput) error {
 	if err != nil {
 		return err
 	}
+	defer func() { _ = conn.Close() }()
 
 	client := apiapplication.NewClient(conn)
-	defer client.Close()
 
 	var force bool = false
 	var timeout time.Duration = 30 * time.Second
@@ -261,7 +262,6 @@ func (c integrationsClient) DestroyIntegration(input *IntegrationInput) error {
 
 func getStatus(conn api.Connection) (*params.FullStatus, error) {
 	client := apiclient.NewClient(conn)
-	defer client.Close()
 
 	status, err := client.Status(nil)
 	if err != nil {

--- a/internal/juju/machines.go
+++ b/internal/juju/machines.go
@@ -82,12 +82,11 @@ func (c machinesClient) CreateMachine(input *CreateMachineInput) (*CreateMachine
 	if err != nil {
 		return nil, err
 	}
+	defer func() { _ = conn.Close() }()
 
 	machineAPIClient := apimachinemanager.NewClient(conn)
-	defer func() { _ = machineAPIClient.Close() }()
 
 	modelConfigAPIClient := apimodelconfig.NewClient(conn)
-	defer func() { _ = modelConfigAPIClient.Close() }()
 
 	if input.SSHAddress != "" {
 		configAttrs, err := modelConfigAPIClient.ModelGet()
@@ -240,9 +239,9 @@ func (c machinesClient) ReadMachine(input ReadMachineInput) (ReadMachineResponse
 	if err != nil {
 		return response, err
 	}
+	defer func() { _ = conn.Close() }()
 
 	clientAPIClient := apiclient.NewClient(conn)
-	defer func() { _ = clientAPIClient.Close() }()
 
 	status, err := clientAPIClient.Status(nil)
 	if err != nil {
@@ -273,9 +272,9 @@ func (c machinesClient) DestroyMachine(input *DestroyMachineInput) error {
 	if err != nil {
 		return err
 	}
+	defer func() { _ = conn.Close() }()
 
 	machineAPIClient := apimachinemanager.NewClient(conn)
-	defer func() { _ = machineAPIClient.Close() }()
 
 	_, err = machineAPIClient.DestroyMachinesWithParams(false, false, (*time.Duration)(nil), input.ID)
 

--- a/internal/juju/offers.go
+++ b/internal/juju/offers.go
@@ -88,9 +88,9 @@ func (c offersClient) CreateOffer(input *CreateOfferInput) (*CreateOfferResponse
 	if err != nil {
 		return nil, append(errs, err)
 	}
+	defer func() { _ = conn.Close() }()
 
 	client := applicationoffers.NewClient(conn)
-	defer client.Close()
 
 	offerName := input.Name
 	if offerName == "" {
@@ -102,9 +102,8 @@ func (c offersClient) CreateOffer(input *CreateOfferInput) (*CreateOfferResponse
 	if err != nil {
 		return nil, append(errs, err)
 	}
-	defer modelConn.Close()
+	defer func() { _ = modelConn.Close() }()
 	applicationClient := application.NewClient(modelConn)
-	defer applicationClient.Close()
 
 	// wait for the app to be available
 	ctx, cancel := context.WithTimeout(context.Background(), OfferAppAvailableTimeout)
@@ -159,10 +158,9 @@ func (c offersClient) ReadOffer(input *ReadOfferInput) (*ReadOfferResponse, erro
 	if err != nil {
 		return nil, err
 	}
+	defer func() { _ = conn.Close() }()
 
 	client := applicationoffers.NewClient(conn)
-	defer client.Close()
-
 	result, err := client.ApplicationOffer(input.OfferURL)
 	if err != nil {
 		return nil, err
@@ -190,10 +188,9 @@ func (c offersClient) DestroyOffer(input *DestroyOfferInput) error {
 	if err != nil {
 		return err
 	}
+	defer func() { _ = conn.Close() }()
 
 	client := applicationoffers.NewClient(conn)
-	defer client.Close()
-
 	offer, err := client.ApplicationOffer(input.OfferURL)
 	if err != nil {
 		return err
@@ -259,15 +256,15 @@ func (c offersClient) ConsumeRemoteOffer(input *ConsumeRemoteOfferInput) (*Consu
 	if err != nil {
 		return nil, err
 	}
+	defer func() { _ = modelConn.Close() }()
 	conn, err := c.GetConnection(nil)
 	if err != nil {
 		return nil, err
 	}
+	defer func() { _ = conn.Close() }()
 
 	offersClient := applicationoffers.NewClient(conn)
-	defer offersClient.Close()
 	client := apiapplication.NewClient(modelConn)
-	defer client.Close()
 
 	url, err := crossmodel.ParseOfferURL(input.OfferURL)
 	if err != nil {
@@ -342,11 +339,10 @@ func (c offersClient) RemoveRemoteOffer(input *RemoveRemoteOfferInput) []error {
 		errors = append(errors, err)
 		return errors
 	}
+	defer func() { _ = conn.Close() }()
 
 	client := apiapplication.NewClient(conn)
-	defer client.Close()
 	clientAPIClient := apiclient.NewClient(conn)
-	defer clientAPIClient.Close()
 
 	status, err := clientAPIClient.Status(nil)
 	if err != nil {

--- a/internal/juju/sshKeys.go
+++ b/internal/juju/sshKeys.go
@@ -47,9 +47,9 @@ func (c *sshKeysClient) CreateSSHKey(input *CreateSSHKeyInput) error {
 	if err != nil {
 		return err
 	}
+	defer func() { _ = conn.Close() }()
 
 	client := keymanager.NewClient(conn)
-	defer client.Close()
 
 	// NOTE
 	// Juju only stores ssh keys at a global level.
@@ -79,9 +79,9 @@ func (c *sshKeysClient) ReadSSHKey(input *ReadSSHKeyInput) (*ReadSSHKeyOutput, e
 	if err != nil {
 		return nil, err
 	}
+	defer func() { _ = conn.Close() }()
 
 	client := keymanager.NewClient(conn)
-	defer client.Close()
 
 	// NOTE: At this moment Juju only uses global ssh keys.
 	// We hardcode the user to be admin.
@@ -109,9 +109,9 @@ func (c *sshKeysClient) DeleteSSHKey(input *DeleteSSHKeyInput) error {
 	if err != nil {
 		return err
 	}
+	defer func() { _ = conn.Close() }()
 
 	client := keymanager.NewClient(conn)
-	defer client.Close()
 
 	// NOTE: Unfortunately Juju will return an error if we try to
 	// remove the last ssh key from the controller. This is something

--- a/internal/juju/users.go
+++ b/internal/juju/users.go
@@ -61,9 +61,9 @@ func (c *usersClient) CreateUser(input CreateUserInput) (*CreateUserResponse, er
 	if err != nil {
 		return nil, err
 	}
+	defer func() { _ = conn.Close() }()
 
 	client := usermanager.NewClient(conn)
-	defer client.Close()
 
 	userTag, userSecret, err := client.AddUser(input.Name, input.DisplayName, input.Password)
 	if err != nil {
@@ -78,9 +78,9 @@ func (c *usersClient) ReadUser(name string) (*ReadUserResponse, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer func() { _ = usermanagerConn.Close() }()
 
 	usermanagerClient := usermanager.NewClient(usermanagerConn)
-	defer usermanagerClient.Close()
 
 	users, err := usermanagerClient.UserInfo([]string{name}, false) //don't list disabled users
 	if err != nil {
@@ -106,9 +106,8 @@ func (c *usersClient) ModelUserInfo(modelName string) (*ReadModelUserResponse, e
 	if err != nil {
 		return nil, err
 	}
-
+	defer func() { _ = usermanagerConn.Close() }()
 	usermanagerClient := usermanager.NewClient(usermanagerConn)
-	defer usermanagerClient.Close()
 
 	uuid, err := c.ModelUUID(modelName)
 	if err != nil {
@@ -134,9 +133,9 @@ func (c *usersClient) UpdateUser(input UpdateUserInput) error {
 	if err != nil {
 		return err
 	}
+	defer func() { _ = conn.Close() }()
 
 	client := usermanager.NewClient(conn)
-	defer client.Close()
 
 	if input.Password != "" {
 		err = client.SetPassword(input.Name, input.Password)
@@ -153,9 +152,9 @@ func (c *usersClient) DestroyUser(input DestroyUserInput) error {
 	if err != nil {
 		return err
 	}
+	defer func() { _ = conn.Close() }()
 
 	client := usermanager.NewClient(conn)
-	defer client.Close()
 
 	err = client.RemoveUser(input.Name)
 	if err != nil {

--- a/internal/provider/data_source_offer_test.go
+++ b/internal/provider/data_source_offer_test.go
@@ -68,7 +68,7 @@ resource "juju_application" "this" {
 
 	charm {
 		name = "postgresql"
-		series = "focal"
+		series = "jammy"
 	}
 }
 

--- a/internal/provider/resource_application.go
+++ b/internal/provider/resource_application.go
@@ -603,7 +603,14 @@ func (r *applicationResource) Update(ctx context.Context, req resource.UpdateReq
 			updateApplicationInput.Channel = planCharm.Channel.ValueString()
 		}
 		if !planCharm.Series.Equal(stateCharm.Series) {
-			updateApplicationInput.Series = planCharm.Series.ValueString()
+			// This violates terraform's declarative model. We could implement
+			// `juju set-application-base`, usually used after `upgrade-machine`,
+			// which would change the operating system used for future units of
+			// the application provided the charm supported it, but not change
+			// the current. This provider does not implement an equivalent to
+			// `upgrade-machine`. There is also a question of how to handle a
+			// change to series, revision and channel at the same time.
+			resp.Diagnostics.AddWarning("Not Supported", "Changing an application's operating system after deploy.")
 		}
 		if !planCharm.Revision.Equal(stateCharm.Revision) {
 			updateApplicationInput.Revision = intPtr(planCharm.Revision)

--- a/internal/provider/resource_model_test.go
+++ b/internal/provider/resource_model_test.go
@@ -226,10 +226,10 @@ func testAccCheckDevelopmentConfigIsUnset(modelName string) resource.TestCheckFu
 		if err != nil {
 			return err
 		}
+		defer func() { _ = conn.Close() }()
 
 		// TODO: consider adding to client so we don't expose this layer (even in tests)
 		modelconfigClient := modelconfig.NewClient(conn)
-		defer modelconfigClient.Close()
 
 		metadata, err := modelconfigClient.ModelGetWithMetadata()
 		if err != nil {

--- a/internal/provider/resource_offer_test.go
+++ b/internal/provider/resource_offer_test.go
@@ -66,7 +66,7 @@ resource "juju_application" "appone" {
 
 	charm {
 		name = "postgresql"
-		series = "focal"
+		series = "jammy"
 	}
 }
 
@@ -148,7 +148,7 @@ resource "juju_application" "this" {
 
 	charm {
 		name = "postgresql"
-		series = "focal"
+		series = "jammy"
 	}
 }
 


### PR DESCRIPTION
## Description

Visual inspection of the code before working to add base support for application resources found a number of issues to fix.
* When refreshing, update application constraints before adding new units, otherwise the new units will not use the new constraints.
* During juju deploy, check the application constraints for architecture, fallback to using the model constraint value if not provided.
* Improve operating system selection for deploying a charm if one is not provided. Including validating against juju supported workload operating systems if a juju 3.x controller.
* Updating an applications's charm revision or channel requires revalidation of the charm with new data against the operating system and architecture deployed with. As well as ensuring they exist.
* When refreshing an application, use the current application charm origin to start. Do not deduce a new one. This could lead to the wrong charm in updates as a charm name can change, the origin holds an ID which is immutable and will guarantee the same charm is used after deploy.
* Do not change a charm series after deployed. That could cause incompatible charm blobs to be used. 
* Do not create juju clients if they will not be used. 
* Close a juju api connection, not each individual client created using the connection. Once a client is closed, the shared connection is also closed, potentially preventing use by other clients.

## Type of change

- Logic changes in resources (the API interaction with Juju has been changed)

## QA steps

Please create a variety of applications plans to ensure no change in behavior, modulo the not changing the series on application resource update. Focus on constraints, charm revision/channel, charm refresh, operating system selection. 

Try deploying jameinel-ubuntu-lite, this is where I noticed that the provider could not determine the correct operating system to deploy with as it failed to deploy.

---
The following plan should produce an error based on the juju bug found
```terraform
terraform {
  required_providers {
    juju = {
      version = ">= 0.9.0"
      source  = "juju/juju"
    }
  }
}

provider "juju" {
}

resource "juju_model" "testmodel" {
  name = "focal-test"
}

resource "juju_application" "ubuntu" {
  model = juju_model.testmodel.name
  charm {
    name = "postgresql"
    series = "focal"
  }
}
```

## Additional notes

JUJU-4711
https://bugs.launchpad.net/juju/+bug/2039179
