### PR TITLE
Ensure we have a valid tag'd sha for the juju 3.5 release.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ go 1.21
 require (
 	github.com/bflad/tfproviderlint v0.29.0
 	github.com/hashicorp/terraform-plugin-docs v0.19.0
-	// juju 3.5.0
-	github.com/juju/juju v0.0.0-20240406000153-4582af466744
+	// v3.5-beta1
+	github.com/juju/juju v0.0.0-20240415234708-a7538882134d
 
 )
 

--- a/go.sum
+++ b/go.sum
@@ -356,8 +356,8 @@ github.com/juju/idmclient/v2 v2.0.0 h1:PsGa092JGy6iFNHZCcao+bigVsTyz1C+tHNRdYmKv
 github.com/juju/idmclient/v2 v2.0.0/go.mod h1:EOiFbPmnkqKvCUS/DHpDRWhL7eKF0AJaTvMjIYlIUak=
 github.com/juju/jsonschema v1.0.0 h1:2ScR9hhVdHxft+Te3fnclVx61MmlikHNEOirTGi+hV4=
 github.com/juju/jsonschema v1.0.0/go.mod h1:SlFW+jFtpWX0P4Tb+zTTPR4ufttLrnJIdQPePxVEfkM=
-github.com/juju/juju v0.0.0-20240406000153-4582af466744 h1:IM8Nvz6eJ8vHklgsleP11gUhsPsU0t6ePAPw0NQFtwE=
-github.com/juju/juju v0.0.0-20240406000153-4582af466744/go.mod h1:8W1iXQ/tGftslRzNF/1U8mVZFjtqc0zZKygwuIcmbPI=
+github.com/juju/juju v0.0.0-20240415234708-a7538882134d h1:yK8L5+7fJvzsNkjUkkEps4dTGPa1RUr5rnumV4rKXIc=
+github.com/juju/juju v0.0.0-20240415234708-a7538882134d/go.mod h1:8W1iXQ/tGftslRzNF/1U8mVZFjtqc0zZKygwuIcmbPI=
 github.com/juju/loggo v1.0.0 h1:Y6ZMQOGR9Aj3BGkiWx7HBbIx6zNwNkxhVNOHU2i1bl0=
 github.com/juju/loggo v1.0.0/go.mod h1:NIXFioti1SmKAlKNuUwbMenNdef59IF52+ZzuOmHYkg=
 github.com/juju/lru v1.0.0 h1:FP8mBNF3jBnKwGO5PtsR+8iIegx8DREfhRhpcGpYcn4=


### PR DESCRIPTION
The 0.12.0 release might be released before juju 3.5.0 is out. 
Reference a tag'd version of juju rather than a random sha. 
The beta1 is feature complete.

