### PR TITLE
Assign non-empty `client_id` to `username`

### DIFF
--- a/internal/juju/client.go
+++ b/internal/juju/client.go
@@ -114,6 +114,10 @@ func (sc *sharedClient) GetConnection(modelName *string) (api.Connection, error)
 		do.RetryDelay = 1 * time.Second
 	}
 
+	if sc.controllerConfig.ClientID != "" {
+		sc.controllerConfig.Username = sc.controllerConfig.ClientID
+	}
+
 	connr, err := connector.NewSimple(connector.SimpleConfig{
 		ControllerAddresses: sc.controllerConfig.ControllerAddresses,
 		Username:            sc.controllerConfig.Username,


### PR DESCRIPTION

## Description

While QA-ing the `rc0.12.0`, we noticed an error complaining about empty `username` field. Actually, when the `client_id` is already assigned, the `username` has to be empty, and there should be no error. In this PR, `username` is assigned to the `client_id` value, whenever the `client_id` is not empty.

Fixes: 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Environment

- Juju controller version: 3.5-rc1

- Terraform version: 1.8.2-dev
