### PR TITLE
GitHub action timeouts

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -30,7 +30,7 @@ jobs:
     needs:
       - build
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -70,5 +70,5 @@ jobs:
       - env:
           TF_ACC: "1"
           TEST_CLOUD: ${{ matrix.cloud }}
-        run: go test -v -cover ./internal/provider/
+        run: go test -timeout 40m -v -cover ./internal/provider/
       

--- a/.github/workflows/test_new_candidates.yml
+++ b/.github/workflows/test_new_candidates.yml
@@ -105,7 +105,7 @@ jobs:
         env:
           TF_ACC: "1"
           TEST_CLOUD: ${{ matrix.cloud }}
-        run: go test -timeout 30m -v -cover ./internal/provider/
+        run: go test -timeout 40m -v -cover ./internal/provider/
         timeout-minutes: 40
       - uses: actions/upload-artifact@v3
         if: ${{ success() }}

--- a/.github/workflows/test_new_candidates.yml
+++ b/.github/workflows/test_new_candidates.yml
@@ -90,6 +90,7 @@ jobs:
           juju-channel: ${{ env.channel }}
       - name: "Set environment to configure provider"
         if: ${{ env.next-test != 'NA' }}
+        # language=bash
         run: |
           CONTROLLER=$(juju whoami --format yaml | yq .controller)
 


### PR DESCRIPTION
The canary and new candidate workflows should have been updated as part of #309, to increase the timeout for the tests. 

Attempting to fix the new candidate workflow from failing with `Custom provider set without credentials:`, though I'm not sure of the cause.
