### PR TITLE
Find operating system for deploy regardless of juju controller version.

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -25,7 +25,7 @@ jobs:
       - run: go build -v .
 
   # Run acceptance tests in a matrix with Terraform CLI versions
-  test29:
+  test:
     name: Terraform Provider Acceptance Tests
     needs:
       - build
@@ -34,13 +34,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        cloud:
-          - "lxd"
-          - "microk8s"
         terraform:
           - "1.6.*"
-        juju:
-          - "2.9/stable"
+        include:
+          - cloud: "lxd"
+            cloud-channel: "5.19/stable"
+            juju-channel: "2.9/stable"
+          - cloud: "microk8s"
+            cloud-channel: "1.28/stable"
+            juju-channel: "2.9/stable"
+          - cloud: "lxd"
+            cloud-channel: "5.19/stable"
+            juju-channel: "3.1/stable"
+          - cloud: "microk8s"
+            cloud-channel: "1.28-strict/stable"
+            juju-channel: "3.1/stable"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
@@ -55,104 +63,8 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: ${{ matrix.cloud }}
-          juju-channel: ${{ matrix.juju }}
-      - name: "Set environment to configure provider"
-        # language=bash
-        run: |
-          CONTROLLER=$(juju whoami --format yaml | yq .controller)
-
-          echo "JUJU_CONTROLLER_ADDRESSES=$(juju show-controller | yq .$CONTROLLER.details.api-endpoints | yq -r '. | join(",")')" >> $GITHUB_ENV
-          echo "JUJU_USERNAME=$(juju show-controller | yq .$CONTROLLER.account.user)"  >> $GITHUB_ENV
-          echo "JUJU_PASSWORD=$(cat ~/.local/share/juju/accounts.yaml | yq .controllers.$CONTROLLER.password)"  >> $GITHUB_ENV
-          echo "JUJU_CA_CERT<<EOF" >> $GITHUB_ENV
-          juju show-controller | yq .$CONTROLLER.details.ca-cert >> $GITHUB_ENV
-          echo "EOF" >> $GITHUB_ENV
-      - env:
-          TF_ACC: "1"
-          TEST_CLOUD: ${{ matrix.cloud }}
-        run: go test -timeout 40m -v -cover ./internal/provider/
-
-  # test-31-microk8s is different from test-31-lxd as the
-  # charmed-kubernetes/actions-operator does not have the ability
-  # to specify a microk8s specific channel. Channel is generic
-  # and the operator tried to use for lxd, which fails. Bug filed.
-  test-31-microk8s:
-    name: Terraform Provider Acceptance Tests
-    needs:
-      - build
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    strategy:
-      fail-fast: false
-      matrix:
-        cloud:
-          - "microk8s"
-        terraform:
-          - "1.6.*"
-        juju:
-          - "3.1/stable"
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v4
-        with:
-          go-version-file: "go.mod"
-          cache: true
-      - uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_version: ${{ matrix.terraform }}
-          terraform_wrapper: false
-      - name: Setup operator environment
-        uses: charmed-kubernetes/actions-operator@main
-        with:
-          provider: ${{ matrix.cloud }}
-          juju-channel: ${{ matrix.juju }}
-          channel: "1.28-strict/stable"
-      - name: "Set environment to configure provider"
-        # language=bash
-        run: |
-          CONTROLLER=$(juju whoami --format yaml | yq .controller)
-
-          echo "JUJU_CONTROLLER_ADDRESSES=$(juju show-controller | yq .$CONTROLLER.details.api-endpoints | yq -r '. | join(",")')" >> $GITHUB_ENV
-          echo "JUJU_USERNAME=$(juju show-controller | yq .$CONTROLLER.account.user)"  >> $GITHUB_ENV
-          echo "JUJU_PASSWORD=$(cat ~/.local/share/juju/accounts.yaml | yq .controllers.$CONTROLLER.password)"  >> $GITHUB_ENV
-          echo "JUJU_CA_CERT<<EOF" >> $GITHUB_ENV
-          juju show-controller | yq .$CONTROLLER.details.ca-cert >> $GITHUB_ENV
-          echo "EOF" >> $GITHUB_ENV
-      - env:
-          TF_ACC: "1"
-          TEST_CLOUD: ${{ matrix.cloud }}
-        run: go test -timeout 40m -v -cover ./internal/provider/
-
-  test-31-lxd:
-    name: Terraform Provider Acceptance Tests
-    needs:
-      - build
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    strategy:
-      fail-fast: false
-      matrix:
-        cloud:
-          - "lxd"
-        terraform:
-          - "1.6.*"
-        juju:
-          - "3.1/stable"
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v4
-        with:
-          go-version-file: "go.mod"
-          cache: true
-      - uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_version: ${{ matrix.terraform }}
-          terraform_wrapper: false
-      - name: Setup operator environment
-        uses: charmed-kubernetes/actions-operator@main
-        with:
-          provider: ${{ matrix.cloud }}
-          juju-channel: ${{ matrix.juju }}
+          channel: ${{ matrix.cloud-channel }}
+          juju-channel: ${{ matrix.juju-channel }}
       - name: "Set environment to configure provider"
         # language=bash
         run: |

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -25,7 +25,7 @@ jobs:
       - run: go build -v .
 
   # Run acceptance tests in a matrix with Terraform CLI versions
