### PR TITLE
WIP: Replace strategy.matrix.include use.

### DIFF
--- a/.github/workflows/test_integration.yml
+++ b/.github/workflows/test_integration.yml
@@ -35,9 +35,6 @@ jobs:
       - run: go build -v .
 
   # Run acceptance tests in a matrix with Terraform CLI versions
-  # Using juju 2.9/stable which requires a classic version
-  # of the microk8s snap. This happens to be the default snap
-  # today.
   test:
     name: Integration
     needs: build
@@ -45,23 +42,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        terraform:
-          - "1.4.*"
-          - "1.5.*"
-          - "1.6.*"
-        include:
-          - cloud: "lxd"
-            cloud-channel: "5.19/stable"
-            juju-channel: "2.9/stable"
-          - cloud: "microk8s"
-            cloud-channel: "1.28/stable"
-            juju-channel: "2.9/stable"
-          - cloud: "lxd"
-            cloud-channel: "5.19/stable"
-            juju-channel: "3.1/stable"
-          - cloud: "microk8s"
-            cloud-channel: "1.28-strict/stable"
-            juju-channel: "3.1/stable"
+        terraform: ["1.4.*", "1.5.*", "1.6.*"]
+        action-operator:
+          - { cloud: "lxd", cloud-channel: "5.19", juju: "2.9" }
+          - { cloud: "lxd", cloud-channel: "5.19", juju: "3.1" }
+          - { cloud: "microk8s", cloud-channel: "1.28", juju: "2.9" }
+          - { cloud: "microk8s", cloud-channel: "1.28-strict", juju: "3.1" }
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
@@ -76,9 +62,9 @@ jobs:
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:
-          provider: ${{ matrix.cloud }}
-          channel: ${{ matrix.cloud-channel }}
-          juju-channel: ${{ matrix.juju-channel }}
+          provider: ${{ matrix.action-operator.cloud }}
+          channel: ${{ matrix.action-operator.cloud-channel }}
+          juju-channel: ${{ matrix.action-operator.juju }}
       - name: "Set environment to configure provider"
         # language=bash
         run: |
@@ -93,6 +79,6 @@ jobs:
       - run: go mod download
       - env:
           TF_ACC: "1"
-          TEST_CLOUD: ${{ matrix.cloud }}
+          TEST_CLOUD: ${{ matrix.action-operator.cloud }}
         run: go test -timeout 40m -v -cover ./internal/provider/
         timeout-minutes: 40


### PR DESCRIPTION
strategy.matrix.include has non intuitive use. See the docs for more info. 

To test what we want, define sets of values to be used together. 

For each terraform 1.4, 1.5 and 1.6 test with each:
- juju 2.9, lxd
- juju 3.1, lxd
- juju 2.9, microk8s
- juju 3.1, microk8s (requires strictly confined snap)

There should be 12 test runs with the above combination.

