### PR TITLE
docs(version): Bump juju provider version

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -40,7 +40,7 @@ Terraform 0.13 and later:
 terraform {
   required_providers {
     juju = {
-      version = "~> 0.3.1"
+      version = "~> 0.10.0"
       source  = "juju/juju"
     }
   }

--- a/docs/index.md
+++ b/docs/index.md
@@ -135,7 +135,7 @@ resource "juju_integration" "wp_to_percona" {
 Terraform 0.12 and earlier:
 ```terraform
 provider "juju" {
-  version = "~> 0.3.1"
+  version = "~> 0.10.0"
 
   controller_addresses = "10.225.205.241:17070,10.225.205.242:17070"
 

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     juju = {
-      version = "~> 0.3.1"
+      version = "~> 0.10.0"
       source  = "juju/juju"
     }
   }

--- a/examples/provider/provider_0.12.tf
+++ b/examples/provider/provider_0.12.tf
@@ -1,5 +1,5 @@
 provider "juju" {
-  version = "~> 0.3.1"
+  version = "~> 0.10.0"
 
   controller_addresses = "10.225.205.241:17070,10.225.205.242:17070"
 


### PR DESCRIPTION

## Description

Bumps the version in the docs from 0.3.1 to 0.10.0, the most recent version. I think this is also replicated in https://registry.terraform.io/providers/juju/juju/latest/docs and new users might go the route of using 0.3.1 by default, which is a pretty old version.

Fixes: 

## Type of change

- Requires a documentation update

## Environment

- Juju controller version: n/a

- Terraform version: n/a

## QA steps

Manual QA steps should be done to test this PR.

```tf
provider juju {}
...
```

## Additional notes

*\<Please add relevant notes & information, links to mattermost chats, other related issues/PRs, anything to help understand and QA the PR.\>*
