### PR TITLE
WIP -  Add placement while creating machines

### DIFF
--- a/internal/provider/resource_machine.go
+++ b/internal/provider/resource_machine.go
@@ -46,11 +46,11 @@ func resourceMachine() *schema.Resource {
 				ConflictsWith: []string{"ssh_address"},
 			},
 			"disks": {
-				Description: "Storage constraints for disks to attach to the machine(s).",
-				Type:        schema.TypeString,
-				Optional:    true,
-				Default:     "",
-				ForceNew:    true,
+				Description:   "Storage constraints for disks to attach to the machine(s).",
+				Type:          schema.TypeString,
+				Optional:      true,
+				Default:       "",
+				ForceNew:      true,
 				ConflictsWith: []string{"ssh_address"},
 			},
 			"series": {
@@ -106,6 +106,7 @@ func resourceMachineCreate(ctx context.Context, d *schema.ResourceData, meta int
 	name := d.Get("name").(string)
 	constraints := d.Get("constraints").(string)
 	disks := d.Get("disks").(string)
+	placement := d.Get("placement").(string)
 	series := d.Get("series").(string)
 	sshAddress := d.Get("ssh_address").(string)
 	publicKeyFile := d.Get("public_key_file").(string)
@@ -128,6 +129,7 @@ func resourceMachineCreate(ctx context.Context, d *schema.ResourceData, meta int
 		Constraints:    constraints,
 		ModelUUID:      modelUUID,
 		Disks:          disks,
+		Placement:      placement,
 		Series:         series,
 		SSHAddress:     sshAddress,
 		PublicKeyFile:  publicKeyFile,


### PR DESCRIPTION

WIP - DO NOT MERGE

## Description

The machine resource does not support creating machines in LXD/KVM like the following command does:
```
juju add-machine kvm:3
```
This PR adds a placement parameter to provide this option.

Fixes: #347 

## Type of change

- Change existing resource
- Change in tests (one or several tests have been changed)
- Requires a documentation update

## Environment

- Juju controller version: 

- Terraform version: 

## QA steps

Manual QA steps should be done to test this PR.

```tf
provider juju {}
...
```

## Additional notes

N/A
