### PR TITLE
fix(application): allow both placement and constraints together.

### DIFF
--- a/internal/provider/resource_machine.go
+++ b/internal/provider/resource_machine.go
@@ -181,7 +181,6 @@ func (r *machineResource) Schema(_ context.Context, req resource.SchemaRequest, 
 				Validators: []validator.String{
 					stringvalidator.ConflictsWith(path.Expressions{
 						path.MatchRoot(SSHAddressKey),
-						path.MatchRoot(ConstraintsKey),
 					}...),
 				},
 			},


### PR DESCRIPTION
## Description

Some constraints and placement details can conflict with each other but not all. Specifying memory size and to use a specific machine doesn't work. Spaces and placement can coexist however.

Let the jujud decide how to resolve conflicts between placement and constraints.

Fixes: #476

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Environment

- Juju controller version: any

- Terraform version: any

## QA steps

Setup your juju environment as follows:
```
$ juju add-model machine-placement-constraints
Added 'machine-placement-constraints' model on localhost/localhost with credential 'localhost' for user 'admin'
$ juju add-machine
created machine 0
```

Run `terraform init  && terraform plan && terraform apply -auto-approve` with the following plan:
```tf
provider juju {}

data "juju_model" "test-model" {
  name = "machine-placement-constraints"
}

resource "juju_machine" "ceph-mon-1" {
  model = data.juju_model.test-model.name
  placement = "lxd:0"
  constraints = "mem=10G"
}
```

## Additional notes

https://warthogs.atlassian.net/browse/JUJU-5985 