### PR TITLE
Remove run limitations for build and unit test workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,18 +6,12 @@ name: Build
 # This GitHub action runs your tests for each pull request.
 on:
   pull_request:
-    paths-ignore:
-      - "README.md"
-      - "Makefile"
-      - "project-docs/**"
+    types: [opened, synchronize, reopened, ready_for_review]
+#    paths-ignore:
+#     DON'T SET - these are "required" so they need to run on every PR
   push:
     branches:
       - "main"
-    paths-ignore:
-      - "README.md"
-      - "Makefile"
-      - "project-docs/**"
-
 
 # Testing only needs permissions to read the repository contents.
 permissions:

--- a/.github/workflows/unit_test.yaml
+++ b/.github/workflows/unit_test.yaml
@@ -5,19 +5,12 @@ name: Unit Tests
 # This GitHub action runs your tests for each pull request.
 on:
   pull_request:
-    paths-ignore:
-      - "README.md"
-      - "project-docs/**"
-      - ".github/ISSUE_TEMPLATE/**"
-      - ".github/PULL_REQUEST_TEMPLATE.md"
+    types: [opened, synchronize, reopened, ready_for_review]
+  #    paths-ignore:
+  #     DON'T SET - these are "required" so they need to run on every PR
   push:
     branches:
       - "main"
-    paths-ignore:
-      - "README.md"
-      - "project-docs/**"
-      - ".github/ISSUE_TEMPLATE/**"
-      - ".github/PULL_REQUEST_TEMPLATE.md"
 
 # Testing only needs permissions to read the repository contents.
 permissions:


### PR DESCRIPTION
## Description

These actions must run on all pull requests as they will be made required for merges.

## Type of change
- Maintenance work (repository related, like Github actions, or revving the Go version, etc.)
