### PR TITLE
chore(makefile): create check makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,5 +101,4 @@ install-snap-dependencies: check-snap-package
 install-dependencies: install-snap-dependencies
 ## install-dependencies: Install all the dependencies
 
-
-
+check: juju-unit-test


### PR DESCRIPTION
## Description

The check target is a special target used in our CI.

This should allow our default Jenkins jobs to correctly run our unit tests and merge

## Type of change

- Change in tests (one or several tests have been changed)
- Maintenance work (repository related, like Github actions, or revving the Go version, etc.)

## QA steps

commenting `/build` or `/merge` correctly trigger jenkins jobs
