### PR TITLE
Use DeployFromRepository when possible.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/juju/version/v2 v2.0.1
 	github.com/rs/zerolog v1.32.0
 	github.com/stretchr/testify v1.8.4
+	gopkg.in/yaml.v2 v2.4.0
 )
 
 require (
@@ -213,7 +214,6 @@ require (
 	gopkg.in/retry.v1 v1.0.3 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/api v0.23.4 // indirect
 	k8s.io/apiextensions-apiserver v0.21.10 // indirect

--- a/internal/juju/applications.go
+++ b/internal/juju/applications.go
@@ -310,6 +310,10 @@ func (c applicationsClient) deployFromRepository(applicationAPIClient *apiapplic
 	return errors.Join(errs...)
 }
 
+// TODO (hml) 23-Feb-2024
+// Remove the funcationality associated with legacyDeploy
+// once the provider no longer supports a version of juju
+// before 3.3.
 func (c applicationsClient) legacyDeploy(ctx context.Context, conn api.Connection, applicationAPIClient *apiapplication.Client, transformedInput transformedCreateApplicationInput) error {
 	// Version needed for operating system selection.
 	c.controllerVersion, _ = conn.ServerVersion()


### PR DESCRIPTION
## Description

If the controller has implemented the Application facade of version 19 or higher, use DeployFromRepository method to deploy a charm. This method shortcuts most of the deploy business logic in the client and allows the controller to handle it all. 

To handle shared input manipulation between the 2 methods, created a new input struct with a parse() method.


## Type of change

- Logic changes in resources (the API interaction with Juju has been changed)

## Environment

- Juju controller version: 2.9.47, 3.3.1

- Terraform version: any

## QA steps

Run the following plan against a 2.9.47 controller and against a 3.3.1 controller with debug enabled, ` export TF_LOG_PROVIDER=TRACE ; export TF_LOG_PATH=./terraform.log`.

Against 2.9.47, you should find the debug line "Calling Deploy". Against 3.3.1, you should find the debug line "Calling DeployFromRepository".

```tf
terraform {
  required_providers {
    juju = {
      version = ">= 0.11.0"
      source  = "juju/juju"
    }
  }
}

provider "juju" {
}

resource "juju_model" "one" {
  name = "unit-test"
}

resource "juju_application" "app-a" {
  model = juju_model.one.name
  charm {
    name = "juju-qa-test"
  }
}

resource "juju_application" "app-b" {
  model = juju_model.one.name
  charm {
    name = "jameinel-ubuntu-lite"
  }
}
```

Also run


## Additional notes

JUJU-5429