-  test:
+  test29:
     name: Terraform Provider Acceptance Tests
     needs:
       - build
@@ -38,9 +38,9 @@ jobs:
           - "lxd"
           - "microk8s"
         terraform:
-          - "1.4.*"
-          - "1.5.*"
           - "1.6.*"
+        juju:
+          - "2.9/stable"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
@@ -55,7 +55,7 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: ${{ matrix.cloud }}
-          juju-channel: 2.9/stable
+          juju-channel: ${{ matrix.juju }}
       - name: "Set environment to configure provider"
         # language=bash
         run: |
@@ -71,4 +71,100 @@ jobs:
           TF_ACC: "1"
           TEST_CLOUD: ${{ matrix.cloud }}
         run: go test -timeout 40m -v -cover ./internal/provider/
-      
+
+  # test-31-microk8s is different from test-31-lxd as the
+  # charmed-kubernetes/actions-operator does not have the ability
+  # to specify a microk8s specific channel. Channel is generic
+  # and the operator tried to use for lxd, which fails. Bug filed.
+  test-31-microk8s:
+    name: Terraform Provider Acceptance Tests
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        cloud:
+          - "microk8s"
+        terraform:
+          - "1.6.*"
+        juju:
+          - "3.1/stable"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: "go.mod"
+          cache: true
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ matrix.terraform }}
+          terraform_wrapper: false
+      - name: Setup operator environment
+        uses: charmed-kubernetes/actions-operator@main
+        with:
+          provider: ${{ matrix.cloud }}
+          juju-channel: ${{ matrix.juju }}
+          channel: "1.28-strict/stable"
+      - name: "Set environment to configure provider"
+        # language=bash
+        run: |
+          CONTROLLER=$(juju whoami --format yaml | yq .controller)
+
+          echo "JUJU_CONTROLLER_ADDRESSES=$(juju show-controller | yq .$CONTROLLER.details.api-endpoints | yq -r '. | join(",")')" >> $GITHUB_ENV
+          echo "JUJU_USERNAME=$(juju show-controller | yq .$CONTROLLER.account.user)"  >> $GITHUB_ENV
+          echo "JUJU_PASSWORD=$(cat ~/.local/share/juju/accounts.yaml | yq .controllers.$CONTROLLER.password)"  >> $GITHUB_ENV
+          echo "JUJU_CA_CERT<<EOF" >> $GITHUB_ENV
+          juju show-controller | yq .$CONTROLLER.details.ca-cert >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+      - env:
+          TF_ACC: "1"
+          TEST_CLOUD: ${{ matrix.cloud }}
+        run: go test -timeout 40m -v -cover ./internal/provider/
+
+  test-31-lxd:
+    name: Terraform Provider Acceptance Tests
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        cloud:
+          - "lxd"
+        terraform:
+          - "1.6.*"
+        juju:
+          - "3.1/stable"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: "go.mod"
+          cache: true
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ matrix.terraform }}
+          terraform_wrapper: false
+      - name: Setup operator environment
+        uses: charmed-kubernetes/actions-operator@main
+        with:
+          provider: ${{ matrix.cloud }}
+          juju-channel: ${{ matrix.juju }}
+      - name: "Set environment to configure provider"
+        # language=bash
+        run: |
+          CONTROLLER=$(juju whoami --format yaml | yq .controller)
+
+          echo "JUJU_CONTROLLER_ADDRESSES=$(juju show-controller | yq .$CONTROLLER.details.api-endpoints | yq -r '. | join(",")')" >> $GITHUB_ENV
+          echo "JUJU_USERNAME=$(juju show-controller | yq .$CONTROLLER.account.user)"  >> $GITHUB_ENV
+          echo "JUJU_PASSWORD=$(cat ~/.local/share/juju/accounts.yaml | yq .controllers.$CONTROLLER.password)"  >> $GITHUB_ENV
+          echo "JUJU_CA_CERT<<EOF" >> $GITHUB_ENV
+          juju show-controller | yq .$CONTROLLER.details.ca-cert >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+      - env:
+          TF_ACC: "1"
+          TEST_CLOUD: ${{ matrix.cloud }}
+        run: go test -timeout 40m -v -cover ./internal/provider/

