### PR TITLE
fix: run provider tests in parallel

### DIFF
--- a/internal/provider/data_source_machine_test.go
+++ b/internal/provider/data_source_machine_test.go
@@ -15,6 +15,11 @@ func TestAcc_DataSourceMachine_Edge(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
+
 	modelName := acctest.RandomWithPrefix("tf-datasource-machine-test-model")
 
 	resource.Test(t, resource.TestCase{
@@ -35,6 +40,11 @@ func TestAcc_DataSourceMachine_Stable(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
+
 	modelName := acctest.RandomWithPrefix("tf-datasource-machine-test-model")
 
 	resource.Test(t, resource.TestCase{

--- a/internal/provider/data_source_model_test.go
+++ b/internal/provider/data_source_model_test.go
@@ -12,6 +12,11 @@ import (
 )
 
 func TestAcc_DataSourceModel_Edge(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
+
 	modelName := acctest.RandomWithPrefix("tf-datasource-model-test")
 
 	resource.Test(t, resource.TestCase{
@@ -30,6 +35,11 @@ func TestAcc_DataSourceModel_Edge(t *testing.T) {
 }
 
 func TestAcc_DataSourceModel_Stable(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
+
 	modelName := acctest.RandomWithPrefix("tf-datasource-model-test")
 
 	resource.Test(t, resource.TestCase{

--- a/internal/provider/data_source_offer_test.go
+++ b/internal/provider/data_source_offer_test.go
@@ -12,6 +12,11 @@ import (
 )
 
 func TestAcc_DataSourceOffer(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
+
 	modelName := acctest.RandomWithPrefix("tf-datasource-offer-test-model")
 	// ...-test-[0-9]+ is not a valid offer name, need to remove the dash before numbers
 	offerName := fmt.Sprintf("tf-datasource-offer-test%d", acctest.RandInt())
@@ -32,6 +37,11 @@ func TestAcc_DataSourceOffer(t *testing.T) {
 }
 
 func TestAcc_DataSourceOffer_UpgradeProvider(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
+
 	modelName := acctest.RandomWithPrefix("tf-datasource-offer-test-model")
 	// ...-test-[0-9]+ is not a valid offer name, need to remove the dash before numbers
 	offerName := fmt.Sprintf("tf-datasource-offer-test%d", acctest.RandInt())

--- a/internal/provider/data_source_secrets_test.go
+++ b/internal/provider/data_source_secrets_test.go
@@ -18,6 +18,11 @@ import (
 // blocked on the lack of schema for secret access.
 
 func TestAcc_DataSourceSecret(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
+
 	version := os.Getenv("JUJU_AGENT_VERSION")
 	if version == "" || internaltesting.CompareVersions(version, "3.3.0") < 0 {
 		t.Skip("JUJU_AGENT_VERSION is not set or is below 3.3.0")

--- a/internal/provider/main_test.go
+++ b/internal/provider/main_test.go
@@ -7,7 +7,7 @@ package provider
 // in the testing phase.
 
 import (
-	"errors"
+	"fmt"
 	"net"
 	"os"
 	"strings"
@@ -59,7 +59,7 @@ func TypeTestingCloudFromString(from string) (CloudTesting, error) {
 	case string(MicroK8sTesting):
 		return MicroK8sTesting, nil
 	default:
-		return "", errors.New("unknown cloud type")
+		return "", fmt.Errorf("unknown cloud type %q", from)
 	}
 }
 

--- a/internal/provider/resource_access_model_test.go
+++ b/internal/provider/resource_access_model_test.go
@@ -13,6 +13,11 @@ import (
 )
 
 func TestAcc_ResourceAccessModel(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
+
 	userName := acctest.RandomWithPrefix("tfuser")
 	userPassword := acctest.RandomWithPrefix("tf-test-user")
 	userName2 := acctest.RandomWithPrefix("tfuser")
@@ -70,6 +75,10 @@ func TestAcc_ResourceAccessModel_UpgradeProvider(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
 
 	userName := acctest.RandomWithPrefix("tfuser")
 	userPassword := acctest.RandomWithPrefix("tf-test-user")

--- a/internal/provider/resource_access_secret_test.go
+++ b/internal/provider/resource_access_secret_test.go
@@ -18,6 +18,11 @@ import (
 // the applications used don't actually require a user secret.
 // TODO(anvial): Add a test that uses a secret that is actually required by the application.
 func TestAcc_ResourceAccessSecret_GrantRevoke(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
+
 	agentVersion := os.Getenv(TestJujuAgentVersion)
 	if agentVersion == "" {
 		t.Errorf("%s is not set", TestJujuAgentVersion)
@@ -58,6 +63,11 @@ func TestAcc_ResourceAccessSecret_GrantRevoke(t *testing.T) {
 }
 
 func TestAcc_ResourceAccessSecret_Import(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
+
 	agentVersion := os.Getenv(TestJujuAgentVersion)
 	if agentVersion == "" {
 		t.Errorf("%s is not set", TestJujuAgentVersion)

--- a/internal/provider/resource_application_test.go
+++ b/internal/provider/resource_application_test.go
@@ -25,6 +25,11 @@ import (
 )
 
 func TestAcc_ResourceApplication(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
+
 	modelName := acctest.RandomWithPrefix("tf-test-application")
 	appName := "test-app"
 
@@ -90,6 +95,11 @@ func TestAcc_ResourceApplication(t *testing.T) {
 }
 
 func TestAcc_ResourceApplication_Updates(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
+
 	modelName := acctest.RandomWithPrefix("tf-test-application")
 	appName := "jameinel-ubuntu-lite"
 	if testingCloud != LXDCloudTesting {
@@ -162,6 +172,10 @@ func TestAcc_ResourceApplication_UpdatesRevisionConfig(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
 
 	modelName := acctest.RandomWithPrefix("tf-test-application")
 	appName := "github-runner"
@@ -192,6 +206,11 @@ func TestAcc_ResourceApplication_UpdatesRevisionConfig(t *testing.T) {
 }
 
 func TestAcc_CharmUpdates(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
+
 	modelName := acctest.RandomWithPrefix("tf-test-charmupdates")
 
 	resource.Test(t, resource.TestCase{
@@ -226,6 +245,11 @@ func TestAcc_ResourceRevisionUpdatesLXD(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
+
 	modelName := acctest.RandomWithPrefix("tf-test-resource-revision-updates-lxd")
 
 	resource.Test(t, resource.TestCase{
@@ -260,6 +284,11 @@ func TestAcc_ResourceRevisionAddedToPlanLXD(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
+
 	modelName := acctest.RandomWithPrefix("tf-test-resource-revision-updates-lxd")
 
 	resource.Test(t, resource.TestCase{
@@ -286,6 +315,11 @@ func TestAcc_ResourceRevisionRemovedFromPlanLXD(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
+
 	modelName := acctest.RandomWithPrefix("tf-test-resource-revision-updates-lxd")
 
 	resource.Test(t, resource.TestCase{
@@ -314,6 +348,11 @@ func TestAcc_ResourceRevisionUpdatesMicrok8s(t *testing.T) {
 	if testingCloud != MicroK8sTesting {
 		t.Skip(t.Name() + " only runs with Microk8s")
 	}
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
+
 	modelName := acctest.RandomWithPrefix("tf-test-resource-revision-updates-microk8s")
 
 	resource.Test(t, resource.TestCase{
@@ -345,6 +384,11 @@ func TestAcc_ResourceRevisionUpdatesMicrok8s(t *testing.T) {
 }
 
 func TestAcc_ResourceApplication_Minimal(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
+
 	modelName := acctest.RandomWithPrefix("tf-test-application")
 	var charmName string
 	if testingCloud == LXDCloudTesting {
@@ -382,6 +426,11 @@ func TestAcc_ResourceApplication_Minimal(t *testing.T) {
 }
 
 func TestAcc_ResourceApplication_UpgradeProvider(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
+
 	modelName := acctest.RandomWithPrefix("tf-test-application")
 	appName := "test-app"
 
@@ -419,6 +468,11 @@ func TestAcc_ResourceApplication_EndpointBindings(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
+
 	modelName := acctest.RandomWithPrefix("tf-test-application-bindings")
 	appName := "test-app"
 
@@ -454,6 +508,11 @@ func TestAcc_ResourceApplication_UpdateEndpointBindings(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
+
 	modelName := acctest.RandomWithPrefix("tf-test-application-bindings-update")
 	appName := "test-app-update"
 

--- a/internal/provider/resource_credential_test.go
+++ b/internal/provider/resource_credential_test.go
@@ -15,6 +15,11 @@ func TestAcc_ResourceCredential(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
+
 	credentialName := acctest.RandomWithPrefix("tf-test-credential")
 	authType := "certificate"
 	token := "123abc"
@@ -57,6 +62,11 @@ func TestAcc_ResourceCredential_UpgradeProvider(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
+
 	credentialName := acctest.RandomWithPrefix("tf-test-credential")
 	authType := "certificate"
 

--- a/internal/provider/resource_integration_test.go
+++ b/internal/provider/resource_integration_test.go
@@ -17,6 +17,11 @@ func TestAcc_ResourceIntegration(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
+
 	modelName := acctest.RandomWithPrefix("tf-test-integration")
 
 	resource.Test(t, resource.TestCase{
@@ -54,6 +59,11 @@ func TestAcc_ResourceIntegrationWithViaCIDRs(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
+
 	srcModelName := acctest.RandomWithPrefix("tf-test-integration")
 	dstModelName := acctest.RandomWithPrefix("tf-test-integration-dst")
 	via := "127.0.0.1/32,127.0.0.3/32"
@@ -81,6 +91,11 @@ func TestAcc_ResourceIntegration_UpgradeProvider(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
+
 	modelName := acctest.RandomWithPrefix("tf-test-integration")
 
 	resource.Test(t, resource.TestCase{
@@ -216,6 +231,11 @@ func TestAcc_ResourceIntegrationWithMultipleConsumers(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
+
 	srcModelName := acctest.RandomWithPrefix("tf-test-integration")
 	dstModelName := acctest.RandomWithPrefix("tf-test-integration-dst")
 

--- a/internal/provider/resource_machine_test.go
+++ b/internal/provider/resource_machine_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
 	internaltesting "github.com/juju/terraform-provider-juju/internal/testing"
 )
 
@@ -16,6 +17,11 @@ func TestAcc_ResourceMachine(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
+
 	modelName := acctest.RandomWithPrefix("tf-test-machine")
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -43,6 +49,11 @@ func TestAcc_ResourceMachine_Minimal(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
+
 	modelName := acctest.RandomWithPrefix("tf-test-machine")
 	resourceName := "juju_machine.testmachine"
 	resource.Test(t, resource.TestCase{
@@ -69,6 +80,11 @@ func TestAcc_ResourceMachine_WithPlacement(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
+
 	modelName := acctest.RandomWithPrefix("tf-test-machine")
 	resourceName := "juju_machine.this_machine_1"
 	resource.Test(t, resource.TestCase{
@@ -108,6 +124,11 @@ func TestAcc_ResourceMachine_UpgradeProvider(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
+
 	modelName := acctest.RandomWithPrefix("tf-test-machine")
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() { testAccPreCheck(t) },
@@ -154,6 +175,11 @@ func TestAcc_ResourceMachine_AddMachine_Edge(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
+
 	if testAddMachineIP == "" {
 		t.Skipf("environment variable %v not setup or invalid for running test", TestMachineIPEnvKey)
 	}

--- a/internal/provider/resource_model_test.go
+++ b/internal/provider/resource_model_test.go
@@ -15,6 +15,11 @@ import (
 )
 
 func TestAcc_ResourceModel(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
+
 	modelName := acctest.RandomWithPrefix("tf-test-model")
 	logLevelInfo := "INFO"
 	logLevelDebug := "DEBUG"
@@ -57,6 +62,11 @@ func TestAcc_ResourceModel(t *testing.T) {
 }
 
 func TestAcc_ResourceModel_UnsetConfig(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
+
 	modelName := acctest.RandomWithPrefix("tf-test-model")
 
 	resourceName := "juju_model.this"
@@ -94,6 +104,11 @@ resource "juju_model" "this" {
 }
 
 func TestAcc_ResourceModel_Minimal(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
+
 	modelName := acctest.RandomWithPrefix("tf-test-model")
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -113,6 +128,11 @@ resource "juju_model" "testmodel" {
 }
 
 func TestAcc_ResourceModel_UpgradeProvider(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
+
 	modelName := acctest.RandomWithPrefix("tf-test-model")
 	logLevelDebug := "DEBUG"
 

--- a/internal/provider/resource_offer_test.go
+++ b/internal/provider/resource_offer_test.go
@@ -15,6 +15,11 @@ func TestAcc_ResourceOffer(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
+
 	modelName := acctest.RandomWithPrefix("tf-test-offer")
 	modelName2 := acctest.RandomWithPrefix("tf-test-offer")
 	destModelName := acctest.RandomWithPrefix("tf-test-offer-dest")
@@ -108,6 +113,11 @@ func TestAcc_ResourceOffer_UpgradeProvider(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
+
 	modelName := acctest.RandomWithPrefix("tf-test-offer")
 
 	resource.Test(t, resource.TestCase{

--- a/internal/provider/resource_secret_test.go
+++ b/internal/provider/resource_secret_test.go
@@ -15,6 +15,11 @@ import (
 )
 
 func TestAcc_ResourceSecret_CreateWithoutName(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
+
 	agentVersion := os.Getenv(TestJujuAgentVersion)
 	if agentVersion == "" {
 		t.Errorf("%s is not set", TestJujuAgentVersion)
@@ -47,6 +52,11 @@ func TestAcc_ResourceSecret_CreateWithoutName(t *testing.T) {
 }
 
 func TestAcc_ResourceSecret_CreateWithInfo(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
+
 	agentVersion := os.Getenv(TestJujuAgentVersion)
 	if agentVersion == "" {
 		t.Errorf("%s is not set", TestJujuAgentVersion)
@@ -87,6 +97,11 @@ func TestAcc_ResourceSecret_CreateWithInfo(t *testing.T) {
 }
 
 func TestAcc_ResourceSecret_CreateWithNoInfo(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
+
 	agentVersion := os.Getenv(TestJujuAgentVersion)
 	if agentVersion == "" {
 		t.Errorf("%s is not set", TestJujuAgentVersion)
@@ -119,6 +134,11 @@ func TestAcc_ResourceSecret_CreateWithNoInfo(t *testing.T) {
 }
 
 func TestAcc_ResourceSecret_Update(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
+
 	agentVersion := os.Getenv(TestJujuAgentVersion)
 	if agentVersion == "" {
 		t.Errorf("%s is not set", TestJujuAgentVersion)

--- a/internal/provider/resource_ssh_key_test.go
+++ b/internal/provider/resource_ssh_key_test.go
@@ -15,6 +15,11 @@ func TestAcc_ResourceSSHKey(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
+
 	modelName := acctest.RandomWithPrefix("tf-test-sshkey")
 	sshKey1 := `ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1I8QDP79MaHEIAlfh933zqcE8LyUt9doytF3YySBUDWippk8MAaKAJJtNb+Qsi+Kx/RsSY02VxMy9xRTp9d/Vr+U5BctKqhqf3ZkJdTIcy+z4hYpFS8A4bECJFHOnKIekIHD9glHkqzS5Vm6E4g/KMNkKylHKlDXOafhNZAiJ1ynxaZIuedrceFJNC47HnocQEtusPKpR09HGXXYhKMEubgF5tsTO4ks6pplMPvbdjxYcVOg4Wv0N/LJ4ffAucG9edMcKOTnKqZycqqZPE6KsTpSZMJi2Kl3mBrJE7JbR1YMlNwG6NlUIdIqVoTLZgLsTEkHqWi6OExykbVTqFuoWJJY2BmRAcP9T3FdLYbqcajfWshwvPM2AmYb8V3zBvzEKL1rpvG26fd3kGhk3Vu07qAUhHLMi3P0McEky4cLiEWgI7UyHFLI2yMRZgz23UUtxhRSkvCJagRlVG/s4yoylzBQJir8G3qmb36WjBXxpqAXhfLxw05EQI1JGV3ReYOs= jimmy@somewhere`
 
@@ -45,6 +50,11 @@ func TestAcc_ResourceSSHKey_ED25519(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
+
 	modelName := acctest.RandomWithPrefix("tf-test-sshkey")
 	sshKey1 := `ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAID3gjJTJtYZU55HTUr+hu0JF9p152yiC9czJi9nKojuW jimmy@somewhere`
 
@@ -66,6 +76,11 @@ func TestAcc_ResourceSSHKey_UpgradeProvider(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
+
 	modelName := acctest.RandomWithPrefix("tf-test-sshkey")
 	sshKey1 := `ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1I8QDP79MaHEIAlfh933zqcE8LyUt9doytF3YySBUDWippk8MAaKAJJtNb+Qsi+Kx/RsSY02VxMy9xRTp9d/Vr+U5BctKqhqf3ZkJdTIcy+z4hYpFS8A4bECJFHOnKIekIHD9glHkqzS5Vm6E4g/KMNkKylHKlDXOafhNZAiJ1ynxaZIuedrceFJNC47HnocQEtusPKpR09HGXXYhKMEubgF5tsTO4ks6pplMPvbdjxYcVOg4Wv0N/LJ4ffAucG9edMcKOTnKqZycqqZPE6KsTpSZMJi2Kl3mBrJE7JbR1YMlNwG6NlUIdIqVoTLZgLsTEkHqWi6OExykbVTqFuoWJJY2BmRAcP9T3FdLYbqcajfWshwvPM2AmYb8V3zBvzEKL1rpvG26fd3kGhk3Vu07qAUhHLMi3P0McEky4cLiEWgI7UyHFLI2yMRZgz23UUtxhRSkvCJagRlVG/s4yoylzBQJir8G3qmb36WjBXxpqAXhfLxw05EQI1JGV3ReYOs= jimmy@somewhere`
 

--- a/internal/provider/resource_user_test.go
+++ b/internal/provider/resource_user_test.go
@@ -12,6 +12,11 @@ import (
 )
 
 func TestAcc_ResourceUser(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
+
 	userName := acctest.RandomWithPrefix("tfuser")
 	userPassword := acctest.RandomWithPrefix("tf-test-user")
 
@@ -49,6 +54,11 @@ resource "juju_user" "user" {
 }
 
 func TestAcc_ResourceUser_UpgradeProvider(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
+
 	userName := acctest.RandomWithPrefix("tfuser")
 	userPassword := acctest.RandomWithPrefix("tf-test-user")
 

--- a/internal/provider/validator_channel_test.go
+++ b/internal/provider/validator_channel_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
 	"github.com/juju/terraform-provider-juju/internal/provider"
 )
 


### PR DESCRIPTION
## Description

The provider tests take a while to run. They create different models.
So they can be run in parallel to speed things up.

In the Juju smoke tests, there are 3 main culprits:

```
--- PASS: TestAcc_ResourceOffer (326.92s)
--- PASS: TestAcc_ResourceIntegrationWithMultipleConsumers (326.57s)
--- PASS: TestAcc_ResourceIntegrationWithViaCIDRs (321.36s)
```

Running these in parallel would save 10 minutes.

Also skip provider tests if -short flag is used.

These changes are just to the test files.

## Type of change

- Change in tests (one or several tests have been changed)

## QA steps

go test ./...

## Additional notes

This is an attempt to get the pre merge tests on the juju project running faster.