### PR TITLE
Adds install-dependencies target in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,22 +76,25 @@ testmicrok8s:
 ## testmicrok8s: Run unit tests against microk8s
 	TF_ACC=1 TEST_CLOUD=microk8s go test ./... -v $(TESTARGS) -timeout 120m
 
+PACKAGES=terraform golangci-lint go
+# Function to check if Snap packages are installed
+check-snap-package:
+	@for package in $(PACKAGES); do \
+		if snap list $$package >/dev/null 2>&1; then \
+			echo "Package $$package is already installed."; \
+		else \
+			echo "Package $$package is not installed."; \
+			sudo snap install $$package --classic; \
+		fi; \
+	done
+
 .PHONY: install-snap-dependencies
-install-snap-dependencies:
-## install-snap-dependencies: Install snap dependencies for terraform-provider-juju
-	@echo "Installing snap dependencies"
-ifneq ($(HAS_TERRAFORM),)
-	@echo "Refreshing terraform snap"
-	@sudo snap refresh terraform --classic
-else
-	@echo "Installing terraform snap"
-	@sudo snap install terraform --classic
-endif
+install-snap-dependencies: check-snap-package
+## install-snap-dependencies: Install all the snap dependencies
 
 .PHONY: install-dependencies
 install-dependencies: install-snap-dependencies
 ## install-dependencies: Install all the dependencies
-	@echo "Installing dependencies"
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ install: simplify docs go-install
 # Reformat and simplify source files.
 simplify:
 ## simplify: Format and simplify the go source code
-	@echo "Formating the go source code"
+	@echo "Formatting the go source code"
 	@gofmt -w -l -s .
 
 .PHONY: lint
@@ -75,3 +75,23 @@ testlxd:
 testmicrok8s:
 ## testmicrok8s: Run unit tests against microk8s
 	TF_ACC=1 TEST_CLOUD=microk8s go test ./... -v $(TESTARGS) -timeout 120m
+
+.PHONY: install-snap-dependencies
+install-snap-dependencies:
+## install-snap-dependencies: Install snap dependencies for terraform-provider-juju
+	@echo "Installing snap dependencies"
+ifneq ($(HAS_TERRAFORM),)
+	@echo "Refreshing terraform snap"
+	@sudo snap refresh terraform --classic
+else
+	@echo "Installing terraform snap"
+	@sudo snap install terraform --classic
+endif
+
+.PHONY: install-dependencies
+install-dependencies: install-snap-dependencies
+## install-dependencies: Install all the dependencies
+	@echo "Installing dependencies"
+
+
+

--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ _Note:_ These features may not have functional parity with the juju cli at this 
 
 1. Clone the repository
 1. Enter the repository directory
+1. Build the provider dependencies using the make `install-dependencies` target:
+
+    ```shell
+    make install-dependencies
+    ```
+
 1. Build the provider using the make `go-install` target:
 
     ```shell


### PR DESCRIPTION
## Description

Add a new Makefile target, which adds the dependency on snaps listed in the PACKAGES variable.

Here is the list of the packages:
- terraform
- golangci-lint
- go

## Environment

- Juju controller version: any

- Terraform version: any

## QA steps

```bash
make install-dependencies
```


## Links

Jira-card: [JUJU-5117](https://warthogs.atlassian.net/browse/JUJU-5117)

[JUJU-5117]: https://warthogs.atlassian.net/browse/JUJU-5117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