--- a/.github/workflows/test_add_machine.yml
+++ b/.github/workflows/test_add_machine.yml
@@ -9,12 +9,16 @@ on:
     paths-ignore:
       - "README.md"
       - "project-docs/**"
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/PULL_REQUEST_TEMPLATE.md"
   push:
     branches:
       - "main"
     paths-ignore:
       - "README.md"
       - "project-docs/**"
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/PULL_REQUEST_TEMPLATE.md"
 
 # Testing only needs permissions to read the repository contents.
 permissions:
@@ -46,6 +50,9 @@ jobs:
           - "lxd"
         terraform:
           - "1.6.*"
+        juju:
+          - "2.9/stable"
+          - "3.1/stable"
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
@@ -63,7 +70,7 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: ${{ matrix.cloud }}
-          juju-channel: 2.9/stable
+          juju-channel: ${{ matrix.juju }}
       - name: "Set environment to configure provider"
         # language=bash
         run: |

--- a/.github/workflows/test_integration.yml
+++ b/.github/workflows/test_integration.yml
@@ -8,12 +8,16 @@ on:
     paths-ignore:
       - "README.md"
       - "project-docs/**"
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/PULL_REQUEST_TEMPLATE.md"
   push:
     branches:
       - "main"
     paths-ignore:
       - "README.md"
       - "project-docs/**"
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/PULL_REQUEST_TEMPLATE.md"
 
 # Testing only needs permissions to read the repository contents.
 permissions:
@@ -31,7 +35,10 @@ jobs:
       - run: go build -v .
 
   # Run acceptance tests in a matrix with Terraform CLI versions
-  test:
+  # Using juju 2.9/stable which requires a classic version
+  # of the microk8s snap. This happens to be the default snap
+  # today.
+  test-29:
     name: Integration
     needs: build
     runs-on: ubuntu-latest
@@ -46,6 +53,8 @@ jobs:
           - "1.4.*"
           - "1.5.*"
           - "1.6.*"
