### PR TITLE
update workflows

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -35,20 +35,24 @@ jobs:
       fail-fast: false
       matrix:
         terraform:
-          - "1.7.*"
+          - "1.8.*"
         include:
           - cloud: "lxd"
             cloud-channel: "5.19/stable"
-            juju-channel: "2.9/edge"
+            juju-channel: "2.9/stable"
+            lxd-channel: "5.19/stable"
           - cloud: "microk8s"
             cloud-channel: "1.28/stable"
             juju-channel: "2.9/stable"
+            lxd-channel: "5.19/stable"
           - cloud: "lxd"
             cloud-channel: "5.19/stable"
             juju-channel: "3/stable"
+            lxd-channel: "5.19/stable"
           - cloud: "microk8s"
             cloud-channel: "1.28-strict/stable"
             juju-channel: "3/stable"
+            lxd-channel: "5.19/stable"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -65,6 +69,7 @@ jobs:
           provider: ${{ matrix.cloud }}
           channel: ${{ matrix.cloud-channel }}
           juju-channel: ${{ matrix.juju-channel }}
+          lxd-channel: ${{ matrix.lxd-channel }}
       - name: "Set environment to configure provider"
         # language=bash
         run: |

--- a/.github/workflows/k8s_tunnel.yml
+++ b/.github/workflows/k8s_tunnel.yml
@@ -44,7 +44,7 @@ jobs:
         cloud:
           - "microk8s"
         terraform:
-          - "1.7.*"
+          - "1.8.*"
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test_add_machine.yml
+++ b/.github/workflows/test_add_machine.yml
@@ -49,9 +49,9 @@ jobs:
         cloud:
           - "lxd"
         terraform:
-          - "1.7.*"
+          - "1.8.*"
         juju:
-          - "2.9/edge"
+          - "2.9/stable"
           - "3/stable"
     timeout-minutes: 60
     steps:

--- a/.github/workflows/test_integration.yml
+++ b/.github/workflows/test_integration.yml
@@ -45,12 +45,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        terraform: ["1.5.*", "1.6.*", "1.7.*"]
+        terraform: ["1.6.*", "1.7.*", "1.8.*"]
         action-operator:
-          - { cloud: "lxd", cloud-channel: "5.19", juju: "2.9/edge" }
-          - { cloud: "lxd", cloud-channel: "5.19", juju: "3" }
-          - { cloud: "microk8s", cloud-channel: "1.28", juju: "2.9" }
-          - { cloud: "microk8s", cloud-channel: "1.28-strict", juju: "3" }
+          - { lxd-channel: "5.19/stable", cloud: "lxd", cloud-channel: "5.19", juju: "2.9" }
+          - { lxd-channel: "5.19/stable", cloud: "lxd", cloud-channel: "5.19", juju: "3" }
+          - { lxd-channel: "5.19/stable", cloud: "microk8s", cloud-channel: "1.28", juju: "2.9" }
+          - { lxd-channel: "5.19/stable", cloud: "microk8s", cloud-channel: "1.28-strict", juju: "3" }
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
@@ -68,6 +68,7 @@ jobs:
           provider: ${{ matrix.action-operator.cloud }}
           channel: ${{ matrix.action-operator.cloud-channel }}
           juju-channel: ${{ matrix.action-operator.juju }}
+          lxd-channel: ${{ matrix.action-operator.lxd-channel }}
       - name: Create additional networks when testing with LXD
         if: ${{ matrix.action-operator.cloud == 'lxd' }}
         run: |


### PR DESCRIPTION
## Description
Update lxd version in github workflows. Issues with the charmed kubernetes

actions operator and downgrading lxd from 5.21 to 5.19.

Also replace 1.5 terraform cli with 1.8.

Fixes our integration tests which started to fail with the release of lxd 5.21 on 9-Apr

## Type of change

- Maintenance work (repository related, like Github actions, or revving the Go version, etc.)
