### PR TITLE
Fix issue 346: Do not require permissions on the controller model to deploy an application.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/juju/names/v4 v4.0.0
 	github.com/juju/retry v1.0.0
 	github.com/juju/utils/v3 v3.0.2
+	github.com/juju/version/v2 v2.0.0
 	github.com/rs/zerolog v1.31.0
 	github.com/stretchr/testify v1.8.4
 )
@@ -137,7 +138,6 @@ require (
 	github.com/juju/schema v1.0.1 // indirect
 	github.com/juju/txn/v2 v2.1.1 // indirect
 	github.com/juju/usso v1.0.1 // indirect
-	github.com/juju/version/v2 v2.0.0 // indirect
 	github.com/juju/webbrowser v1.0.0 // indirect
 	github.com/juju/worker/v3 v3.4.0 // indirect
 	github.com/julienschmidt/httprouter v1.3.0 // indirect

--- a/internal/provider/resource_offer_test.go
+++ b/internal/provider/resource_offer_test.go
@@ -149,6 +149,7 @@ resource "juju_application" "this" {
 
 	charm {
 		name = "postgresql"
+		channel = "latest/stable"
 		%s
 	}
 }


### PR DESCRIPTION
## Description

The controller version can be found via the conn object. We can ignore the boolean as we do have a logged in connection by the time the applicationClient gets one. This is easier, less work and resolves the issue of users not having permissions on the controller for determining the controller version.

Added a channel to the postgresql charm in a test to ensure that ubuntu@18.04 can be used. The current default channel only supports ubuntu@22.04.

Fixes: #346 

## Type of change

- Change in tests (one or several tests have been changed)
- Bug fix (non-breaking change which fixes an issue)

## Environment

- Juju controller version: 2.9.47

- Terraform version: 1.6.5

## QA steps

```bash
$ juju bootstrap localhost terraform
$ juju add-model tf-test
$ juju add-user tf-test
$ juju grant tf-test write tf-test

#  Set the new user password to "testing".
$ juju change-user-password tf-test

# Set a password for the admin user to be able to use it again.
$ juju change-user-password
$ juju logout

# Now login with the new user.
$ juju login -u tf-test -c terraform
```

```tf
terraform {
  required_version = ">= 1.5"
  required_providers {
    juju = {
      source  = "juju/juju"
      version = ">=0.10.0"
    }
  }
}

provider "juju" {
    username = "tf-test"
    password = "testing"
}

data "juju_model" "tf_test" {
    name       = "tf-test"
}

resource "juju_application" "ubuntu" {
  model = data.juju_model.tf_test.name
  charm {
    name = "ubuntu"
  }
}
```

To run the plan, supply username and password for the user created above.
```bash
terraform init  && terraform plan && terraform apply
```

Try to deploy the ubuntu charm using base "ubuntu@18.04" against a 3.1.x controller via terraform. Ensure it continues to fail as the controller does not support 18.04.

## Additional notes

JUJU-5119