+        juju:
+          - "2.9/stable"
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
@@ -61,7 +70,119 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: ${{ matrix.cloud }}
-          juju-channel: 2.9/stable
+          juju-channel: ${{ matrix.juju }}
+      - name: "Set environment to configure provider"
+        # language=bash
+        run: |
+          CONTROLLER=$(juju whoami --format yaml | yq .controller)
+
+          echo "JUJU_CONTROLLER_ADDRESSES=$(juju show-controller | yq .$CONTROLLER.details.api-endpoints | yq -r '. | join(",")')" >> $GITHUB_ENV
+          echo "JUJU_USERNAME=$(juju show-controller | yq .$CONTROLLER.account.user)"  >> $GITHUB_ENV
+          echo "JUJU_PASSWORD=$(cat ~/.local/share/juju/accounts.yaml | yq .controllers.$CONTROLLER.password)"  >> $GITHUB_ENV
+          echo "JUJU_CA_CERT<<EOF" >> $GITHUB_ENV
+          juju show-controller | yq .$CONTROLLER.details.ca-cert >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+      - run: go mod download
+      - env:
+          TF_ACC: "1"
+          TEST_CLOUD: ${{ matrix.cloud }}
+        run: go test -timeout 40m -v -cover ./internal/provider/
+        timeout-minutes: 40
+
+  # Run acceptance tests in a matrix with Terraform CLI versions
+  # Using juju 3.1/stable which requires a strictly confined version
+  # of the microk8s snap.
+  #
+  # test-31-microk8s is different from test-31-lxd as the
+  # charmed-kubernetes/actions-operator does not have the ability
+  # to specify a microk8s specific channel. Channel is generic
+  # and the operator tried to use for lxd, which fails. Bug filed.
+  test-31-microk8s:
+    name: Integration
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Different clouds
+        cloud:
+          - "microk8s"
+        terraform:
+          - "1.4.*"
+          - "1.5.*"
+          - "1.6.*"
+        juju:
+          - "3.1/stable"
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: "go.mod"
+          cache: true
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ matrix.terraform }}
+          terraform_wrapper: false
+      - name: Setup operator environment
+        uses: charmed-kubernetes/actions-operator@main
+        with:
+          provider: ${{ matrix.cloud }}
+          juju-channel: ${{ matrix.juju }}
+          channel: "1.28-strict/stable"
+      - name: "Set environment to configure provider"
+        # language=bash
+        run: |
+          CONTROLLER=$(juju whoami --format yaml | yq .controller)
+
+          echo "JUJU_CONTROLLER_ADDRESSES=$(juju show-controller | yq .$CONTROLLER.details.api-endpoints | yq -r '. | join(",")')" >> $GITHUB_ENV
+          echo "JUJU_USERNAME=$(juju show-controller | yq .$CONTROLLER.account.user)"  >> $GITHUB_ENV
+          echo "JUJU_PASSWORD=$(cat ~/.local/share/juju/accounts.yaml | yq .controllers.$CONTROLLER.password)"  >> $GITHUB_ENV
+          echo "JUJU_CA_CERT<<EOF" >> $GITHUB_ENV
+          juju show-controller | yq .$CONTROLLER.details.ca-cert >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+      - run: go mod download
+      - env:
+          TF_ACC: "1"
+          TEST_CLOUD: ${{ matrix.cloud }}
+        run: go test -timeout 40m -v -cover ./internal/provider/
+        timeout-minutes: 40
+
+  # Run acceptance tests in a matrix with Terraform CLI versions
+  # Using juju 3.1/stable which requires a strictly confined version
+  # of the microk8s snap.
+  test-31-lxd:
+    name: Integration
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Different clouds
+        cloud:
+          - "lxd"
+        terraform:
+          - "1.4.*"
+          - "1.5.*"
+          - "1.6.*"
+        juju:
+          - "3.1/stable"
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: "go.mod"
+          cache: true
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ matrix.terraform }}
+          terraform_wrapper: false
+      - name: Setup operator environment
+        uses: charmed-kubernetes/actions-operator@main
+        with:
+          provider: ${{ matrix.cloud }}
+          juju-channel: ${{ matrix.juju }}
       - name: "Set environment to configure provider"
         # language=bash
         run: |

--- a/.github/workflows/test_integration.yml
+++ b/.github/workflows/test_integration.yml
@@ -38,23 +38,30 @@ jobs:
   # Using juju 2.9/stable which requires a classic version
   # of the microk8s snap. This happens to be the default snap
   # today.
-  test-29:
+  test:
     name: Integration
     needs: build
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        # Different clouds
-        cloud:
-          - "lxd"
-          - "microk8s"
         terraform:
           - "1.4.*"
           - "1.5.*"
           - "1.6.*"
