### PR TITLE
Add Placement parameter

### DIFF
--- a/docs/resources/machine.md
+++ b/docs/resources/machine.md
@@ -34,6 +34,7 @@ resource "juju_machine" "this_machine" {
 - `constraints` (String) Machine constraints that overwrite those available from 'juju get-model-constraints' and provider's defaults.
 - `disks` (String) Storage constraints for disks to attach to the machine(s).
 - `name` (String) A name for the machine resource in Terraform.
+- `placement` (String) Additional information about how to allocate the machine in the cloud.
 - `private_key_file` (String) The file path to read the private key from.
 - `public_key_file` (String) The file path to read the public key from.
 - `series` (String, Deprecated) The operating system series to install on the new machine(s).

--- a/internal/provider/resource_machine.go
+++ b/internal/provider/resource_machine.go
@@ -46,6 +46,7 @@ type machineResourceModel struct {
 	Disks          types.String `tfsdk:"disks"`
 	Base           types.String `tfsdk:"base"`
 	Series         types.String `tfsdk:"series"`
+	Placement      types.String `tfsdk:"placement"`
 	MachineID      types.String `tfsdk:"machine_id"`
 	SSHAddress     types.String `tfsdk:"ssh_address"`
 	PublicKeyFile  types.String `tfsdk:"public_key_file"`
@@ -87,6 +88,7 @@ const (
 	ConstraintsKey    = "constraints"
 	DisksKey          = "disks"
 	SeriesKey         = "series"
+	PlacementKey      = "placement"
 	BaseKey           = "base"
 	MachineIDKey      = "machine_id"
 	SSHAddressKey     = "ssh_address"
@@ -168,6 +170,20 @@ func (r *machineResource) Schema(_ context.Context, req resource.SchemaRequest, 
 					}...),
 				},
 				DeprecationMessage: "Configure base instead. This attribute will be removed in the next major version of the provider.",
+			},
+			PlacementKey: schema.StringAttribute{
+				Description: "Additional information about how to allocate the machine in the cloud.",
+				Optional:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplaceIfConfigured(),
+					stringplanmodifier.UseStateForUnknown(),
+				},
+				Validators: []validator.String{
+					stringvalidator.ConflictsWith(path.Expressions{
+						path.MatchRoot(SSHAddressKey),
+						path.MatchRoot(ConstraintsKey),
+					}...),
+				},
 			},
 			MachineIDKey: schema.StringAttribute{
 				Description: "The id of the machine Juju creates.",
@@ -257,6 +273,7 @@ func (r *machineResource) Create(ctx context.Context, req resource.CreateRequest
 		Base:           data.Base.ValueString(),
 		Series:         data.Series.ValueString(),
 		SSHAddress:     data.SSHAddress.ValueString(),
+		Placement:      data.Placement.ValueString(),
 		PublicKeyFile:  data.PublicKeyFile.ValueString(),
 		PrivateKeyFile: data.PrivateKeyFile.ValueString(),
 	})


### PR DESCRIPTION
## Description

The machine resource does not support creating machines in LXD/KVM like the following command does:
```
juju add-machine kvm:3
```
This PR adds a placement parameter to provide this option.

Fixes: #347 

## Type of change

- Change existing resource
- Change in tests (one or several tests have been changed)
- Requires a documentation update

## Environment

- Juju controller version: 

- Terraform version: 

## QA steps

Manual QA steps should be done to test this PR.

```tf
terraform {
  required_providers {
    juju = {
      version = "~> 0.7.0"
      source  = "registry.terraform.io/juju/juju"
    }
  }
}

provider "juju" {}

resource "juju_model" "development" {
  name = "development"
}

resource "juju_machine" "this_machine" {
  model     = juju_model.development.name
  name      = "this_machine"
  placement = "lxd"
}

resource "juju_machine" "this_machine_1" {
  model     = juju_model.development.name
  name      = "this_machine_1"
  placement = "lxd:0"
}
```

Expected
```
$ juju status
Model        Controller  Cloud/Region         Version  SLA          Timestamp
development  lxd-local   localhost/localhost  2.9.45   unsupported  18:27:04-03:00

Machine  State    Address       Inst id              Series  AZ  Message
0        started  10.42.91.156  juju-317769-4        focal       Running
0/lxd/0  started                juju-317769-4-lxd-0  focal       Container started
0/lxd/1  started                juju-317769-4-lxd-1  focal       Container started
```

## Additional notes

Approved schema in:
https://github.com/juju/terraform-provider-juju/issues/381
