### PR TITLE
fix(github): fix goreleaser configuration to comply with version 2

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -62,4 +62,5 @@ release:
   # If you want to manually examine the release before its live, uncomment this line:
   draft: true
 changelog:
-  skip: true
+  disable: true
+version: 2

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,13 +23,10 @@ builds:
     - darwin
   goarch:
     - amd64
-    # TODO: the following are disabled due to => juju/lru maxLRUSize (untyped int constant 4294967295) overflows int
-    # - '386'
-    # - arm
     - arm64
   ignore:
     - goos: darwin
-      goarch: '386'
+      goarch: 'arm64'
     # TODO: disabled => juju/utils symlink_windows.go:54:8: undefined: createSymbolicLink
     - goos: windows
       goarch: arm64


### PR DESCRIPTION
## Description

It looks like a while ago dependabot changed the `uses: goreleaser/goreleaser-action@v5` -> `uses: goreleaser/goreleaser-action@v6`, which apparently uses `goreleaser v2`. And because of that the [release github action is failing](https://github.com/juju/terraform-provider-juju/actions/runs/10045178942) on the `v0.13.0` release.

This updates the goreleaser configuration based on the [deprecation notices for v2](https://goreleaser.com/deprecations/).

Basically the main change is the [changelog skip](https://goreleaser.com/deprecations/#changelogskip).

## Type of change

- Maintenance work (repository related, like Github actions, or revving the Go version, etc.)

## QA steps

Manual QA steps should be done to test this PR.

```
 $ snap install goreleaser --classic
 $ goreleaser check
```
