### PR TITLE
test: parallelize tests

### DIFF
--- a/.github/workflows/test_integration.yml
+++ b/.github/workflows/test_integration.yml
@@ -92,5 +92,5 @@ jobs:
       - env:
           TF_ACC: "1"
           TEST_CLOUD: ${{ matrix.action-operator.cloud }}
-        run: go test -timeout 40m -v -cover ./internal/provider/
+        run: go test -parallel 1 -timeout 40m -v -cover ./internal/provider/
         timeout-minutes: 40

--- a/Makefile
+++ b/Makefile
@@ -74,12 +74,12 @@ envtestlxd:
 .PHONY: testlxd
 testlxd:
 ## testlxd: Run acceptance tests against lxd
-	TF_ACC=1 TEST_CLOUD=lxd go test ./... -v $(TESTARGS) -timeout 120m
+	TF_ACC=1 TEST_CLOUD=lxd go test ./internal/provider/... -parallel 3 -v $(TESTARGS) -timeout 120m
 
 .PHONY: testmicrok8s
 testmicrok8s:
 ## testmicrok8s: Run acceptance tests against microk8s
-	TF_ACC=1 TEST_CLOUD=microk8s go test ./... -v $(TESTARGS) -timeout 120m
+	TF_ACC=1 TEST_CLOUD=microk8s go test ./internal/provider/... -parallel 3 -v $(TESTARGS) -timeout 120m
 
 PACKAGES=terraform golangci-lint go
 # Function to check if Snap packages are installed

--- a/Makefile
+++ b/Makefile
@@ -13,15 +13,16 @@ go-install:
 GOOS=$(shell go env GOOS)
 GOARCH=$(shell go env GOARCH)
 GOPATH=$(shell go env GOPATH)
-EDGEVERSION=0.14.0
-REGISTRY_DIR=~/.terraform.d/plugins/registry.terraform.io/juju/juju/${EDGEVERSION}/${GOOS}_${GOARCH}
+PARALLEL_TEST_COUNT ?= 3
+EDGE_VERSION ?= 0.14.0
+REGISTRY_DIR=~/.terraform.d/plugins/registry.terraform.io/juju/juju/${EDGE_VERSION}/${GOOS}_${GOARCH}
 
 .PHONY: install
 install: simplify docs go-install
 ## install: Build terraform-provider-juju and copy to ~/.terraform.d using EDGEVERSION
-	@echo "Copied to ~/.terraform.d/plugins/registry.terraform.io/juju/juju/${EDGEVERSION}/${GOOS}_${GOARCH}"
+	@echo "Copied to ~/.terraform.d/plugins/registry.terraform.io/juju/juju/${EDGE_VERSION}/${GOOS}_${GOARCH}"
 	@mkdir -p ${REGISTRY_DIR}
-	@cp ${GOPATH}/bin/terraform-provider-juju ${REGISTRY_DIR}/terraform-provider-juju_v${EDGEVERSION}
+	@cp ${GOPATH}/bin/terraform-provider-juju ${REGISTRY_DIR}/terraform-provider-juju_v${EDGE_VERSION}
 
 .PHONY: simplify
 # Reformat and simplify source files.
@@ -74,12 +75,12 @@ envtestlxd:
 .PHONY: testlxd
 testlxd:
 ## testlxd: Run acceptance tests against lxd
-	TF_ACC=1 TEST_CLOUD=lxd go test ./internal/provider/... -parallel 3 -v $(TESTARGS) -timeout 120m
+	TF_ACC=1 TEST_CLOUD=lxd go test ./internal/provider/... -parallel ${PARALLEL_TEST_COUNT} -v $(TESTARGS) -timeout 120m
 
 .PHONY: testmicrok8s
 testmicrok8s:
 ## testmicrok8s: Run acceptance tests against microk8s
-	TF_ACC=1 TEST_CLOUD=microk8s go test ./internal/provider/... -parallel 3 -v $(TESTARGS) -timeout 120m
+	TF_ACC=1 TEST_CLOUD=microk8s go test ./internal/provider/... -parallel ${PARALLEL_TEST_COUNT} -v $(TESTARGS) -timeout 120m
 
 PACKAGES=terraform golangci-lint go
 # Function to check if Snap packages are installed

