### PR TITLE
Fix panic in intergration resource update

### DIFF
--- a/internal/provider/resource_integration.go
+++ b/internal/provider/resource_integration.go
@@ -372,7 +372,7 @@ func (r *integrationResource) Update(ctx context.Context, req resource.UpdateReq
 	}
 
 	applications := parseApplications(response.Applications)
-	appType := req.State.Schema.GetAttributes()["application"].(schema.SetNestedAttribute).NestedObject.Type()
+	appType := req.State.Schema.GetBlocks()["application"].(schema.SetNestedBlock).NestedObject.Type()
 	apps, aErr := types.SetValueFrom(ctx, appType, applications)
 	if aErr.HasError() {
 		resp.Diagnostics.Append(aErr...)


### PR DESCRIPTION
## Description

This is a quick run-by fix for something I bumped into when I was working on #235. Looks like the type of the `applications` in integration resource's `Update` is set to be an Attribute instead of a Block like in the Schema.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Environment

- Juju controller version: 2.9

- Terraform version: 1.5

## QA steps

Any plan that updates an integration would hit that. I'll add the plan that I was using when I bumped into this one.

Apply the plan below, let it settle, then uncomment the `wordpresstwo` and change the app name in the integration.

```terraform
resource "juju_model" "development" {
  name = "development"
}

resource "juju_application" "wordpress" {
  name = "wordpress"

  model = juju_model.development.name

  charm {
    name = "wordpress"
  }

  units = 3
}


/*
resource "juju_application" "wordpresstwo" {
  name = "wordpresstwo"

  model = juju_model.development.name

  charm {
    name = "wordpress"
  }

  units = 3
}
*/


resource "juju_application" "percona-cluster" {
  name = "percona-cluster"

  model = juju_model.development.name

  charm {
    name = "percona-cluster"
  }

  units = 3
}

resource "juju_integration" "wp_to_percona" {
  model = juju_model.development.name

  application {
    name     = juju_application.wordpress.name # <---------- change this to wordpresstwo
    endpoint = "db"
  }

  application {
    name     = juju_application.percona-cluster.name
    endpoint = "db"
  }
}

```