### PR TITLE
Remove principal from schema

### DIFF
--- a/docs/resources/application.md
+++ b/docs/resources/application.md
@@ -72,7 +72,7 @@ resource "juju_application" "placement_example" {
 ### Read-Only
 
 - `id` (String) The ID of this resource.
-- `principal` (Boolean) Whether this is a Principal application
+- `principal` (Boolean, Deprecated) Whether this is a Principal application
 
 <a id="nestedblock--charm"></a>
 ### Nested Schema for `charm`

--- a/internal/provider/resource_application_test.go
+++ b/internal/provider/resource_application_test.go
@@ -37,9 +37,6 @@ func TestAcc_ResourceApplication_Edge(t *testing.T) {
 					resource.TestCheckResourceAttr("juju_application.this", "charm.0.name", "jameinel-ubuntu-lite"),
 					resource.TestCheckResourceAttr("juju_application.this", "trust", "true"),
 					resource.TestCheckResourceAttr("juju_application.this", "expose.#", "1"),
-					// We do not have access to this data during creation, only during read.
-					// Therefor it's set to the bool default
-					resource.TestCheckResourceAttr("juju_application.this", "principal", "true"),
 				),
 			},
 			{
@@ -102,8 +99,6 @@ func TestAcc_ResourceApplication_Edge(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("juju_application.this", "model", modelName),
 					resource.TestCheckResourceAttr("juju_application.this", "constraints", "arch=amd64 cores=1 mem=4096M"),
-					resource.TestCheckResourceAttr("juju_application.this", "principal", "true"),
-					resource.TestCheckResourceAttr("juju_application.subordinate", "principal", "false"),
 				),
 			},
 			{
@@ -227,7 +222,6 @@ func TestAcc_ResourceApplication_Minimal(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", charmName),
 					resource.TestCheckResourceAttr(resourceName, "charm.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "charm.0.name", charmName),
-					resource.TestCheckResourceAttr(resourceName, "principal", "true"),
 				),
 			},
 			{
@@ -269,7 +263,6 @@ func TestAcc_ResourceApplication_Stable(t *testing.T) {
 					resource.TestCheckResourceAttr("juju_application.this", "charm.0.name", "jameinel-ubuntu-lite"),
 					resource.TestCheckResourceAttr("juju_application.this", "trust", "true"),
 					resource.TestCheckResourceAttr("juju_application.this", "expose.#", "1"),
-					resource.TestCheckResourceAttr("juju_application.this", "principal", "true"),
 				),
 			},
 			{
@@ -303,8 +296,6 @@ func TestAcc_ResourceApplication_Stable(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("juju_application.this", "model", modelName),
 					resource.TestCheckResourceAttr("juju_application.this", "constraints", "arch=amd64 cores=1 mem=4096M"),
-					resource.TestCheckResourceAttr("juju_application.this", "principal", "true"),
-					resource.TestCheckResourceAttr("juju_application.subordinate", "principal", "false"),
 				),
 			},
 			{


### PR DESCRIPTION
## Description

Remove unused schema value which cannot be used by a user either. The provider was saving the principal value, but not using it. Rather it was using the Principal value from a juju api response. No need to keep it.

## Type of change

- Other (please describe)


## QA steps

Deploy an application via a plan with 0.9.1 and upgrade. Deploy another application with the new version of the provider.


