### PR TITLE
feat(githubactions): dependabot to use custom labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,13 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    labels:
+      - "hint/dependencies"
+      - "area/go"
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
       interval: "daily"
+    labels:
+      - "hint/dependencies"
+      - "area/go"


### PR DESCRIPTION
## Description

Adds custom labels for dependabot to use when opening chore PRs, as documented in https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#labels .

Normally it adds the `dependencies` and `go` labels. The `hint/dependencies` and `area/go` are added. 

## Type of change

- Maintenance work (repository related, like Github actions, or revving the Go version, etc.)

## Additional notes

> [!WARNING]
> I'm not entirely sure if the new labels will replace the old ones or be added on top.
