### PR TITLE
Update terraform versions in github actions.

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -38,9 +38,9 @@ jobs:
           - "lxd"
           - "microk8s"
         terraform:
-          - "1.3.*"
           - "1.4.*"
           - "1.5.*"
+          - "1.6.*"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4

--- a/.github/workflows/k8s_tunnel.yml
+++ b/.github/workflows/k8s_tunnel.yml
@@ -41,7 +41,7 @@ jobs:
         cloud:
           - "microk8s"
         terraform:
-          - "1.5.*"
+          - "1.6.*"
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test_add_machine.yml
+++ b/.github/workflows/test_add_machine.yml
@@ -45,7 +45,7 @@ jobs:
         cloud:
           - "lxd"
         terraform:
-          - "1.5.*"
+          - "1.6.*"
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test_integration.yml
+++ b/.github/workflows/test_integration.yml
@@ -43,9 +43,9 @@ jobs:
           - "lxd"
           - "microk8s"
         terraform:
-          - "1.3.*"
           - "1.4.*"
           - "1.5.*"
+          - "1.6.*"
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test_new_candidates.yml
+++ b/.github/workflows/test_new_candidates.yml
@@ -24,8 +24,8 @@ jobs:
           # - "candidate"
            - "edge"
         terraform:
-          - "1.4.*"
           - "1.5.*"
+          - "1.6.*"
     steps:
       - name: Set channel and artifact id
         run: |


### PR DESCRIPTION
## Description

Ensure we test with terraform 1.6.* now. Removing 1.3.* from the rotation as old. This is past due, 1.6.5 is out.

## Type of change

- Maintenance work (repository related, like Github actions, or revving the Go version, etc.)
