### PR TITLE
Fix upgrade charm revision for application resources

### DIFF
--- a/internal/provider/resource_application.go
+++ b/internal/provider/resource_application.go
@@ -629,9 +629,14 @@ func (r *applicationResource) Update(ctx context.Context, req resource.UpdateReq
 		}
 		planCharm := planCharms[0]
 		stateCharm := stateCharms[0]
-		if !planCharm.Channel.Equal(stateCharm.Channel) {
+		if !planCharm.Channel.Equal(stateCharm.Channel) && !planCharm.Revision.Equal(stateCharm.Revision) {
+			resp.Diagnostics.AddWarning("Not Supported", "Changing an application's revision and channel at the same time.")
+		} else if !planCharm.Channel.Equal(stateCharm.Channel) {
 			updateApplicationInput.Channel = planCharm.Channel.ValueString()
+		} else if !planCharm.Revision.Equal(stateCharm.Revision) {
+			updateApplicationInput.Revision = intPtr(planCharm.Revision)
 		}
+
 		if !planCharm.Series.Equal(stateCharm.Series) || !planCharm.Base.Equal(stateCharm.Base) {
 			// This violates terraform's declarative model. We could implement
 			// `juju set-application-base`, usually used after `upgrade-machine`,
@@ -641,9 +646,6 @@ func (r *applicationResource) Update(ctx context.Context, req resource.UpdateReq
 			// `upgrade-machine`. There is also a question of how to handle a
 			// change to series, revision and channel at the same time.
 			resp.Diagnostics.AddWarning("Not Supported", "Changing an application's operating system after deploy.")
-		}
-		if !planCharm.Revision.Equal(stateCharm.Revision) {
-			updateApplicationInput.Revision = intPtr(planCharm.Revision)
 		}
 	}
 

--- a/internal/testing/plangenerator.go
+++ b/internal/testing/plangenerator.go
@@ -1,0 +1,84 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the Apache License, Version 2.0, see LICENCE file for details.
+
+package testsing
+
+import (
+	"bytes"
+	"text/template"
+)
+
+type TemplateData map[string]string
+
+// GetStringFromTemplateWithData returns a string from a template with data.
+//
+// Here is the example usage:
+// templateStr := GetStringFromTemplateWithData(
+//
+//	"testAccResourceApplicationWithRevisionAndConfig",
+//	`
+//
+//	resource "juju_model" "this" {
+//	 name = "{{.ModelName}}"
+//	}
+//
+//	resource "juju_application" "{{.AppName}}" {
+//	 name  = "{{.AppName}}"
+//	 model = juju_model.this.name
+//
+//	 charm {
+//	   name     = "{{.AppName}}"
+//	   revision = {{.Revision}}
+//	   channel  = "latest/edge"
+//	 }
+//
+//	 {{ if ne .ConfigParamName "" }}
+//	 config = {
+//	   {{.ConfigParamName}} = "{{.ConfigParamName}}-value"
+//	 }
+//	 {{ end }}
+//
+//	 units = 1
+//	}
+//
+//	`, utils.TemplateData{
+//					"ModelName":       "test-model",
+//					"AppName":         "test-app"
+//					"Revision":        fmt.Sprintf("%d", 7),
+//					"ConfigParamName": "test-config-param-name",
+//				})
+//
+// The templateStr will be:
+//
+//	resource "juju_model" "this" {
+//	  name = "test-model"
+//	}
+//
+//	resource "juju_application" "test-app" {
+//	  name  = "test-app"
+//	  model = juju_model.this.name
+//
+//	  charm {
+//	    name     = "test-app"
+//	    revision = 7
+//	    channel  = "latest/edge"
+//	  }
+//
+//	  config = {
+//	    test-config-param-name = "test-config-param-name-value"
+//	  }
+//
+//	  units = 1
+//	}
+func GetStringFromTemplateWithData(templateName string, templateStr string, templateData TemplateData) string {
+	tmpl, err := template.New(templateName).Parse(templateStr)
+	if err != nil {
+		panic(err)
+	}
+	var tpl bytes.Buffer
+	err = tmpl.Execute(&tpl, templateData)
+	if err != nil {
+		panic(err)
+	}
+	return tpl.String()
+}


### PR DESCRIPTION

## Description

Fix update charm revision for an application resource as done in the juju client. Resolve the charm as if it's being created instead so that revision and channel do not conflict. There are potential issues written out in the code. However it's a better solution that the current breakage. Juju changes are needed to fix correctly.

Additional validation added for updating a charm such as ensuring the you cannot update the revision and channel are both updated and that the new charm revision supports the architecture and operating system of the current charm revision. 

Included new acceptance test writing method introduce by @anvial in a PR which hasn't landed yet. This cherry picked commit also has the test needed to verify this change.

Fixes: #413 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## QA steps

As documented in bug and in new acceptance test.

```
TF_ACC=1 TEST_CLOUD=lxd go test -v ./internal/provider/ -parallel=1 -run TestAcc_ResourceApplication
```

## Additional notes

JUJU-5543
