### PR TITLE
Update charm resources if necessary when updating a charm

### DIFF
--- a/internal/juju/applications.go
+++ b/internal/juju/applications.go
@@ -751,7 +751,6 @@ func (c applicationsClient) UpdateApplication(input *UpdateApplicationInput) err
 	if err != nil {
 		return err
 	}
-	defer resourcesAPIClient.Close()
 
 	status, err := clientAPIClient.Status(nil)
 	if err != nil {
@@ -945,7 +944,6 @@ func (c applicationsClient) computeSetCharmConfig(
 	}
 
 	resultOrigin, err := charmsAPIClient.AddCharm(resolvedURL, resolvedOrigin, false)
-
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description

Updates the charm resources (if needed) when refreshing a charm.

Fixes #278

## Type of change

- Logic changes in resources (the API interaction with Juju has been changed)

## Environment

- Juju controller version: 2.9.46

- Terraform version: 1.5

## QA steps

I used `coredns` on `microk8s` to test this, any charm with different resource revisions would work for the QA.
We start with the `channel=1.27/stable revision=48` as follows:

```terraform
provider "juju" {}

resource "juju_model" "tst278" {
  name = "tst278"

  cloud {
    name = "microk8s"
    region = "localhost"
  }
}

resource "juju_application" "tst" {
  name = "corednstest"

  model = juju_model.tst278.name

  charm {
    name = "coredns"
    channel = "1.27/stable"
    revision = 48
    series = "jammy"
  }
}
```

Apply this plan:

```sh
 $ terraform init && terraform plan && terraform apply --auto-approve
```

Check that the application has the resource revision 13:

```sh
juju resources coredns
Resource       Supplied by  Revision
coredns-image  charmstore   13
```

Now modify the charm details in the plan and change it to `channel=1.28/stable revision=121`, and re-apply.

You should see an `update in-place` for the application in the plan:

```sh
$ terraform plan
juju_model.tst278: Refreshing state... [id=4c930e9e-9ef7-496b-8d10-5127662a8ea3]
juju_application.tst: Refreshing state... [id=tst278:corednstest]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the
following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # juju_application.tst will be updated in-place
  ~ resource "juju_application" "tst" {
        id          = "tst278:corednstest"
        name        = "corednstest"
        # (5 unchanged attributes hidden)

      ~ charm {
          ~ channel  = "1.27/stable" -> "1.28/stable"
            name     = "coredns"
          ~ revision = 48 -> 121
            # (1 unchanged attribute hidden)
        }
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

Now apply this with `terraform apply --auto-approve` and check the resource revision, it should be 60 🎉 :

```sh
juju resources coredns
Resource       Supplied by  Revision
coredns-image  charmstore   60
```

## Additional notes

JUJU-4527
