### PR TITLE
fix(application): handle storage details conversion error

### DIFF
--- a/internal/juju/applications.go
+++ b/internal/juju/applications.go
@@ -71,6 +71,17 @@ func (se *storageNotFoundError) Error() string {
 	return fmt.Sprintf("storage %s not found", se.storageName)
 }
 
+var RetryReadError = &retryReadError{}
+
+// retryReadError
+type retryReadError struct {
+	msg string
+}
+
+func (e *retryReadError) Error() string {
+	return fmt.Sprintf("retrying: %s", e.msg)
+}
+
 type applicationsClient struct {
 	SharedClient
 	controllerVersion version.Number
@@ -756,11 +767,7 @@ func (c applicationsClient) ReadApplicationWithRetryOnNotFound(ctx context.Conte
 			if errors.As(err, &ApplicationNotFoundError) || errors.As(err, &StorageNotFoundError) {
 				return err
 			} else if err != nil {
-				// Log the error to the terraform Diagnostics to be
-				// caught in the provider. Return nil so we stop
-				// retrying.
-				c.Errorf(err, fmt.Sprintf("ReadApplicationWithRetryOnNotFound %q", input.AppName))
-				return nil
+				return err
 			}
 
 			// NOTE: Applications can always have storage. However, they
@@ -768,9 +775,9 @@ func (c applicationsClient) ReadApplicationWithRetryOnNotFound(ctx context.Conte
 			// we need to wait for the storage to be ready. And we need to
 			// check if all storage constraints have pool equal "" and size equal 0
 			// to drop the error.
-			for _, storage := range output.Storage {
+			for label, storage := range output.Storage {
 				if storage.Pool == "" || storage.Size == 0 {
-					return fmt.Errorf("ReadApplicationWithRetryOnNotFound: no storage found in output")
+					return &retryReadError{msg: fmt.Sprintf("storage label %q missing detail", label)}
 				}
 			}
 
@@ -784,20 +791,24 @@ func (c applicationsClient) ReadApplicationWithRetryOnNotFound(ctx context.Conte
 				return nil
 			}
 			if output.Placement == "" {
-				return fmt.Errorf("ReadApplicationWithRetryOnNotFound: no machines found in output")
+				return &retryReadError{msg: "no machines found in output"}
 			}
 			machines := strings.Split(output.Placement, ",")
 			if len(machines) != output.Units {
-				return fmt.Errorf("ReadApplicationWithRetryOnNotFound: need %d machines, have %d", output.Units, len(machines))
+				return &retryReadError{msg: fmt.Sprintf("need %d machines, have %d", output.Units, len(machines))}
 			}
 
-			// NOTE: An IAAS subordinate should also have machines. However, they
-			// will not be listed until after the relation has been created.
-			// Those happen with the integration resource which will not be
-			// run by terraform before the application resource finishes. Thus
-			// do not block here for subordinates.
 			c.Tracef("Have machines - returning", map[string]interface{}{"output": *output})
 			return nil
+		},
+		IsFatalError: func(err error) bool {
+			if errors.As(err, &ApplicationNotFoundError) ||
+				errors.As(err, &StorageNotFoundError) ||
+				errors.As(err, &RetryReadError) ||
+				strings.Contains(err.Error(), "connection refused") {
+				return false
+			}
+			return true
 		},
 		NotifyFunc: func(err error, attempt int) {
 			if attempt%4 == 0 {
@@ -874,8 +885,7 @@ func (c applicationsClient) ReadApplication(input *ReadApplicationInput) (*ReadA
 
 	apps, err := applicationAPIClient.ApplicationsInfo([]names.ApplicationTag{names.NewApplicationTag(input.AppName)})
 	if err != nil {
-		c.Errorf(err, "found when querying the applications info")
-		return nil, err
+		return nil, jujuerrors.Annotate(err, "when querying the applications info")
 	}
 	if len(apps) > 1 {
 		return nil, fmt.Errorf("more than one result for application: %s", input.AppName)

--- a/internal/provider/resource_application_test.go
+++ b/internal/provider/resource_application_test.go
@@ -575,7 +575,7 @@ func TestAcc_ResourceApplication_UpdateEndpointBindings(t *testing.T) {
 	})
 }
 
-func TestAcc_ResourceApplication_Storage(t *testing.T) {
+func TestAcc_ResourceApplication_StorageLXD(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
@@ -589,7 +589,7 @@ func TestAcc_ResourceApplication_Storage(t *testing.T) {
 		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceApplicationStorage(modelName, appName, storageConstraints),
+				Config: testAccResourceApplicationStorageLXD(modelName, appName, storageConstraints),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("juju_application."+appName, "model", modelName),
 					resource.TestCheckResourceAttr("juju_application."+appName, "storage_directives.runner", "2G"),
@@ -597,6 +597,34 @@ func TestAcc_ResourceApplication_Storage(t *testing.T) {
 					resource.TestCheckResourceAttr("juju_application."+appName, "storage.0.count", "1"),
 					resource.TestCheckResourceAttr("juju_application."+appName, "storage.0.size", "2G"),
 					resource.TestCheckResourceAttr("juju_application."+appName, "storage.0.pool", "lxd"),
+				),
+			},
+		},
+	})
+}
+
+func TestAcc_ResourceApplication_StorageK8s(t *testing.T) {
+	if testingCloud != MicroK8sTesting {
+		t.Skip(t.Name() + " only runs with Microk8s")
+	}
+	modelName := acctest.RandomWithPrefix("tf-test-application-storage")
+	appName := "test-app-storage"
+
+	storageConstraints := map[string]string{"label": "pgdata", "size": "2G"}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: frameworkProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceApplicationStorageK8s(modelName, appName, storageConstraints),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("juju_application."+appName, "model", modelName),
+					resource.TestCheckResourceAttr("juju_application."+appName, "storage_directives.pgdata", "2G"),
+					resource.TestCheckResourceAttr("juju_application."+appName, "storage.0.label", "pgdata"),
+					resource.TestCheckResourceAttr("juju_application."+appName, "storage.0.count", "1"),
+					resource.TestCheckResourceAttr("juju_application."+appName, "storage.0.size", "2G"),
+					resource.TestCheckResourceAttr("juju_application."+appName, "storage.0.pool", "kubernetes"),
 				),
 			},
 		},
@@ -950,7 +978,7 @@ resource "juju_application" "{{.AppName}}" {
 	})
 }
 
