### PR TITLE
Populating Juju controller config no longer immediately fails if Juju CLI does not exist

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -39,15 +39,16 @@ const (
 // controller as a fallback.
 func populateJujuProviderModelLive() (jujuProviderModel, error) {
 	data := jujuProviderModel{}
-	controllerConfig, err := juju.GetLocalControllerConfig()
-	if err != nil {
-		return data, err
-	}
-
+	controllerConfig, cliNotExist := juju.GetLocalControllerConfig()
 	data.ControllerAddrs = types.StringValue(getField(JujuControllerEnvKey, controllerConfig))
 	data.UserName = types.StringValue(getField(JujuUsernameEnvKey, controllerConfig))
 	data.Password = types.StringValue(getField(JujuPasswordEnvKey, controllerConfig))
 	data.CACert = types.StringValue(getField(JujuCACertEnvKey, controllerConfig))
+	// Only error if a valid controller config could not be fetched
+	// from the environment variables.
+	if cliNotExist != nil && !data.valid() {
+		return data, errors.New("unable to acquire Juju controller config: no working Juju client, and environment variables are not fully set")
+	}
 
 	return data, nil
 }


### PR DESCRIPTION
## Description

Populating Juju controller config will fail if the Juju CLI does not exist. This PR changes that behaviour to attempt to fill the config using environment variables. Only if environment variables are incomplete will the function error.

Fixes: https://github.com/juju/terraform-provider-juju/issues/340.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Environment

- Juju controller version: 2.9.47

- Terraform version: v1.5.7

## QA steps

Manual QA steps should be done to test this PR.

```tf
terraform {
  required_version = ">= 1.5"
  required_providers {
    juju = {
      source  = "juju/juju"
      version = "0.11.0"
    }
  }
}

data "juju_model" "tf_test" {
  name = "tf-test"
}

resource "juju_application" "postgresql-k8s" {
  model = data.juju_model.tf_test.name
  charm {
    name = "postgresql-k8s"
  }
}
```

```bash
# Setup env
juju bootstrap microk8s terraform
juju add-model tf-test
terraform init

# This will get config through Juju CLI
terraform apply

export JUJU_CONTROLLER_ADDRESSES="$(juju show-controller | yq '.[$CONTROLLER]'.details.\"api-endpoints\" | tr -d "[]' "|tr -d '"'|tr -d '\n')"
export JUJU_USERNAME="$(cat ~/.local/share/juju/accounts.yaml | yq .controllers.$CONTROLLER.user|tr -d '"')"
export JUJU_PASSWORD="$(cat ~/.local/share/juju/accounts.yaml | yq .controllers.$CONTROLLER.password|tr -d '"')"
export JUJU_CA_CERT="$(juju show-controller $(echo $CONTROLLER|tr -d '"') | yq '.[$CONTROLLER]'.details.\"ca-cert\"|tr -d '"'|sed 's/\\n/\n/g')"

# Remove Juju config, to make Juju CLI error. You can try by doing `juju show-controller --show-password`
mv ~/.local/share/juju ~/.local/share/juju.backup
terraform apply # Should still work by fetching controller data from the env only

# Revert backup and run Juju status
rm -rf ~/.local/share/juju && mv ~/.local/share/juju.backup/ ~/.local/share/juju
juju status
```
```