### PR TITLE
Add ClientStore connector support

### DIFF
--- a/internal/juju/client.go
+++ b/internal/juju/client.go
@@ -29,6 +29,7 @@ const (
 )
 
 type ControllerConfiguration struct {
+	Name                string
 	ControllerAddresses []string
 	Username            string
 	Password            string
@@ -124,12 +125,11 @@ func (sc *sharedClient) GetConnection(modelName *string) (api.Connection, error)
 		do.RetryDelay = 1 * time.Second
 	}
 
-	connr, err := connector.NewSimple(connector.SimpleConfig{
-		ControllerAddresses: sc.controllerConfig.ControllerAddresses,
-		Username:            sc.controllerConfig.Username,
-		Password:            sc.controllerConfig.Password,
-		CACert:              sc.controllerConfig.CACert,
-		ModelUUID:           modelUUID,
+	connr, err := connector.NewClientStore(connector.ClientStoreConfig{
+		ControllerName: sc.controllerConfig.Name,
+		ModelUUID:      modelUUID,
+		ClientStore:    nil,
+		AccountDetails: nil,
 	}, dialOptions)
 	if err != nil {
 		return nil, err

--- a/internal/juju/utils.go
+++ b/internal/juju/utils.go
@@ -89,9 +89,11 @@ func populateControllerConfig() {
 		return
 	}
 
+	controllerName := ""
 	// convert to the map and extract the only entry
 	controllerConfig := controllerConfig{}
-	for _, v := range cliOutput.(map[string]interface{}) {
+	for name, v := range cliOutput.(map[string]interface{}) {
+		controllerName = name
 		// now v is a map[string]interface{} type
 		marshalled, err := json.Marshal(v)
 		if err != nil {
@@ -108,6 +110,7 @@ func populateControllerConfig() {
 	}
 
 	localProviderConfig = map[string]string{}
+	localProviderConfig["JUJU_CONTROLLER_NAME"] = controllerName
 	localProviderConfig["JUJU_CONTROLLER_ADDRESSES"] = strings.Join(controllerConfig.ProviderDetails.ApiEndpoints, ",")
 	localProviderConfig["JUJU_CA_CERT"] = controllerConfig.ProviderDetails.CACert
 	localProviderConfig["JUJU_USERNAME"] = controllerConfig.Account.User


### PR DESCRIPTION
## Description

This PR moves away from `SimpleConnector` to `ClientStore`, in sync with remaining juju `modelcmd` commands.

It also adds support for the user to specify the controller name, which changes the schema.

Fixes:  #421 

## Type of change

- Change existing resource
- Bug fix (non-breaking change which fixes an issue)

## Environment

- Juju controller version: v3.4

- Terraform version: v1.7.4

## QA steps

Manual QA steps should be done to test this PR.

```tf
provider juju {}
...
```
