### PR TITLE
Add grant and remove secret access function to `internal/juju`

### DIFF
--- a/internal/juju/interfaces.go
+++ b/internal/juju/interfaces.go
@@ -73,4 +73,6 @@ type SecretAPIClient interface {
 		newName string, description string, data map[string]string,
 	) error
 	RemoveSecret(uri *secrets.URI, name string, revision *int) error
+	GrantSecret(uri *secrets.URI, name string, apps []string) ([]error, error)
+	RevokeSecret(uri *secrets.URI, name string, apps []string) ([]error, error)
 }

--- a/internal/juju/mock_test.go
+++ b/internal/juju/mock_test.go
@@ -610,6 +610,21 @@ func (mr *MockSecretAPIClientMockRecorder) CreateSecret(arg0, arg1, arg2 any) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSecret", reflect.TypeOf((*MockSecretAPIClient)(nil).CreateSecret), arg0, arg1, arg2)
 }
 
+// GrantSecret mocks base method.
+func (m *MockSecretAPIClient) GrantSecret(arg0 *secrets0.URI, arg1 string, arg2 []string) ([]error, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GrantSecret", arg0, arg1, arg2)
+	ret0, _ := ret[0].([]error)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GrantSecret indicates an expected call of GrantSecret.
+func (mr *MockSecretAPIClientMockRecorder) GrantSecret(arg0, arg1, arg2 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GrantSecret", reflect.TypeOf((*MockSecretAPIClient)(nil).GrantSecret), arg0, arg1, arg2)
+}
+
 // ListSecrets mocks base method.
 func (m *MockSecretAPIClient) ListSecrets(arg0 bool, arg1 secrets0.Filter) ([]secrets.SecretDetails, error) {
 	m.ctrl.T.Helper()
@@ -637,6 +652,21 @@ func (m *MockSecretAPIClient) RemoveSecret(arg0 *secrets0.URI, arg1 string, arg2
 func (mr *MockSecretAPIClientMockRecorder) RemoveSecret(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveSecret", reflect.TypeOf((*MockSecretAPIClient)(nil).RemoveSecret), arg0, arg1, arg2)
+}
+
+// RevokeSecret mocks base method.
+func (m *MockSecretAPIClient) RevokeSecret(arg0 *secrets0.URI, arg1 string, arg2 []string) ([]error, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RevokeSecret", arg0, arg1, arg2)
+	ret0, _ := ret[0].([]error)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RevokeSecret indicates an expected call of RevokeSecret.
+func (mr *MockSecretAPIClientMockRecorder) RevokeSecret(arg0, arg1, arg2 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RevokeSecret", reflect.TypeOf((*MockSecretAPIClient)(nil).RevokeSecret), arg0, arg1, arg2)
 }
 
 // UpdateSecret mocks base method.

--- a/internal/juju/secrets_test.go
+++ b/internal/juju/secrets_test.go
@@ -301,6 +301,35 @@ func (s *SecretSuite) TestDeleteSecret() {
 	s.Assert().NoError(err)
 }
 
+func (s *SecretSuite) TestUpdateSecretAccess() {
+	ctlr := s.setupMocks(s.T())
+	defer ctlr.Finish()
+
+	secretId := "secret:9m4e2mr0ui3e8a215n4g"
+	applications := []string{"app1", "app2"}
+
+	secretURI, err := coresecrets.ParseURI(secretId)
+	s.Require().NoError(err)
+
+	s.mockSecretClient.EXPECT().GrantSecret(secretURI, "", applications).Return([]error{nil}, nil).AnyTimes()
+	s.mockSecretClient.EXPECT().RevokeSecret(secretURI, "", applications).Return([]error{nil}, nil).AnyTimes()
+
+	client := s.getSecretsClient()
+	err = client.UpdateSecretAccess(&GrantRevokeSecretAccessInput{
+		SecretId:     secretId,
+		ModelName:    s.testModelName,
+		Applications: applications,
+	}, GrantAccess)
+	s.Require().NoError(err)
+
+	err = client.UpdateSecretAccess(&GrantRevokeSecretAccessInput{
+		SecretId:     secretId,
+		ModelName:    s.testModelName,
+		Applications: applications,
+	}, RevokeAccess)
+	s.Require().NoError(err)
+}
+
 // In order for 'go test' to run this suite, we need to create
 // a normal test function and pass our suite to suite.Run
 func TestUserSecretSuite(t *testing.T) {

--- a/internal/juju/utils.go
+++ b/internal/juju/utils.go
@@ -156,3 +156,11 @@ func WaitForAppsAvailable(ctx context.Context, client *apiapplication.Client, ap
 		}
 	}
 }
+
+// ProcessErrorResults processes the results of a secret operation.
+func ProcessErrorResults(results []error) error {
+	if results[0] != nil && len(results) > 1 {
+		return &MultiError{Errors: results}
+	}
+	return nil
+}


### PR DESCRIPTION
## Description

This PR introduces the functionality to grant and revoke access to secrets in the internal secrets client. It includes the necessary methods in the secrets client and corresponding tests to ensure the functionality works as expected.

Fixes: 

## Type of change

- Other (please describe)

Extention of `internal/juju` wrapper 

## Environment

- Juju controller version: 

- Terraform version: 

## QA steps

```bash
go test github.com/juju/terraform-provider-juju/internal/juju/... -v
```

## Links

[JUJU-5714](https://warthogs.atlassian.net/browse/JUJU-5714)

[JUJU-5714]: https://warthogs.atlassian.net/browse/JUJU-5714?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