-        juju:
-          - "2.9/stable"
+        include:
+          - cloud: "lxd"
+            cloud-channel: "5.19/stable"
+            juju-channel: "2.9/stable"
+          - cloud: "microk8s"
+            cloud-channel: "1.28/stable"
+            juju-channel: "2.9/stable"
+          - cloud: "lxd"
+            cloud-channel: "5.19/stable"
+            juju-channel: "3.1/stable"
+          - cloud: "microk8s"
+            cloud-channel: "1.28-strict/stable"
+            juju-channel: "3.1/stable"
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
@@ -70,119 +77,8 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: ${{ matrix.cloud }}
-          juju-channel: ${{ matrix.juju }}
-      - name: "Set environment to configure provider"
-        # language=bash
-        run: |
-          CONTROLLER=$(juju whoami --format yaml | yq .controller)
-
-          echo "JUJU_CONTROLLER_ADDRESSES=$(juju show-controller | yq .$CONTROLLER.details.api-endpoints | yq -r '. | join(",")')" >> $GITHUB_ENV
-          echo "JUJU_USERNAME=$(juju show-controller | yq .$CONTROLLER.account.user)"  >> $GITHUB_ENV
-          echo "JUJU_PASSWORD=$(cat ~/.local/share/juju/accounts.yaml | yq .controllers.$CONTROLLER.password)"  >> $GITHUB_ENV
-          echo "JUJU_CA_CERT<<EOF" >> $GITHUB_ENV
-          juju show-controller | yq .$CONTROLLER.details.ca-cert >> $GITHUB_ENV
-          echo "EOF" >> $GITHUB_ENV
-      - run: go mod download
-      - env:
-          TF_ACC: "1"
-          TEST_CLOUD: ${{ matrix.cloud }}
-        run: go test -timeout 40m -v -cover ./internal/provider/
-        timeout-minutes: 40
-
-  # Run acceptance tests in a matrix with Terraform CLI versions
-  # Using juju 3.1/stable which requires a strictly confined version
-  # of the microk8s snap.
-  #
-  # test-31-microk8s is different from test-31-lxd as the
-  # charmed-kubernetes/actions-operator does not have the ability
-  # to specify a microk8s specific channel. Channel is generic
-  # and the operator tried to use for lxd, which fails. Bug filed.
-  test-31-microk8s:
-    name: Integration
-    needs: build
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        # Different clouds
-        cloud:
-          - "microk8s"
-        terraform:
-          - "1.4.*"
-          - "1.5.*"
-          - "1.6.*"
-        juju:
-          - "3.1/stable"
-    timeout-minutes: 60
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v4
-        with:
-          go-version-file: "go.mod"
-          cache: true
-      - uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_version: ${{ matrix.terraform }}
-          terraform_wrapper: false
-      - name: Setup operator environment
-        uses: charmed-kubernetes/actions-operator@main
-        with:
-          provider: ${{ matrix.cloud }}
-          juju-channel: ${{ matrix.juju }}
-          channel: "1.28-strict/stable"
-      - name: "Set environment to configure provider"
-        # language=bash
-        run: |
-          CONTROLLER=$(juju whoami --format yaml | yq .controller)
-
-          echo "JUJU_CONTROLLER_ADDRESSES=$(juju show-controller | yq .$CONTROLLER.details.api-endpoints | yq -r '. | join(",")')" >> $GITHUB_ENV
-          echo "JUJU_USERNAME=$(juju show-controller | yq .$CONTROLLER.account.user)"  >> $GITHUB_ENV
-          echo "JUJU_PASSWORD=$(cat ~/.local/share/juju/accounts.yaml | yq .controllers.$CONTROLLER.password)"  >> $GITHUB_ENV
-          echo "JUJU_CA_CERT<<EOF" >> $GITHUB_ENV
-          juju show-controller | yq .$CONTROLLER.details.ca-cert >> $GITHUB_ENV
-          echo "EOF" >> $GITHUB_ENV
-      - run: go mod download
-      - env:
-          TF_ACC: "1"
-          TEST_CLOUD: ${{ matrix.cloud }}
-        run: go test -timeout 40m -v -cover ./internal/provider/
-        timeout-minutes: 40
-
-  # Run acceptance tests in a matrix with Terraform CLI versions
-  # Using juju 3.1/stable which requires a strictly confined version
-  # of the microk8s snap.
-  test-31-lxd:
-    name: Integration
-    needs: build
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        # Different clouds
-        cloud:
-          - "lxd"
-        terraform:
-          - "1.4.*"
-          - "1.5.*"
-          - "1.6.*"
-        juju:
-          - "3.1/stable"
-    timeout-minutes: 60
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v4
-        with:
-          go-version-file: "go.mod"
-          cache: true
-      - uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_version: ${{ matrix.terraform }}
-          terraform_wrapper: false
-      - name: Setup operator environment
-        uses: charmed-kubernetes/actions-operator@main
-        with:
-          provider: ${{ matrix.cloud }}
-          juju-channel: ${{ matrix.juju }}
+          channel: ${{ matrix.cloud-channel }}
+          juju-channel: ${{ matrix.juju-channel }}
       - name: "Set environment to configure provider"
         # language=bash
         run: |