--- a/internal/provider/data_source_machine_test.go
+++ b/internal/provider/data_source_machine_test.go
@@ -17,7 +17,7 @@ func TestAcc_DataSourceMachine_Edge(t *testing.T) {
 	}
 	modelName := acctest.RandomWithPrefix("tf-datasource-machine-test-model")
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{
@@ -37,7 +37,7 @@ func TestAcc_DataSourceMachine_Stable(t *testing.T) {
 	}
 	modelName := acctest.RandomWithPrefix("tf-datasource-machine-test-model")
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() { testAccPreCheck(t) },
 		ExternalProviders: map[string]resource.ExternalProvider{
 			"juju": {

--- a/internal/provider/data_source_machine_test.go
+++ b/internal/provider/data_source_machine_test.go
@@ -15,11 +15,6 @@ func TestAcc_DataSourceMachine_Edge(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
-	if testing.Short() {
-		t.Skip()
-	}
-	t.Parallel()
-
 	modelName := acctest.RandomWithPrefix("tf-datasource-machine-test-model")
 
 	resource.Test(t, resource.TestCase{
@@ -40,11 +35,6 @@ func TestAcc_DataSourceMachine_Stable(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
-	if testing.Short() {
-		t.Skip()
-	}
-	t.Parallel()
-
 	modelName := acctest.RandomWithPrefix("tf-datasource-machine-test-model")
 
 	resource.Test(t, resource.TestCase{

--- a/internal/provider/data_source_machine_test.go
+++ b/internal/provider/data_source_machine_test.go
@@ -31,7 +31,7 @@ func TestAcc_DataSourceMachine_Edge(t *testing.T) {
 	})
 }
 
-func TestAcc_DataSourceMachine_Stable(t *testing.T) {
+func TestAcc_DataSourceMachine_UpgradeProvider(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
@@ -39,18 +39,24 @@ func TestAcc_DataSourceMachine_Stable(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() { testAccPreCheck(t) },
-		ExternalProviders: map[string]resource.ExternalProvider{
-			"juju": {
-				VersionConstraint: TestProviderStableVersion,
-				Source:            "juju/juju",
-			},
-		},
+
 		Steps: []resource.TestStep{
 			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"juju": {
+						VersionConstraint: TestProviderStableVersion,
+						Source:            "juju/juju",
+					},
+				},
 				Config: testAccDataSourceMachine(modelName, "series = \"jammy\""),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.juju_machine.machine", "model", modelName),
 				),
+			},
+			{
+				ProtoV6ProviderFactories: frameworkProviderFactories,
+				Config:                   testAccDataSourceMachine(modelName, "series = \"jammy\""),
+				PlanOnly:                 true,
 			},
 		},
 	})

--- a/internal/provider/data_source_model_test.go
+++ b/internal/provider/data_source_model_test.go
@@ -29,24 +29,30 @@ func TestAcc_DataSourceModel_Edge(t *testing.T) {
 	})
 }
 
-func TestAcc_DataSourceModel_Stable(t *testing.T) {
+func TestAcc_DataSourceModel_UpgradeProvider(t *testing.T) {
 	modelName := acctest.RandomWithPrefix("tf-datasource-model-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() { testAccPreCheck(t) },
-		ExternalProviders: map[string]resource.ExternalProvider{
-			"juju": {
-				VersionConstraint: TestProviderStableVersion,
-				Source:            "juju/juju",
-			},
-		},
+
 		Steps: []resource.TestStep{
 			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"juju": {
+						VersionConstraint: TestProviderStableVersion,
+						Source:            "juju/juju",
+					},
+				},
 				Config: testAccFrameworkDataSourceModel(modelName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.juju_model.test-model", "name", modelName),
 					resource.TestCheckResourceAttrSet("data.juju_model.test-model", "uuid"),
 				),
+			},
+			{
+				ProtoV6ProviderFactories: frameworkProviderFactories,
+				Config:                   testAccFrameworkDataSourceModel(modelName),
+				PlanOnly:                 true,
 			},
 		},
 	})

--- a/internal/provider/data_source_model_test.go
+++ b/internal/provider/data_source_model_test.go
@@ -14,7 +14,7 @@ import (
 func TestAcc_DataSourceModel_Edge(t *testing.T) {
 	modelName := acctest.RandomWithPrefix("tf-datasource-model-test")
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{
@@ -32,7 +32,7 @@ func TestAcc_DataSourceModel_Edge(t *testing.T) {
 func TestAcc_DataSourceModel_Stable(t *testing.T) {
 	modelName := acctest.RandomWithPrefix("tf-datasource-model-test")
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() { testAccPreCheck(t) },
 		ExternalProviders: map[string]resource.ExternalProvider{
 			"juju": {

--- a/internal/provider/data_source_model_test.go
+++ b/internal/provider/data_source_model_test.go
@@ -12,11 +12,6 @@ import (
 )
 
 func TestAcc_DataSourceModel_Edge(t *testing.T) {
-	if testing.Short() {
-		t.Skip()
-	}
-	t.Parallel()
-
 	modelName := acctest.RandomWithPrefix("tf-datasource-model-test")
 
 	resource.Test(t, resource.TestCase{
@@ -35,11 +30,6 @@ func TestAcc_DataSourceModel_Edge(t *testing.T) {
 }
 
 func TestAcc_DataSourceModel_Stable(t *testing.T) {
-	if testing.Short() {
-		t.Skip()
-	}
-	t.Parallel()
-
 	modelName := acctest.RandomWithPrefix("tf-datasource-model-test")
 
 	resource.Test(t, resource.TestCase{

--- a/internal/provider/data_source_offer_test.go
+++ b/internal/provider/data_source_offer_test.go
@@ -16,7 +16,7 @@ func TestAcc_DataSourceOffer(t *testing.T) {
 	// ...-test-[0-9]+ is not a valid offer name, need to remove the dash before numbers
 	offerName := fmt.Sprintf("tf-datasource-offer-test%d", acctest.RandInt())
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{
@@ -36,7 +36,7 @@ func TestAcc_DataSourceOffer_UpgradeProvider(t *testing.T) {
 	// ...-test-[0-9]+ is not a valid offer name, need to remove the dash before numbers
 	offerName := fmt.Sprintf("tf-datasource-offer-test%d", acctest.RandInt())
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() { testAccPreCheck(t) },
 
 		Steps: []resource.TestStep{

--- a/internal/provider/data_source_offer_test.go
+++ b/internal/provider/data_source_offer_test.go
@@ -12,11 +12,6 @@ import (
 )
 
 func TestAcc_DataSourceOffer(t *testing.T) {
-	if testing.Short() {
-		t.Skip()
-	}
-	t.Parallel()
-
 	modelName := acctest.RandomWithPrefix("tf-datasource-offer-test-model")
 	// ...-test-[0-9]+ is not a valid offer name, need to remove the dash before numbers
 	offerName := fmt.Sprintf("tf-datasource-offer-test%d", acctest.RandInt())
@@ -37,11 +32,6 @@ func TestAcc_DataSourceOffer(t *testing.T) {
 }
 
 func TestAcc_DataSourceOffer_UpgradeProvider(t *testing.T) {
-	if testing.Short() {
-		t.Skip()
-	}
-	t.Parallel()
-
 	modelName := acctest.RandomWithPrefix("tf-datasource-offer-test-model")
 	// ...-test-[0-9]+ is not a valid offer name, need to remove the dash before numbers
 	offerName := fmt.Sprintf("tf-datasource-offer-test%d", acctest.RandInt())

--- a/internal/provider/data_source_secrets_test.go
+++ b/internal/provider/data_source_secrets_test.go
@@ -30,7 +30,7 @@ func TestAcc_DataSourceSecret(t *testing.T) {
 		"key2": "value2",
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{

--- a/internal/provider/data_source_secrets_test.go
+++ b/internal/provider/data_source_secrets_test.go
@@ -18,11 +18,6 @@ import (
 // blocked on the lack of schema for secret access.
 
 func TestAcc_DataSourceSecret(t *testing.T) {
-	if testing.Short() {
-		t.Skip()
-	}
-	t.Parallel()
-
 	version := os.Getenv("JUJU_AGENT_VERSION")
 	if version == "" || internaltesting.CompareVersions(version, "3.3.0") < 0 {
 		t.Skip("JUJU_AGENT_VERSION is not set or is below 3.3.0")

--- a/internal/provider/main_test.go
+++ b/internal/provider/main_test.go
@@ -7,7 +7,7 @@ package provider
 // in the testing phase.
 
 import (
-	"fmt"
+	"errors"
 	"net"
 	"os"
 	"strings"
@@ -59,7 +59,7 @@ func TypeTestingCloudFromString(from string) (CloudTesting, error) {
 	case string(MicroK8sTesting):
 		return MicroK8sTesting, nil
 	default:
-		return "", fmt.Errorf("unknown cloud type %q", from)
+		return "", errors.New("unknown cloud type")
 	}
 }
 

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/juju/terraform-provider-juju/internal/juju"
 )
 
-const TestProviderStableVersion = "0.10.1"
+const TestProviderStableVersion = "0.12.0"
 
 // providerFactories are used to instantiate the Framework provider during
 // acceptance testing.

--- a/internal/provider/resource_access_model_test.go
+++ b/internal/provider/resource_access_model_test.go
@@ -23,7 +23,7 @@ func TestAcc_ResourceAccessModel(t *testing.T) {
 	accessFail := "bogus"
 
 	resourceName := "juju_access_model.test"
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{
@@ -77,7 +77,7 @@ func TestAcc_ResourceAccessModel_UpgradeProvider(t *testing.T) {
 	access := "write"
 
 	resourceName := "juju_access_model.test"
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() { testAccPreCheck(t) },
 
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_access_model_test.go
+++ b/internal/provider/resource_access_model_test.go
@@ -17,8 +17,8 @@ func TestAcc_ResourceAccessModel(t *testing.T) {
 	userPassword := acctest.RandomWithPrefix("tf-test-user")
 	userName2 := acctest.RandomWithPrefix("tfuser")
 	userPassword2 := acctest.RandomWithPrefix("tf-test-user")
-	modelName1 := "testing1"
-	modelName2 := "testing2"
+	modelName1 := acctest.RandomWithPrefix("tf-access-model-one")
+	modelName2 := acctest.RandomWithPrefix("tf-access-model-two")
 	accessSuccess := "write"
 	accessFail := "bogus"
 
@@ -73,7 +73,7 @@ func TestAcc_ResourceAccessModel_UpgradeProvider(t *testing.T) {
 
 	userName := acctest.RandomWithPrefix("tfuser")
 	userPassword := acctest.RandomWithPrefix("tf-test-user")
-	modelName := "testing"
+	modelName := acctest.RandomWithPrefix("tf-access-model")
 	access := "write"
 
 	resourceName := "juju_access_model.test"

--- a/internal/provider/resource_access_model_test.go
+++ b/internal/provider/resource_access_model_test.go
@@ -13,11 +13,6 @@ import (
 )
 
 func TestAcc_ResourceAccessModel(t *testing.T) {
-	if testing.Short() {
-		t.Skip()
-	}
-	t.Parallel()
-
 	userName := acctest.RandomWithPrefix("tfuser")
 	userPassword := acctest.RandomWithPrefix("tf-test-user")
 	userName2 := acctest.RandomWithPrefix("tfuser")
@@ -75,10 +70,6 @@ func TestAcc_ResourceAccessModel_UpgradeProvider(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
-	if testing.Short() {
-		t.Skip()
-	}
-	t.Parallel()
 
 	userName := acctest.RandomWithPrefix("tfuser")
 	userPassword := acctest.RandomWithPrefix("tf-test-user")

--- a/internal/provider/resource_access_secret_test.go
+++ b/internal/provider/resource_access_secret_test.go
@@ -18,11 +18,6 @@ import (
 // the applications used don't actually require a user secret.
 // TODO(anvial): Add a test that uses a secret that is actually required by the application.
 func TestAcc_ResourceAccessSecret_GrantRevoke(t *testing.T) {
-	if testing.Short() {
-		t.Skip()
-	}
-	t.Parallel()
-
 	agentVersion := os.Getenv(TestJujuAgentVersion)
 	if agentVersion == "" {
 		t.Errorf("%s is not set", TestJujuAgentVersion)
@@ -63,11 +58,6 @@ func TestAcc_ResourceAccessSecret_GrantRevoke(t *testing.T) {
 }
 
 func TestAcc_ResourceAccessSecret_Import(t *testing.T) {
-	if testing.Short() {
-		t.Skip()
-	}
-	t.Parallel()
-
 	agentVersion := os.Getenv(TestJujuAgentVersion)
 	if agentVersion == "" {
 		t.Errorf("%s is not set", TestJujuAgentVersion)

--- a/internal/provider/resource_access_secret_test.go
+++ b/internal/provider/resource_access_secret_test.go
@@ -27,7 +27,7 @@ func TestAcc_ResourceAccessSecret_GrantRevoke(t *testing.T) {
 
 	modelName := acctest.RandomWithPrefix("tf-test-model")
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{
@@ -67,7 +67,7 @@ func TestAcc_ResourceAccessSecret_Import(t *testing.T) {
 
 	modelName := acctest.RandomWithPrefix("tf-test-model")
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_application_test.go
+++ b/internal/provider/resource_application_test.go
@@ -28,7 +28,7 @@ func TestAcc_ResourceApplication(t *testing.T) {
 	modelName := acctest.RandomWithPrefix("tf-test-application")
 	appName := "test-app"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{
@@ -96,7 +96,7 @@ func TestAcc_ResourceApplication_Updates(t *testing.T) {
 		appName = "hello-kubecon"
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{
@@ -167,7 +167,7 @@ func TestAcc_ResourceApplication_UpdatesRevisionConfig(t *testing.T) {
 	appName := "github-runner"
 	configParamName := "runner-storage"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{
@@ -194,7 +194,7 @@ func TestAcc_ResourceApplication_UpdatesRevisionConfig(t *testing.T) {
 func TestAcc_CharmUpdates(t *testing.T) {
 	modelName := acctest.RandomWithPrefix("tf-test-charmupdates")
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{
@@ -228,7 +228,7 @@ func TestAcc_ResourceRevisionUpdatesLXD(t *testing.T) {
 	}
 	modelName := acctest.RandomWithPrefix("tf-test-resource-revision-updates-lxd")
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{
@@ -262,7 +262,7 @@ func TestAcc_ResourceRevisionAddedToPlanLXD(t *testing.T) {
 	}
 	modelName := acctest.RandomWithPrefix("tf-test-resource-revision-updates-lxd")
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{
@@ -288,7 +288,7 @@ func TestAcc_ResourceRevisionRemovedFromPlanLXD(t *testing.T) {
 	}
 	modelName := acctest.RandomWithPrefix("tf-test-resource-revision-updates-lxd")
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{
@@ -316,7 +316,7 @@ func TestAcc_ResourceRevisionUpdatesMicrok8s(t *testing.T) {
 	}
 	modelName := acctest.RandomWithPrefix("tf-test-resource-revision-updates-microk8s")
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{
@@ -363,7 +363,7 @@ func TestAcc_ResourceApplication_Minimal(t *testing.T) {
 		// Microk8s doesn't have machine, thus no placement
 		checkResourceAttr = append(checkResourceAttr, resource.TestCheckResourceAttr(resourceName, "placement", "0"))
 	}
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{
@@ -385,7 +385,7 @@ func TestAcc_ResourceApplication_UpgradeProvider(t *testing.T) {
 	modelName := acctest.RandomWithPrefix("tf-test-application")
 	appName := "test-app"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() { testAccPreCheck(t) },
 
 		Steps: []resource.TestStep{
@@ -426,7 +426,7 @@ func TestAcc_ResourceApplication_EndpointBindings(t *testing.T) {
 	defer cleanUp()
 
 	constraints := "arch=amd64 spaces=" + managementSpace + "," + publicSpace
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{
@@ -461,7 +461,7 @@ func TestAcc_ResourceApplication_UpdateEndpointBindings(t *testing.T) {
 	defer cleanUp()
 	constraints := "arch=amd64 spaces=" + managementSpace + "," + publicSpace
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{
@@ -525,7 +525,7 @@ func TestAcc_ResourceApplication_Storage(t *testing.T) {
 
 	storageConstraints := map[string]string{"label": "runner", "size": "2G"}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_application_test.go
+++ b/internal/provider/resource_application_test.go
@@ -25,11 +25,6 @@ import (
 )
 
 func TestAcc_ResourceApplication(t *testing.T) {
-	if testing.Short() {
-		t.Skip()
-	}
-	t.Parallel()
-
 	modelName := acctest.RandomWithPrefix("tf-test-application")
 	appName := "test-app"
 
@@ -95,11 +90,6 @@ func TestAcc_ResourceApplication(t *testing.T) {
 }
 
 func TestAcc_ResourceApplication_Updates(t *testing.T) {
-	if testing.Short() {
-		t.Skip()
-	}
-	t.Parallel()
-
 	modelName := acctest.RandomWithPrefix("tf-test-application")
 	appName := "jameinel-ubuntu-lite"
 	if testingCloud != LXDCloudTesting {
@@ -172,10 +162,6 @@ func TestAcc_ResourceApplication_UpdatesRevisionConfig(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
-	if testing.Short() {
-		t.Skip()
-	}
-	t.Parallel()
 
 	modelName := acctest.RandomWithPrefix("tf-test-application")
 	appName := "github-runner"
@@ -206,11 +192,6 @@ func TestAcc_ResourceApplication_UpdatesRevisionConfig(t *testing.T) {
 }
 
 func TestAcc_CharmUpdates(t *testing.T) {
-	if testing.Short() {
-		t.Skip()
-	}
-	t.Parallel()
-
 	modelName := acctest.RandomWithPrefix("tf-test-charmupdates")
 
 	resource.Test(t, resource.TestCase{
@@ -245,11 +226,6 @@ func TestAcc_ResourceRevisionUpdatesLXD(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
-	if testing.Short() {
-		t.Skip()
-	}
-	t.Parallel()
-
 	modelName := acctest.RandomWithPrefix("tf-test-resource-revision-updates-lxd")
 
 	resource.Test(t, resource.TestCase{
@@ -284,11 +260,6 @@ func TestAcc_ResourceRevisionAddedToPlanLXD(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
-	if testing.Short() {
-		t.Skip()
-	}
-	t.Parallel()
-
 	modelName := acctest.RandomWithPrefix("tf-test-resource-revision-updates-lxd")
 
 	resource.Test(t, resource.TestCase{
@@ -315,11 +286,6 @@ func TestAcc_ResourceRevisionRemovedFromPlanLXD(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
-	if testing.Short() {
-		t.Skip()
-	}
-	t.Parallel()
-
 	modelName := acctest.RandomWithPrefix("tf-test-resource-revision-updates-lxd")
 
 	resource.Test(t, resource.TestCase{
@@ -348,11 +314,6 @@ func TestAcc_ResourceRevisionUpdatesMicrok8s(t *testing.T) {
 	if testingCloud != MicroK8sTesting {
 		t.Skip(t.Name() + " only runs with Microk8s")
 	}
-	if testing.Short() {
-		t.Skip()
-	}
-	t.Parallel()
-
 	modelName := acctest.RandomWithPrefix("tf-test-resource-revision-updates-microk8s")
 
 	resource.Test(t, resource.TestCase{
@@ -384,11 +345,6 @@ func TestAcc_ResourceRevisionUpdatesMicrok8s(t *testing.T) {
 }
 
 func TestAcc_ResourceApplication_Minimal(t *testing.T) {
-	if testing.Short() {
-		t.Skip()
-	}
-	t.Parallel()
-
 	modelName := acctest.RandomWithPrefix("tf-test-application")
 	var charmName string
 	if testingCloud == LXDCloudTesting {
@@ -426,11 +382,6 @@ func TestAcc_ResourceApplication_Minimal(t *testing.T) {
 }
 
 func TestAcc_ResourceApplication_UpgradeProvider(t *testing.T) {
-	if testing.Short() {
-		t.Skip()
-	}
-	t.Parallel()
-
 	modelName := acctest.RandomWithPrefix("tf-test-application")
 	appName := "test-app"
 
@@ -468,11 +419,6 @@ func TestAcc_ResourceApplication_EndpointBindings(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
-	if testing.Short() {
-		t.Skip()
-	}
-	t.Parallel()
-
 	modelName := acctest.RandomWithPrefix("tf-test-application-bindings")
 	appName := "test-app"
 
@@ -508,11 +454,6 @@ func TestAcc_ResourceApplication_UpdateEndpointBindings(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
-	if testing.Short() {
-		t.Skip()
-	}
-	t.Parallel()
-
 	modelName := acctest.RandomWithPrefix("tf-test-application-bindings-update")
 	appName := "test-app-update"
 

--- a/internal/provider/resource_credential_test.go
+++ b/internal/provider/resource_credential_test.go
@@ -15,11 +15,6 @@ func TestAcc_ResourceCredential(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
-	if testing.Short() {
-		t.Skip()
-	}
-	t.Parallel()
-
 	credentialName := acctest.RandomWithPrefix("tf-test-credential")
 	authType := "certificate"
 	token := "123abc"
@@ -62,11 +57,6 @@ func TestAcc_ResourceCredential_UpgradeProvider(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
-	if testing.Short() {
-		t.Skip()
-	}
-	t.Parallel()
-
 	credentialName := acctest.RandomWithPrefix("tf-test-credential")
 	authType := "certificate"
 

--- a/internal/provider/resource_credential_test.go
+++ b/internal/provider/resource_credential_test.go
@@ -20,7 +20,7 @@ func TestAcc_ResourceCredential(t *testing.T) {
 	token := "123abc"
 
 	resourceName := "juju_credential.test-credential"
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{
@@ -61,7 +61,7 @@ func TestAcc_ResourceCredential_UpgradeProvider(t *testing.T) {
 	authType := "certificate"
 
 	resourceName := "juju_credential.test-credential"
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() { testAccPreCheck(t) },
 
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_integration_test.go
+++ b/internal/provider/resource_integration_test.go
@@ -19,7 +19,7 @@ func TestAcc_ResourceIntegration(t *testing.T) {
 	}
 	modelName := acctest.RandomWithPrefix("tf-test-integration")
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: frameworkProviderFactories,
 		CheckDestroy:             testAccCheckIntegrationDestroy,
@@ -58,7 +58,7 @@ func TestAcc_ResourceIntegrationWithViaCIDRs(t *testing.T) {
 	dstModelName := acctest.RandomWithPrefix("tf-test-integration-dst")
 	via := "127.0.0.1/32,127.0.0.3/32"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: frameworkProviderFactories,
 		CheckDestroy:             testAccCheckIntegrationDestroy,
@@ -83,7 +83,7 @@ func TestAcc_ResourceIntegration_UpgradeProvider(t *testing.T) {
 	}
 	modelName := acctest.RandomWithPrefix("tf-test-integration")
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		CheckDestroy: testAccCheckIntegrationDestroy,
 		Steps: []resource.TestStep{
@@ -219,7 +219,7 @@ func TestAcc_ResourceIntegrationWithMultipleConsumers(t *testing.T) {
 	srcModelName := acctest.RandomWithPrefix("tf-test-integration")
 	dstModelName := acctest.RandomWithPrefix("tf-test-integration-dst")
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: frameworkProviderFactories,
 		CheckDestroy:             testAccCheckIntegrationDestroy,

--- a/internal/provider/resource_integration_test.go
+++ b/internal/provider/resource_integration_test.go
@@ -17,11 +17,6 @@ func TestAcc_ResourceIntegration(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
-	if testing.Short() {
-		t.Skip()
-	}
-	t.Parallel()
-
 	modelName := acctest.RandomWithPrefix("tf-test-integration")
 
 	resource.Test(t, resource.TestCase{
@@ -59,11 +54,6 @@ func TestAcc_ResourceIntegrationWithViaCIDRs(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
-	if testing.Short() {
-		t.Skip()
-	}
-	t.Parallel()
-
 	srcModelName := acctest.RandomWithPrefix("tf-test-integration")
 	dstModelName := acctest.RandomWithPrefix("tf-test-integration-dst")
 	via := "127.0.0.1/32,127.0.0.3/32"
@@ -91,11 +81,6 @@ func TestAcc_ResourceIntegration_UpgradeProvider(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
-	if testing.Short() {
-		t.Skip()
-	}
-	t.Parallel()
-
 	modelName := acctest.RandomWithPrefix("tf-test-integration")
 
 	resource.Test(t, resource.TestCase{
@@ -231,11 +216,6 @@ func TestAcc_ResourceIntegrationWithMultipleConsumers(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
-	if testing.Short() {
-		t.Skip()
-	}
-	t.Parallel()
-
 	srcModelName := acctest.RandomWithPrefix("tf-test-integration")
 	dstModelName := acctest.RandomWithPrefix("tf-test-integration-dst")
 

--- a/internal/provider/resource_machine_test.go
+++ b/internal/provider/resource_machine_test.go
@@ -17,7 +17,7 @@ func TestAcc_ResourceMachine(t *testing.T) {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
 	modelName := acctest.RandomWithPrefix("tf-test-machine")
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{
@@ -45,7 +45,7 @@ func TestAcc_ResourceMachine_Minimal(t *testing.T) {
 	}
 	modelName := acctest.RandomWithPrefix("tf-test-machine")
 	resourceName := "juju_machine.testmachine"
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{
@@ -71,7 +71,7 @@ func TestAcc_ResourceMachine_WithPlacement(t *testing.T) {
 	}
 	modelName := acctest.RandomWithPrefix("tf-test-machine")
 	resourceName := "juju_machine.this_machine_1"
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{
@@ -109,7 +109,7 @@ func TestAcc_ResourceMachine_UpgradeProvider(t *testing.T) {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
 	modelName := acctest.RandomWithPrefix("tf-test-machine")
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() { testAccPreCheck(t) },
 
 		Steps: []resource.TestStep{
@@ -162,7 +162,7 @@ func TestAcc_ResourceMachine_AddMachine_Edge(t *testing.T) {
 			TestSSHPublicKeyFileEnvKey, TestSSHPrivateKeyFileEnvKey)
 	}
 	modelName := acctest.RandomWithPrefix("tf-test-machine-ssh-address")
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_machine_test.go
+++ b/internal/provider/resource_machine_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-
 	internaltesting "github.com/juju/terraform-provider-juju/internal/testing"
 )
 
@@ -17,11 +16,6 @@ func TestAcc_ResourceMachine(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
-	if testing.Short() {
-		t.Skip()
-	}
-	t.Parallel()
-
 	modelName := acctest.RandomWithPrefix("tf-test-machine")
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -49,11 +43,6 @@ func TestAcc_ResourceMachine_Minimal(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
-	if testing.Short() {
-		t.Skip()
-	}
-	t.Parallel()
-
 	modelName := acctest.RandomWithPrefix("tf-test-machine")
 	resourceName := "juju_machine.testmachine"
 	resource.Test(t, resource.TestCase{
@@ -80,11 +69,6 @@ func TestAcc_ResourceMachine_WithPlacement(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
-	if testing.Short() {
-		t.Skip()
-	}
-	t.Parallel()
-
 	modelName := acctest.RandomWithPrefix("tf-test-machine")
 	resourceName := "juju_machine.this_machine_1"
 	resource.Test(t, resource.TestCase{
@@ -124,11 +108,6 @@ func TestAcc_ResourceMachine_UpgradeProvider(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
-	if testing.Short() {
-		t.Skip()
-	}
-	t.Parallel()
-
 	modelName := acctest.RandomWithPrefix("tf-test-machine")
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() { testAccPreCheck(t) },
@@ -175,11 +154,6 @@ func TestAcc_ResourceMachine_AddMachine_Edge(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
-	if testing.Short() {
-		t.Skip()
-	}
-	t.Parallel()
-
 	if testAddMachineIP == "" {
 		t.Skipf("environment variable %v not setup or invalid for running test", TestMachineIPEnvKey)
 	}

--- a/internal/provider/resource_model_test.go
+++ b/internal/provider/resource_model_test.go
@@ -15,11 +15,6 @@ import (
 )
 
 func TestAcc_ResourceModel(t *testing.T) {
-	if testing.Short() {
-		t.Skip()
-	}
-	t.Parallel()
-
 	modelName := acctest.RandomWithPrefix("tf-test-model")
 	logLevelInfo := "INFO"
 	logLevelDebug := "DEBUG"
@@ -62,11 +57,6 @@ func TestAcc_ResourceModel(t *testing.T) {
 }
 
 func TestAcc_ResourceModel_UnsetConfig(t *testing.T) {
-	if testing.Short() {
-		t.Skip()
-	}
-	t.Parallel()
-
 	modelName := acctest.RandomWithPrefix("tf-test-model")
 
 	resourceName := "juju_model.this"
@@ -104,11 +94,6 @@ resource "juju_model" "this" {
 }
 
 func TestAcc_ResourceModel_Minimal(t *testing.T) {
-	if testing.Short() {
-		t.Skip()
-	}
-	t.Parallel()
-
 	modelName := acctest.RandomWithPrefix("tf-test-model")
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -128,11 +113,6 @@ resource "juju_model" "testmodel" {
 }
 
 func TestAcc_ResourceModel_UpgradeProvider(t *testing.T) {
-	if testing.Short() {
-		t.Skip()
-	}
-	t.Parallel()
-
 	modelName := acctest.RandomWithPrefix("tf-test-model")
 	logLevelDebug := "DEBUG"
 

--- a/internal/provider/resource_model_test.go
+++ b/internal/provider/resource_model_test.go
@@ -20,7 +20,7 @@ func TestAcc_ResourceModel(t *testing.T) {
 	logLevelDebug := "DEBUG"
 
 	resourceName := "juju_model.model"
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{
@@ -60,7 +60,7 @@ func TestAcc_ResourceModel_UnsetConfig(t *testing.T) {
 	modelName := acctest.RandomWithPrefix("tf-test-model")
 
 	resourceName := "juju_model.this"
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{
@@ -95,7 +95,7 @@ resource "juju_model" "this" {
 
 func TestAcc_ResourceModel_Minimal(t *testing.T) {
 	modelName := acctest.RandomWithPrefix("tf-test-model")
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{
@@ -117,7 +117,7 @@ func TestAcc_ResourceModel_UpgradeProvider(t *testing.T) {
 	logLevelDebug := "DEBUG"
 
 	resourceName := "juju_model.model"
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() { testAccPreCheck(t) },
 		Steps: []resource.TestStep{
 			{

--- a/internal/provider/resource_offer_test.go
+++ b/internal/provider/resource_offer_test.go
@@ -15,11 +15,6 @@ func TestAcc_ResourceOffer(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
-	if testing.Short() {
-		t.Skip()
-	}
-	t.Parallel()
-
 	modelName := acctest.RandomWithPrefix("tf-test-offer")
 	modelName2 := acctest.RandomWithPrefix("tf-test-offer")
 	destModelName := acctest.RandomWithPrefix("tf-test-offer-dest")
@@ -113,11 +108,6 @@ func TestAcc_ResourceOffer_UpgradeProvider(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
-	if testing.Short() {
-		t.Skip()
-	}
-	t.Parallel()
-
 	modelName := acctest.RandomWithPrefix("tf-test-offer")
 
 	resource.Test(t, resource.TestCase{

--- a/internal/provider/resource_offer_test.go
+++ b/internal/provider/resource_offer_test.go
@@ -19,7 +19,7 @@ func TestAcc_ResourceOffer(t *testing.T) {
 	modelName2 := acctest.RandomWithPrefix("tf-test-offer")
 	destModelName := acctest.RandomWithPrefix("tf-test-offer-dest")
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{
@@ -110,7 +110,7 @@ func TestAcc_ResourceOffer_UpgradeProvider(t *testing.T) {
 	}
 	modelName := acctest.RandomWithPrefix("tf-test-offer")
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() { testAccPreCheck(t) },
 
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_secret_test.go
+++ b/internal/provider/resource_secret_test.go
@@ -15,11 +15,6 @@ import (
 )
 
 func TestAcc_ResourceSecret_CreateWithoutName(t *testing.T) {
-	if testing.Short() {
-		t.Skip()
-	}
-	t.Parallel()
-
 	agentVersion := os.Getenv(TestJujuAgentVersion)
 	if agentVersion == "" {
 		t.Errorf("%s is not set", TestJujuAgentVersion)
@@ -52,11 +47,6 @@ func TestAcc_ResourceSecret_CreateWithoutName(t *testing.T) {
 }
 
 func TestAcc_ResourceSecret_CreateWithInfo(t *testing.T) {
-	if testing.Short() {
-		t.Skip()
-	}
-	t.Parallel()
-
 	agentVersion := os.Getenv(TestJujuAgentVersion)
 	if agentVersion == "" {
 		t.Errorf("%s is not set", TestJujuAgentVersion)
@@ -97,11 +87,6 @@ func TestAcc_ResourceSecret_CreateWithInfo(t *testing.T) {
 }
 
 func TestAcc_ResourceSecret_CreateWithNoInfo(t *testing.T) {
-	if testing.Short() {
-		t.Skip()
-	}
-	t.Parallel()
-
 	agentVersion := os.Getenv(TestJujuAgentVersion)
 	if agentVersion == "" {
 		t.Errorf("%s is not set", TestJujuAgentVersion)
@@ -134,11 +119,6 @@ func TestAcc_ResourceSecret_CreateWithNoInfo(t *testing.T) {
 }
 
 func TestAcc_ResourceSecret_Update(t *testing.T) {
-	if testing.Short() {
-		t.Skip()
-	}
-	t.Parallel()
-
 	agentVersion := os.Getenv(TestJujuAgentVersion)
 	if agentVersion == "" {
 		t.Errorf("%s is not set", TestJujuAgentVersion)

--- a/internal/provider/resource_secret_test.go
+++ b/internal/provider/resource_secret_test.go
@@ -29,7 +29,7 @@ func TestAcc_ResourceSecret_CreateWithoutName(t *testing.T) {
 		"key2": "value2",
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{
@@ -62,7 +62,7 @@ func TestAcc_ResourceSecret_CreateWithInfo(t *testing.T) {
 		"key2": "value2",
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{
@@ -101,7 +101,7 @@ func TestAcc_ResourceSecret_CreateWithNoInfo(t *testing.T) {
 		"key2": "value2",
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{
@@ -143,7 +143,7 @@ func TestAcc_ResourceSecret_Update(t *testing.T) {
 		"key3": "value3",
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_ssh_key_test.go
+++ b/internal/provider/resource_ssh_key_test.go
@@ -20,7 +20,7 @@ func TestAcc_ResourceSSHKey(t *testing.T) {
 
 	sshKey2 := `ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1I8QDP79MaHEIAlfh933zqcE8LyUt9doytF3YySBUDWippk8MAaKAJJtNb+Qsi+Kx/RsSY02VxMy9xRTp9d/Vr+U5BctKqhqf3ZkJdTIcy+z4hYpFS8A4bECJFHOnKIekIHD9glHkqzS5Vm6E4g/KMNkKylHKlDXOafhNZAiJ1ynxaZIuedrceFJNC47HnocQEtusPKpR09HGXXYhKMEubgF5tsTO4ks6pplMPvbdjxYcVOg4Wv0N/LJ4ffAucG9edMcKOTnKqZycqqZPE6KsTpSZMJi2Kl3mBrJE7JbR1YMlNwG6NlUIdIqVoTLZgLsTEkHqWi6OExykbVTqFuoWJJY2BmRAcP9T3FdLYbqcajfWshwvPM2AmYb8V3zBvzEKL1rpvG26fd3kGhk3Vu07qAUhHLMi3P0McEky4cLiEWgI7UyHFLI2yMRZgz23UUtxhRSkvCJagRlVG/s4yoylzBQJir8G3qmb36WjBXxpqAXhfLxw05EQI1JGV3ReYOs= jimmy@somewhere`
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{
@@ -48,7 +48,7 @@ func TestAcc_ResourceSSHKey_ED25519(t *testing.T) {
 	modelName := acctest.RandomWithPrefix("tf-test-sshkey")
 	sshKey1 := `ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAID3gjJTJtYZU55HTUr+hu0JF9p152yiC9czJi9nKojuW jimmy@somewhere`
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{
@@ -71,7 +71,7 @@ func TestAcc_ResourceSSHKey_UpgradeProvider(t *testing.T) {
 
 	sshKey2 := `ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1I8QDP79MaHEIAlfh933zqcE8LyUt9doytF3YySBUDWippk8MAaKAJJtNb+Qsi+Kx/RsSY02VxMy9xRTp9d/Vr+U5BctKqhqf3ZkJdTIcy+z4hYpFS8A4bECJFHOnKIekIHD9glHkqzS5Vm6E4g/KMNkKylHKlDXOafhNZAiJ1ynxaZIuedrceFJNC47HnocQEtusPKpR09HGXXYhKMEubgF5tsTO4ks6pplMPvbdjxYcVOg4Wv0N/LJ4ffAucG9edMcKOTnKqZycqqZPE6KsTpSZMJi2Kl3mBrJE7JbR1YMlNwG6NlUIdIqVoTLZgLsTEkHqWi6OExykbVTqFuoWJJY2BmRAcP9T3FdLYbqcajfWshwvPM2AmYb8V3zBvzEKL1rpvG26fd3kGhk3Vu07qAUhHLMi3P0McEky4cLiEWgI7UyHFLI2yMRZgz23UUtxhRSkvCJagRlVG/s4yoylzBQJir8G3qmb36WjBXxpqAXhfLxw05EQI1JGV3ReYOs= jimmy@somewhere`
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() { testAccPreCheck(t) },
 
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_ssh_key_test.go
+++ b/internal/provider/resource_ssh_key_test.go
@@ -15,11 +15,6 @@ func TestAcc_ResourceSSHKey(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
-	if testing.Short() {
-		t.Skip()
-	}
-	t.Parallel()
-
 	modelName := acctest.RandomWithPrefix("tf-test-sshkey")
 	sshKey1 := `ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1I8QDP79MaHEIAlfh933zqcE8LyUt9doytF3YySBUDWippk8MAaKAJJtNb+Qsi+Kx/RsSY02VxMy9xRTp9d/Vr+U5BctKqhqf3ZkJdTIcy+z4hYpFS8A4bECJFHOnKIekIHD9glHkqzS5Vm6E4g/KMNkKylHKlDXOafhNZAiJ1ynxaZIuedrceFJNC47HnocQEtusPKpR09HGXXYhKMEubgF5tsTO4ks6pplMPvbdjxYcVOg4Wv0N/LJ4ffAucG9edMcKOTnKqZycqqZPE6KsTpSZMJi2Kl3mBrJE7JbR1YMlNwG6NlUIdIqVoTLZgLsTEkHqWi6OExykbVTqFuoWJJY2BmRAcP9T3FdLYbqcajfWshwvPM2AmYb8V3zBvzEKL1rpvG26fd3kGhk3Vu07qAUhHLMi3P0McEky4cLiEWgI7UyHFLI2yMRZgz23UUtxhRSkvCJagRlVG/s4yoylzBQJir8G3qmb36WjBXxpqAXhfLxw05EQI1JGV3ReYOs= jimmy@somewhere`
 
@@ -50,11 +45,6 @@ func TestAcc_ResourceSSHKey_ED25519(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
-	if testing.Short() {
-		t.Skip()
-	}
-	t.Parallel()
-
 	modelName := acctest.RandomWithPrefix("tf-test-sshkey")
 	sshKey1 := `ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAID3gjJTJtYZU55HTUr+hu0JF9p152yiC9czJi9nKojuW jimmy@somewhere`
 
@@ -76,11 +66,6 @@ func TestAcc_ResourceSSHKey_UpgradeProvider(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
-	if testing.Short() {
-		t.Skip()
-	}
-	t.Parallel()
-
 	modelName := acctest.RandomWithPrefix("tf-test-sshkey")
 	sshKey1 := `ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1I8QDP79MaHEIAlfh933zqcE8LyUt9doytF3YySBUDWippk8MAaKAJJtNb+Qsi+Kx/RsSY02VxMy9xRTp9d/Vr+U5BctKqhqf3ZkJdTIcy+z4hYpFS8A4bECJFHOnKIekIHD9glHkqzS5Vm6E4g/KMNkKylHKlDXOafhNZAiJ1ynxaZIuedrceFJNC47HnocQEtusPKpR09HGXXYhKMEubgF5tsTO4ks6pplMPvbdjxYcVOg4Wv0N/LJ4ffAucG9edMcKOTnKqZycqqZPE6KsTpSZMJi2Kl3mBrJE7JbR1YMlNwG6NlUIdIqVoTLZgLsTEkHqWi6OExykbVTqFuoWJJY2BmRAcP9T3FdLYbqcajfWshwvPM2AmYb8V3zBvzEKL1rpvG26fd3kGhk3Vu07qAUhHLMi3P0McEky4cLiEWgI7UyHFLI2yMRZgz23UUtxhRSkvCJagRlVG/s4yoylzBQJir8G3qmb36WjBXxpqAXhfLxw05EQI1JGV3ReYOs= jimmy@somewhere`
 

--- a/internal/provider/resource_user_test.go
+++ b/internal/provider/resource_user_test.go
@@ -16,7 +16,7 @@ func TestAcc_ResourceUser(t *testing.T) {
 	userPassword := acctest.RandomWithPrefix("tf-test-user")
 
 	resourceName := "juju_user.user"
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{
@@ -53,7 +53,7 @@ func TestAcc_ResourceUser_UpgradeProvider(t *testing.T) {
 	userPassword := acctest.RandomWithPrefix("tf-test-user")
 
 	resourceName := "juju_user.user"
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() { testAccPreCheck(t) },
 		Steps: []resource.TestStep{
 			{

--- a/internal/provider/resource_user_test.go
+++ b/internal/provider/resource_user_test.go
@@ -12,11 +12,6 @@ import (
 )
 
 func TestAcc_ResourceUser(t *testing.T) {
-	if testing.Short() {
-		t.Skip()
-	}
-	t.Parallel()
-
 	userName := acctest.RandomWithPrefix("tfuser")
 	userPassword := acctest.RandomWithPrefix("tf-test-user")
 
@@ -54,11 +49,6 @@ resource "juju_user" "user" {
 }
 
 func TestAcc_ResourceUser_UpgradeProvider(t *testing.T) {
-	if testing.Short() {
-		t.Skip()
-	}
-	t.Parallel()
-
 	userName := acctest.RandomWithPrefix("tfuser")
 	userPassword := acctest.RandomWithPrefix("tf-test-user")
 

--- a/internal/provider/validator_channel_test.go
+++ b/internal/provider/validator_channel_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
 	"github.com/juju/terraform-provider-juju/internal/provider"
 )
 

--- a/internal/provider/validator_channel_test.go
+++ b/internal/provider/validator_channel_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-
 	"github.com/juju/terraform-provider-juju/internal/provider"
 )
 


### PR DESCRIPTION
## Description

Use the terraform plugin testing package ParallelTest to help speed up acceptance test time rather than a straight `t.Parallel()` call. Update make test targets to include `-parallel 1`.  To enable parallel testing in this repository, work needs to be done with the GitHub runners. We need new self-hosted ones, or rewrite them not to use the charmed-kubernetes setup GitHub action.

A few tests needed updates to ensure that the model names were unique per run. Other tests needed to be updated to test ProviderUpgrade rather than doing nothing as they were.

Use 0.12.0 release to test Provider Upgrade, the panic seen sometimes with 0.10.1 has already been resolved there.

## Type of change

- Change in tests (one or several tests have been changed)

## QA steps

Setup and run the tests with `make testlxd` and `make testmicrok8s`