-func testAccResourceApplicationStorage(modelName, appName string, storageConstraints map[string]string) string {
+func testAccResourceApplicationStorageLXD(modelName, appName string, storageConstraints map[string]string) string {
 	return internaltesting.GetStringFromTemplateWithData("testAccResourceApplicationStorage", `
 resource "juju_model" "{{.ModelName}}" {
   name = "{{.ModelName}}"
@@ -963,6 +991,33 @@ resource "juju_application" "{{.AppName}}" {
     name = "github-runner"
     channel = "latest/stable"
     revision = 177
+  }
+
+  storage_directives = {
+    {{.StorageConstraints.label}} = "{{.StorageConstraints.size}}"
+  }
+
+  units = 1
+}
+`, internaltesting.TemplateData{
+		"ModelName":          modelName,
+		"AppName":            appName,
+		"StorageConstraints": storageConstraints,
+	})
+}
+
+func testAccResourceApplicationStorageK8s(modelName, appName string, storageConstraints map[string]string) string {
+	return internaltesting.GetStringFromTemplateWithData("testAccResourceApplicationStorage", `
+resource "juju_model" "{{.ModelName}}" {
+  name = "{{.ModelName}}"
+}
+
+resource "juju_application" "{{.AppName}}" {
+  model = juju_model.{{.ModelName}}.name
+  name = "{{.AppName}}"
+  charm {
+    name = "postgresql-k8s"
+    channel = "14/stable"
   }
 
   storage_directives = {


### PR DESCRIPTION
## Description

This PR ensures that the application correctly handles storage conversion errors and retries appropriately until the storage is ready.

- Added error handling for "cannot convert storage details" in `applicationsClient.ReadApplication`.
- Improved retry logic for storage readiness in `ReadApplicationWithRetryOnNotFound`.

Add a fatal error check to the retry logic around reading an application. Fail if ApplicationsInfo fails in a way other than expected. See a "connection refused" error, which is intermittent, so allow for retry in that case.

Fixes: #520 

## Type of change

- Change in tests (one or several tests have been changed)
- Bug fix (non-breaking change which fixes an issue)

## QA steps

Also run reproduction steps from bug.

```tf
terraform {
  required_providers {
    juju = {
      source  = "juju/juju"
      version = "0.14.0"
    }
  }
}
provider "juju" {}

resource "juju_model" "sunbeam" {
  name = var.model

  cloud {
    name   = var.cloud
    region = "localhost"
  }

  config = var.config
}

resource "juju_application" "mysql" {
  name  = "mysql"
  trust = true
  model = juju_model.sunbeam.name

  charm {
    name    = "mysql-k8s"
    channel = "8.0/stable"
    base    = "ubuntu@22.04"
  }

  storage_directives = { database = "1G" }
}

resource "juju_application" "mysql1" {
  name  = "mysql1"
  trust = true
  model = juju_model.sunbeam.name

  charm {
    name    = "mysql-k8s"
    channel = "8.0/stable"
    base    = "ubuntu@22.04"
  }

  storage_directives = { database = "1G" }
}

resource "juju_application" "mysql2" {
  name  = "mysql2"
  trust = true
  model = juju_model.sunbeam.name

  charm {
    name    = "mysql-k8s"
    channel = "8.0/stable"
    base    = "ubuntu@22.04"
  }

  storage_directives = { database = "1G" }
}

resource "juju_application" "mysql3" {
  name  = "mysql3"
  trust = true
  model = juju_model.sunbeam.name

  charm {
    name    = "mysql-k8s"
    channel = "8.0/stable"
    base    = "ubuntu@22.04"
  }

  storage_directives = { database = "1G" }
}

resource "juju_application" "mysql4" {
  name  = "mysql4"
  trust = true
  model = juju_model.sunbeam.name

  charm {
    name    = "mysql-k8s"
    channel = "8.0/stable"
    base    = "ubuntu@22.04"
  }

  storage_directives = { database = "1G" }
}

resource "juju_application" "mysql5" {
  name  = "mysql5"
  trust = true
  model = juju_model.sunbeam.name

  charm {
    name    = "mysql-k8s"
    channel = "8.0/stable"
    base    = "ubuntu@22.04"
  }

  storage_directives = { database = "1G" }
}

resource "juju_application" "mysql6" {
  name  = "mysql6"
  trust = true
  model = juju_model.sunbeam.name

  charm {
    name    = "mysql-k8s"
    channel = "8.0/stable"
    base    = "ubuntu@22.04"
  }

  storage_directives = { database = "1G" }
}

resource "juju_application" "mysql7" {
  name  = "mysql7"
  trust = true
  model = juju_model.sunbeam.name

  charm {
    name    = "mysql-k8s"
    channel = "8.0/stable"
    base    = "ubuntu@22.04"
  }

  storage_directives = { database = "1G" }
}

resource "juju_application" "mysql8" {
  name  = "mysql8"
  trust = true
  model = juju_model.sunbeam.name

  charm {
    name    = "mysql-k8s"
    channel = "8.0/stable"
    base    = "ubuntu@22.04"
  }

  storage_directives = { database = "1G" }
}

variable "model" {
  description = "Name of Juju model to use for deployment"
  default     = "sunbeam"
}

variable "cloud" {
  description = "Name of K8S cloud to use for deployment"
  default     = "microk8s"
}

variable "config" {
  description = "Set configuration on model"
  default     = { "workload-storage" : "microk8s-hostpath" }
}
```

```
rm -rf .terraform* && rm -rf terraform*

terraform init -upgrade  && terraform plan && terraform apply -auto-approve -parallelism=3
```
