### PR TITLE
feat(storage): extend application schema for storage flag

### DIFF
--- a/docs/resources/application.md
+++ b/docs/resources/application.md
@@ -78,6 +78,7 @@ resource "juju_application" "placement_example" {
 		  latest revision.
 	    * If the charm revision or channel are not updated, then no changes will take 
 		  place (juju does not have an "un-attach" command for resources).
+- `storage` (Attributes Set) Configure storage constraints for the juju application. (see [below for nested schema](#nestedatt--storage))
 - `trust` (Boolean) Set the trust for the application.
 - `units` (Number) The number of application units to deploy for the charm.
 
@@ -121,6 +122,20 @@ Optional:
 - `cidrs` (String) A comma-delimited list of CIDRs that should be able to access the application ports once exposed.
 - `endpoints` (String) Expose only the ports that charms have opened for this comma-delimited list of endpoints
 - `spaces` (String) A comma-delimited list of spaces that should be able to access the application ports once exposed.
+
+
+<a id="nestedatt--storage"></a>
+### Nested Schema for `storage`
+
+Required:
+
+- `label` (String) The specific storage option defined in the charm.
+
+Optional:
+
+- `count` (Number) The number of volumes.
+- `pool` (String) Name of the storage pool to use. E.g. ebs on aws.
+- `size` (String) The size of each volume. E.g. 100G.
 
 ## Import
 

--- a/internal/provider/resource_application.go
+++ b/internal/provider/resource_application.go
@@ -20,13 +20,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/juju/errors"
-
 	"github.com/juju/juju/core/constraints"
 
 	"github.com/juju/terraform-provider-juju/internal/juju"
@@ -162,6 +162,55 @@ func (r *applicationResource) Schema(_ context.Context, _ resource.SchemaRequest
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplaceIfConfigured(),
 					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"storage": schema.SetNestedAttribute{
+				Description: "Configure storage constraints for the juju application.",
+				Optional:    true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"label": schema.StringAttribute{
+							Description: "The specific storage option defined in the charm.",
+							Required:    true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.RequiresReplaceIfConfigured(),
+								stringplanmodifier.UseStateForUnknown(),
+							},
+						},
+						"size": schema.StringAttribute{
+							Description: "The size of each volume. E.g. 100G.",
+							Optional:    true,
+							Computed:    true,
+							Default:     stringdefault.StaticString("1G"),
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.RequiresReplaceIfConfigured(),
+								stringplanmodifier.UseStateForUnknown(),
+							},
+						},
+						"pool": schema.StringAttribute{
+							Description: "Name of the storage pool to use. E.g. ebs on aws.",
+							Optional:    true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.RequiresReplaceIfConfigured(),
+								stringplanmodifier.UseStateForUnknown(),
+							},
+						},
+						"count": schema.Int64Attribute{
+							Description: "The number of volumes.",
+							Optional:    true,
+							Computed:    true,
+							Default:     int64default.StaticInt64(int64(1)),
+							PlanModifiers: []planmodifier.Int64{
+								int64planmodifier.RequiresReplaceIfConfigured(),
+								int64planmodifier.UseStateForUnknown(),
+							},
+						},
+					},
+				},
+				Validators: []validator.Set{
+					setNestedIsAttributeUniqueValidator{
+						PathExpressions: path.MatchRelative().AtAnySetValue().MergeExpressions(path.MatchRelative().AtName("label")),
+					},
 				},
 			},
 			"trust": schema.BoolAttribute{


### PR DESCRIPTION
## Description

This PR introduces significant enhancements to our Terraform provider for Juju. The main changes include extending of the application schema to support the storage flag in the Terraform provider for Juju. 

The schema now includes various attributes for configuring the storage constraints of a Juju application.

Fixes: 

## Type of change

- Change existing resource

## Environment

- Juju controller version: -

- Terraform version: -

## Plan example

```tf
terraform {
  required_providers {
    juju = {
      source  = "juju/juju"
      version = "0.12.0"
    }
  }
}
provider "juju" {}

resource "juju_model" "storage-model" {
  name = "storage-model"
}

resource "juju_application" "postgresql" {
  name  = "postgresql"
  model = juju_model.storage-model.name

  charm {
    name     = "postgresql"
    channel  = "latest/stable"
  }

  storage = [
    {
      pool  = "lxd"
      label = "pgdata"
      size  = "8M"
      count = 1
    }
  ]

  units = 1
}
...
```
