### PR TITLE
fix: live discovery of data needed for juju

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -60,6 +60,9 @@ func jujuProviderModelEnvVar() jujuProviderModel {
 func jujuProviderModelLiveDiscovery() (jujuProviderModel, bool) {
 	data := jujuProviderModel{}
 	controllerConfig, cliNotExist := juju.GetLocalControllerConfig()
+	if cliNotExist {
+		return data, false
+	}
 
 	if ctrlAddrs, ok := controllerConfig[JujuControllerEnvKey]; ok && ctrlAddrs != "" {
 		data.ControllerAddrs = types.StringValue(ctrlAddrs)
@@ -73,7 +76,7 @@ func jujuProviderModelLiveDiscovery() (jujuProviderModel, bool) {
 	if password, ok := controllerConfig[JujuPasswordEnvKey]; ok && password != "" {
 		data.Password = types.StringValue(password)
 	}
-	return data, cliNotExist
+	return data, true
 }
 
 func getEnvVar(field string) types.String {

--- a/internal/provider/resource_application.go
+++ b/internal/provider/resource_application.go
@@ -26,7 +26,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/juju/errors"
-
 	"github.com/juju/juju/core/constraints"
 
 	"github.com/juju/terraform-provider-juju/internal/juju"


### PR DESCRIPTION
## Description

#502 introduced a bug being fixed here. Auto discovery of data necessary to connect to the juju controller failed. This was due to bool interpretation error.

If the juju client is not available, jujuProviderModelEnvVar should return false to facilitate authentication error message  where values for juju controller authentication are coming from.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Environment

- Juju controller version: any

- Terraform version:  upstream/main

## QA steps

Without juju controller details provided in the plan nor your environment variables, run a simple plan. 

```tf
provider "juju" {
}

resource "juju_model" "testmodel" {
  name = "duplicate"
}
```

