### PR TITLE
Update ACC tests, framework migration complete.

### DIFF
--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/juju/terraform-provider-juju/internal/juju"
 )
 
-const TestProviderStableVersion = "0.8.0"
+const TestProviderStableVersion = "0.9.1"
 
 // providerFactories are used to instantiate the Framework provider during
 // acceptance testing.

--- a/internal/provider/resource_machine_test.go
+++ b/internal/provider/resource_machine_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
-func TestAcc_ResourceMachine_Edge(t *testing.T) {
+func TestAcc_ResourceMachine(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
@@ -75,21 +75,22 @@ resource "juju_machine" "testmachine" {
 `, modelName)
 }
 
-func TestAcc_ResourceMachine_Stable(t *testing.T) {
+func TestAcc_ResourceMachine_UpgradeProvider(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
 	modelName := acctest.RandomWithPrefix("tf-test-machine")
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() { testAccPreCheck(t) },
-		ExternalProviders: map[string]resource.ExternalProvider{
-			"juju": {
-				VersionConstraint: TestProviderStableVersion,
-				Source:            "juju/juju",
-			},
-		},
+
 		Steps: []resource.TestStep{
 			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"juju": {
+						VersionConstraint: TestProviderStableVersion,
+						Source:            "juju/juju",
+					},
+				},
 				Config: testAccResourceMachine(modelName, "series = \"focal\""),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("juju_machine.this", "model", modelName),
@@ -98,9 +99,9 @@ func TestAcc_ResourceMachine_Stable(t *testing.T) {
 				),
 			},
 			{
-				ImportStateVerify: true,
-				ImportState:       true,
-				ResourceName:      "juju_machine.this",
+				ProtoV6ProviderFactories: frameworkProviderFactories,
+				Config:                   testAccResourceMachine(modelName, "series = \"focal\""),
+				PlanOnly:                 true,
 			},
 		},
 	})

--- a/internal/provider/resource_offer_test.go
+++ b/internal/provider/resource_offer_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
-func TestAcc_ResourceOffer_Edge(t *testing.T) {
+func TestAcc_ResourceOffer(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
@@ -104,7 +104,7 @@ resource "juju_integration" "int" {
 `, srcModelName, destModelName)
 }
 
-func TestAcc_ResourceOffer_Stable(t *testing.T) {
+func TestAcc_ResourceOffer_UpgradeProvider(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
@@ -112,14 +112,15 @@ func TestAcc_ResourceOffer_Stable(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() { testAccPreCheck(t) },
-		ExternalProviders: map[string]resource.ExternalProvider{
-			"juju": {
-				VersionConstraint: TestProviderStableVersion,
-				Source:            "juju/juju",
-			},
-		},
+
 		Steps: []resource.TestStep{
 			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"juju": {
+						VersionConstraint: TestProviderStableVersion,
+						Source:            "juju/juju",
+					},
+				},
 				Config: testAccResourceOffer(modelName, "series = \"focal\""),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("juju_offer.this", "model", modelName),
@@ -128,9 +129,9 @@ func TestAcc_ResourceOffer_Stable(t *testing.T) {
 				),
 			},
 			{
-				ImportStateVerify: true,
-				ImportState:       true,
-				ResourceName:      "juju_offer.this",
+				ProtoV6ProviderFactories: frameworkProviderFactories,
+				Config:                   testAccResourceOffer(modelName, "series = \"focal\""),
+				PlanOnly:                 true,
 			},
 		},
 	})

--- a/internal/provider/resource_ssh_key_test.go
+++ b/internal/provider/resource_ssh_key_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
-func TestAcc_ResourceSSHKey_Edge(t *testing.T) {
+func TestAcc_ResourceSSHKey(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
@@ -41,7 +41,7 @@ func TestAcc_ResourceSSHKey_Edge(t *testing.T) {
 	})
 }
 
-func TestAcc_ResourceSSHKey_ED25519_Edge(t *testing.T) {
+func TestAcc_ResourceSSHKey_ED25519(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
@@ -62,7 +62,7 @@ func TestAcc_ResourceSSHKey_ED25519_Edge(t *testing.T) {
 	})
 }
 
-func TestAcc_ResourceSSHKey_Stable(t *testing.T) {
+func TestAcc_ResourceSSHKey_UpgradeProvider(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
@@ -73,51 +73,24 @@ func TestAcc_ResourceSSHKey_Stable(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() { testAccPreCheck(t) },
-		ExternalProviders: map[string]resource.ExternalProvider{
-			"juju": {
-				VersionConstraint: TestProviderStableVersion,
-				Source:            "juju/juju",
-			},
-		},
+
 		Steps: []resource.TestStep{
 			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"juju": {
+						VersionConstraint: TestProviderStableVersion,
+						Source:            "juju/juju",
+					},
+				},
 				Config: testAccResourceSSHKey(modelName, sshKey1),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("juju_ssh_key.this", "model", modelName),
 					resource.TestCheckResourceAttr("juju_ssh_key.this", "payload", sshKey1)),
 			},
-			// we update the key
 			{
-				Config: testAccResourceSSHKey(modelName, sshKey2),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("juju_ssh_key.this", "model", modelName),
-					resource.TestCheckResourceAttr("juju_ssh_key.this", "payload", sshKey2)),
-			},
-		},
-	})
-}
-
-func TestAcc_ResourceSSHKey_ED25519_Stable(t *testing.T) {
-	if testingCloud != LXDCloudTesting {
-		t.Skip(t.Name() + " only runs with LXD")
-	}
-	modelName := acctest.RandomWithPrefix("tf-test-sshkey")
-	sshKey1 := `ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAID3gjJTJtYZU55HTUr+hu0JF9p152yiC9czJi9nKojuW jimmy@somewhere`
-
-	resource.Test(t, resource.TestCase{
-		PreCheck: func() { testAccPreCheck(t) },
-		ExternalProviders: map[string]resource.ExternalProvider{
-			"juju": {
-				VersionConstraint: TestProviderStableVersion,
-				Source:            "juju/juju",
-			},
-		},
-		Steps: []resource.TestStep{
-			{
-				Config: testAccResourceSSHKey(modelName, sshKey1),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("juju_ssh_key.this", "model", modelName),
-					resource.TestCheckResourceAttr("juju_ssh_key.this", "payload", sshKey1)),
+				ProtoV6ProviderFactories: frameworkProviderFactories,
+				Config:                   testAccResourceSSHKey(modelName, sshKey2),
+				PlanOnly:                 true,
 			},
 		},
 	})


### PR DESCRIPTION

## Description

Convert one Stable test per DataSource/Resource to an UpgradeProvider test from the latest released version. The other Stable tests are no longer needed, as migration to the framework is done. This will improve our testing and reduce test time.

Change the released version of juju provider for testing to most recent, 0.9.1.

Read this example https://developer.hashicorp.com/terraform/plugin/framework/migrating/testing#example more closely for the idea.

## Type of change

- Change in tests (one or several tests have been changed)
