### PR TITLE
Test with juju 3.4.

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -45,10 +45,10 @@ jobs:
             juju-channel: "2.9/stable"
           - cloud: "lxd"
             cloud-channel: "5.19/stable"
-            juju-channel: "3.2/stable"
+            juju-channel: "3/stable"
           - cloud: "microk8s"
             cloud-channel: "1.28-strict/stable"
-            juju-channel: "3.2/stable"
+            juju-channel: "3/stable"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5

--- a/.github/workflows/test_add_machine.yml
+++ b/.github/workflows/test_add_machine.yml
@@ -52,7 +52,7 @@ jobs:
           - "1.6.*"
         juju:
           - "2.9/stable"
-          - "3.2/stable"
+          - "3/stable"
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test_integration.yml
+++ b/.github/workflows/test_integration.yml
@@ -48,9 +48,9 @@ jobs:
         terraform: ["1.4.*", "1.5.*", "1.6.*"]
         action-operator:
           - { cloud: "lxd", cloud-channel: "5.19", juju: "2.9" }
-          - { cloud: "lxd", cloud-channel: "5.19", juju: "3.2" }
+          - { cloud: "lxd", cloud-channel: "5.19", juju: "3" }
           - { cloud: "microk8s", cloud-channel: "1.28", juju: "2.9" }
-          - { cloud: "microk8s", cloud-channel: "1.28-strict", juju: "3.2" }
+          - { cloud: "microk8s", cloud-channel: "1.28-strict", juju: "3" }
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Description

TODO from #402 related to which version of juju to test with.

Juju 3.4.0 will be released before 3.3.2. Either will have the fix we need to fix the panic for not verifying a map entry before using.

The juju 2.9 tests will continue to fail with:
```
        Unable to create user resource, got error: juju client with version 3.3 used
        with a controller having major version 2 not supported
```
until juju 2.9.47 is released. Any other failure with 2.9 is a problem.
## Type of change

- Maintenance work (repository related, like Github actions, or revving the Go version, etc.)

