### PR TITLE
Adds error check to ReadModel function

### DIFF
--- a/internal/juju/models.go
+++ b/internal/juju/models.go
@@ -232,6 +232,10 @@ func (c *modelsClient) ReadModel(name string) (*ReadModelResponse, error) {
 		return nil, &modelNotFoundError{uuid: modelUUIDTag.Id()}
 	}
 
+	// Check if the model has an error first
+	if models[0].Error != nil {
+		return nil, models[0].Error
+	}
 	modelInfo := *models[0].Result
 
 	modelConfig, err := modelconfigClient.ModelGet()


### PR DESCRIPTION

## Description

This PR adds a missed error check after we get the models. This fix will help to avoid stack traces.

Fixes: 
https://github.com/juju/terraform-provider-juju/issues/399

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Environment

- Juju controller version: 
3.3.1

- Terraform version: 
1.7.2

## QA steps

```tf
N\A
```
