### PR TITLE
Fixes Config/Revision update ordering.

### DIFF
--- a/docs/resources/application.md
+++ b/docs/resources/application.md
@@ -85,7 +85,7 @@ Optional:
 
 - `base` (String) The operating system on which to deploy. E.g. ubuntu@22.04.
 - `channel` (String) The channel to use when deploying a charm. Specified as \<track>/\<risk>/\<branch>.
-- `revision` (Number) The revision of the charm to deploy.
+- `revision` (Number) The revision of the charm to deploy. During the update phase, the charm revision should be update before config update, to avoid issues with config parameters parsing.
 - `series` (String, Deprecated) The series on which to deploy.
 
 

--- a/internal/provider/resource_application.go
+++ b/internal/provider/resource_application.go
@@ -196,7 +196,7 @@ func (r *applicationResource) Schema(_ context.Context, _ resource.SchemaRequest
 							},
 						},
 						"revision": schema.Int64Attribute{
-							Description: "The revision of the charm to deploy.",
+							Description: "The revision of the charm to deploy. During the update phase, the charm revision should be update before config update, to avoid issues with config parameters parsing.",
 							Optional:    true,
 							Computed:    true,
 							PlanModifiers: []planmodifier.Int64{

--- a/internal/provider/resource_application_test.go
+++ b/internal/provider/resource_application_test.go
@@ -147,6 +147,7 @@ func TestAcc_ResourceApplication_UpdatesRevisionConfig(t *testing.T) {
 	}
 	modelName := acctest.RandomWithPrefix("tf-test-application")
 	appName := "github-runner"
+	configParamName := "runner-storage"
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: frameworkProviderFactories,
@@ -161,9 +162,10 @@ func TestAcc_ResourceApplication_UpdatesRevisionConfig(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccResourceApplicationWithRevisionAndConfig(modelName, appName, 95, ""),
+				Config: testAccResourceApplicationWithRevisionAndConfig(modelName, appName, 96, configParamName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("juju_application."+appName, "charm.0.revision", "95"),
+					resource.TestCheckResourceAttr("juju_application."+appName, "charm.0.revision", "96"),
+					resource.TestCheckResourceAttr("juju_application."+appName, "config."+configParamName, configParamName+"-value"),
 				),
 			},
 		},
@@ -352,7 +354,7 @@ resource "juju_application" "{{.AppName}}" {
 `, internaltesting.TemplateData{
 			"ModelName":       modelName,
 			"AppName":         appName,
-			"Revision":        fmt.Sprintf("%d", revision),
+			"Revision":        revision,
 			"ConfigParamName": configParamName,
 		})
 }

--- a/internal/testing/plangenerator.go
+++ b/internal/testing/plangenerator.go
@@ -8,7 +8,8 @@ import (
 	"text/template"
 )
 
-type TemplateData map[string]string
+// TemplateData is a map of string to any that is used to pass data to a template.
+type TemplateData map[string]any
 
 // GetStringFromTemplateWithData returns a string from a template with data.
 //


### PR DESCRIPTION
## Description

This PR puts a Revision update before a Config update in the update plan function of the plugin. This will help to avoid issues that prevent working with new config parameters, which are added in new charm revisions.

Fixes: 

https://github.com/juju/terraform-provider-juju/issues/389

## Type of change

- Logic changes in resources (the API interaction with Juju has been changed)
- (WIP) Change in tests (one or several tests have been changed)

## Environment

- Juju controller version: 
3.3.1

- Terraform version:
1.7.3

## QA steps

Manual QA steps should be done to test this PR.

```
juju boostrap microk8s k8s
juju add-model test
```

Apply plan:

```tf
terraform {
  required_providers {
    juju = {
      source  = "juju/juju"
      version = "0.11.1"
    }
  }
}
provider "juju" {}

resource "juju_application" "githubrunner" {
  name  = "github-runner"
  model = "test"


  charm {
    name     = "github-runner"
    revision = 8
    channel  = "latest/edge"
  }

  units = 1
}
```
Then update plan to
```tf
terraform {
  required_providers {
    juju = {
      source  = "juju/juju"
      version = "0.11.1"
    }
  }
}
provider "juju" {}

resource "juju_application" "githubrunner" {
  name  = "github-runner"
  model = "test"


  charm {
    name     = "github-runner"
    revision = 10
    channel  = "latest/edge"
  }

  config = {
    group = "mygroup"
   }

  units = 1
}
```


