### PR TITLE
Handle race where offer is already destroyed

### DIFF
--- a/internal/juju/offers.go
+++ b/internal/juju/offers.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	jujuerrors "github.com/juju/errors"
 	"github.com/juju/juju/api/client/application"
 	apiapplication "github.com/juju/juju/api/client/application"
 	"github.com/juju/juju/api/client/applicationoffers"
@@ -192,6 +193,10 @@ func (c offersClient) DestroyOffer(input *DestroyOfferInput) error {
 
 	client := applicationoffers.NewClient(conn)
 	offer, err := client.ApplicationOffer(input.OfferURL)
+	if jujuerrors.Is(err, jujuerrors.NotFound) {
+		// Offer is already destroyed
+		return nil
+	}
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description

If an offer has already been destroyed, 'DestroyOffer' will fail with a 'not found' error. In this case, there is no offer to destroy, so we should just return successfully.

This race is rare, but has been seen here:
https://github.com/juju/juju/actions/runs/7745564317/job/21121856659?pr=16883

Fixes: https://github.com/juju/terraform-provider-juju/issues/395

## Type of change

- Change existing resource
- Logic changes in resources (the API interaction with Juju has been changed)
- Bug fix (non-breaking change which fixes an issue)
- Maintenance work (repository related, like Github actions, or revving the Go version, etc.)

## Environment

- Juju controller version: I'm using 3.4, since the bug this addresses was seen in 3.4

- Terraform version: 1.7.5

## QA steps

```
TF_ACC="1" TEST_CLOUD="lxd" go test -count=10 -timeout 60m ./internal/provider/ -run TestAcc_ResourceIntegrationWithMultipleConsumers
```