### PR TITLE
Handle resolved charm origins without base.

### DIFF
--- a/internal/juju/applications.go
+++ b/internal/juju/applications.go
@@ -269,9 +269,11 @@ func (c applicationsClient) CreateApplication(ctx context.Context, input *Create
 
 	// Of the resolvedURL.Series, resolvedOrigin.Series and resolvedOrigin.Base,
 	// the latter is the only trustworthy across all juju controllers supported.
+	// If we resolve a charm with a revision and no user specified operating
+	// system, none of the above will have values.
 	suggestedSeries, err := series.GetSeriesFromBase(resolvedOrigin.Base)
 	if err != nil {
-		return nil, err
+		c.Warnf("failed to get a suggested operating system from resolved charm response", map[string]interface{}{"err": err})
 	}
 
 	seriesToUse, err := c.seriesToUse(modelconfigAPIClient, userSuppliedSeries, suggestedSeries, set.NewStrings(supportedSeries...))


### PR DESCRIPTION
## Description

In the case of resolving a charm with a revision, unless the user supplies a base to use, ResolveCharm will not return a suggested base. However there will be a suggested list of series or bases which can be used with that charm revision. Log any errors from GetSeriesFromBase for using an empty base and continue rather than failing. seriesToUse will handle picking a base.

When juju queries charmhub about a charm by default or with a specific channel, the base negotiated starting with the architecture. If you specify a revision, charmhub assumes you know the base or at least the architecture and it's not part of the request.

Fixes: bug found with #369 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Environment

- Juju controller version: 2.9.47 or 3.1.7

- Terraform version: 1.6

## QA steps

Run the tests that failed;
$ (cd internal/provider/ ; TEST_CLOUD=lxd TF_ACC=1 go test -v -run TestAcc_ResourceApplication)

And a plan which reproduces the problem without the tests.

```tf
terraform { 
  required_providers {
    juju = {
      source  = "juju/juju"
      version = ">0.10.0"
    }
  }
}

provider "juju" {
}

resource "juju_model" "tf_test" {
    name       = "tf-test"
}

resource "juju_application" "ubuntu" {
  name  = "ubuntu"
  model = juju_model.tf_test.name

  charm {
    name = "jameinel-ubuntu-lite"
    revision = 10
  }
}
```

## Additional notes

JUJU-5261