--- a/.github/workflows/test_new_candidates.yml
+++ b/.github/workflows/test_new_candidates.yml
@@ -18,28 +18,37 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        juju_track:
-          - "2.9"
-          - "3.1"
-        juju_risk:
+        juju-risk:
            - "edge"
         terraform:
-          - "1.5.*"
           - "1.6.*"
+        include:
+          - cloud: "lxd"
+            cloud-channel: "5.19/stable"
+            juju-track: "2.9"
+          - cloud: "microk8s"
+            cloud-channel: "1.28/stable"
+            juju-track: "2.9"
+          - cloud: "lxd"
+            cloud-channel: "5.19/stable"
+            juju-track: "3.1"
+          - cloud: "microk8s"
+            cloud-channel: "1.28-strict/stable"
+            juju-track: "3.1"
     steps:
       - name: Set channel and artifact id
         run: |
-          channel=$(echo ${{ matrix.juju_track }}/${{ matrix.juju_risk }})
+          channel=$(echo ${{ matrix.juju-track }}/${{ matrix.juju-risk }})
           echo "Target channel is $channel"
           echo "channel=$channel" >> $GITHUB_ENV
           terraform_version=$(echo ${{ matrix.terraform }} |  awk -F'\.' '{print $1$2}')
-          id=$(echo ${{ github.sha }}-${{ matrix.juju_track }}-${{ matrix.juju_risk }}-$terraform_version)
+          id=$(echo ${{ github.sha }}-${{ matrix.juju-track }}-${{ matrix.juju-risk }}-$terraform_version)
           echo "Target id is $id"
           echo "id=$id" >> $GITHUB_ENV
       - name: Checkout branch
         uses: actions/checkout@v4
         with:
-          ref: ${{ env.juju_track }}
+          ref: ${{ env.juju-track }}
       - name: Download artifact
         uses: dawidd6/action-download-artifact@v2
         id: download_artifact
@@ -87,6 +96,7 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: ${{ matrix.cloud }}
+          channel: ${{ matrix.cloud-channel }}
           juju-channel: ${{ env.channel }}
       - name: "Set environment to configure provider"
         if: ${{ env.next-test != 'NA' }}

--- a/.github/workflows/test_new_candidates.yml
+++ b/.github/workflows/test_new_candidates.yml
@@ -20,8 +20,8 @@ jobs:
       matrix:
         juju_track:
           - "2.9"
+          - "3.1"
         juju_risk:
-          # - "candidate"
            - "edge"
         terraform:
           - "1.5.*"


### PR DESCRIPTION
## Description

Ensure we always have a suggested series from resolve charm. The value will be in different places depending on the juju controller version. Prefer the base value in the resolved charm origin. Fallback to the series from resolved charm.URL.

Updated the canary, add-machine, and integration test workflows to test with a 3.1.x controller as well as 2.9. Help find issues like this before release. The default microk8s snap channel provides a classic snap version. 3.x juju requires a strictly confined version of the microk8s snap. Added channel to ensure both set of tests were using the same version of microk8s. We will have to update the versions in the future.

Updated a test due to changes in the charm used by the test.

Fixes: #352 

## Type of change

- Change in tests (one or several tests have been changed)
- Bug fix (non-breaking change which fixes an issue)

## Environment

- Juju controller version: 3.1.6

- Terraform version: 1.6.5

## QA steps

Run these steps against juju 2.9/stable and 3.1/stable juju controllers. 

```tf
terraform {
  required_providers {
    juju = {
      version = ">= 0.10.0"
      source  = "juju/juju"
    }
  }
}

provider "juju" {
}

resource "juju_model" "testmodel" {
  name = "machinetest"
}

resource "juju_application" "kubernetes-control-plane" {
  model = juju_model.testmodel.name
  charm {
    name     = "kubernetes-control-plane"
    base     = "ubuntu@22.04"
    channel  = "1.28/stable"
  }
}
```

```bash
terraform init  && terraform plan && terraform apply
```
## Additional notes

JUJU-5169