### PR TITLE
fix(storagedirective): fix storage directive validator

### DIFF
--- a/internal/provider/validator_storagedirective.go
+++ b/internal/provider/validator_storagedirective.go
@@ -31,6 +31,9 @@ func (v stringIsStorageDirectiveValidator) ValidateMap(ctx context.Context, req 
 	}
 
 	// If the value of any element is unknown or null, there is nothing to validate.
+	// Note tha the method is called twice by terraform. The first time it is called with
+	// unknown values, and the second time with known values.
+	// If the behavior changes, there is no need to validate all the values.
 	for _, element := range req.ConfigValue.Elements() {
 		if element.IsUnknown() || element.IsNull() {
 			return


### PR DESCRIPTION
## Description

This fix add the following: 
- Add validation logic to check for unknown or null values in the map elements.
- Parse and validate storage directives using `juju/storage` package (use `jujustorage` name instead `storage`).

Fixes: #534 

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## Environment

- Juju controller version: 

- Terraform version: 

## QA steps

```tf
terraform {
  required_providers {
    juju = {
      source  = "juju/juju"
      version = "0.14.0"
    }
  }
}
provider "juju" {}

resource "juju_model" "tf-test" {
  name = "tf-test"
}

variable "blocksize"{
  type    = string
  default = "101M"
}

variable "filessize"{
  type    = string
  default = "102M"
}

variable "pgstorages" {
  type = map
  default = {
    "files"  = "2G"
  }
}

resource "juju_application" "test-app-storage" {
  model = juju_model.tf-test.name
  name = "test-app-storage"
  charm {
    name = "ubuntu"
    channel = "latest/stable"
    revision = 24
  }

  # storage_directives = var.pgstorages
  storage_directives = {
    files = var.filessize
    block = var.blocksize
  }

  units = 1
}
...
```

