### PR TITLE
feat: add jaas validators

### DIFF
--- a/internal/juju/client.go
+++ b/internal/juju/client.go
@@ -49,6 +49,14 @@ type Client struct {
 	SSHKeys      sshKeysClient
 	Users        usersClient
 	Secrets      secretsClient
+
+	isJAAS func() bool
+}
+
+// IsJAAS returns a boolean to indicate whether the controller configured is a JAAS controller.
+// JAAS controllers offer additional functionality for permission management.
+func (c Client) IsJAAS() bool {
+	return c.isJAAS()
 }
 
 type jujuModel struct {
@@ -82,6 +90,12 @@ func NewClient(ctx context.Context, config ControllerConfiguration) (*Client, er
 		modelUUIDcache:   make(map[string]jujuModel),
 		subCtx:           tflog.NewSubsystem(ctx, LogJujuClient),
 	}
+	// Client ID and secret are only set when connecting to JAAS. Use this as a fallback
+	// value if connecting to the controller fails.
+	defaultJAASCheck := false
+	if config.ClientID != "" && config.ClientSecret != "" {
+		defaultJAASCheck = true
+	}
 
 	return &Client{
 		Applications: *newApplicationClient(sc),
@@ -93,7 +107,30 @@ func NewClient(ctx context.Context, config ControllerConfiguration) (*Client, er
 		SSHKeys:      *newSSHKeysClient(sc),
 		Users:        *newUsersClient(sc),
 		Secrets:      *newSecretsClient(sc),
+		isJAAS:       func() bool { return sc.IsJAAS(defaultJAASCheck) },
 	}, nil
+}
+
+var checkJAASOnce sync.Once
+var isJAAS bool
+
+// IsJAAS checks if the controller is a JAAS controller.
+// It does this by checking whether it offers the "JIMM" facade which
+// will only ever be offered by JAAS. The method accepts a default value
+// and doesn't return an error because callers are not expected to fail if
+// they can't determine whether they are connecting to JAAS.
+//
+// IsJAAS uses a synchronisation object to only perform the check once and return the same result.
+func (sc *sharedClient) IsJAAS(defaultVal bool) bool {
+	checkJAASOnce.Do(func() {
+		conn, err := sc.GetConnection(nil)
+		if err != nil {
+			isJAAS = defaultVal
+			return
+		}
+		isJAAS = conn.BestFacadeVersion("JIMM") != 0
+	})
+	return isJAAS
 }
 
 // GetConnection returns a juju connection for use creating juju

--- a/internal/juju/client.go
+++ b/internal/juju/client.go
@@ -128,6 +128,7 @@ func (sc *sharedClient) IsJAAS(defaultVal bool) bool {
 			isJAAS = defaultVal
 			return
 		}
+		defer conn.Close()
 		isJAAS = conn.BestFacadeVersion("JIMM") != 0
 	})
 	return isJAAS

--- a/internal/provider/validator_avoid_jaas.go
+++ b/internal/provider/validator_avoid_jaas.go
@@ -1,0 +1,65 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the Apache License, Version 2.0, see LICENCE file for details.
+
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/juju/terraform-provider-juju/internal/juju"
+)
+
+var _ datasource.ConfigValidator = &AvoidJAASValidator{}
+var _ provider.ConfigValidator = &AvoidJAASValidator{}
+var _ resource.ConfigValidator = &AvoidJAASValidator{}
+
+// AvoidJAASValidator enforces that the resource is not used with JAAS.
+// Useful to direct users to more capable resources.
+type AvoidJAASValidator struct {
+	Client          *juju.Client
+	PreferredObject string
+}
+
+func (v AvoidJAASValidator) Description(ctx context.Context) string {
+	return v.MarkdownDescription(ctx)
+}
+
+func (v AvoidJAASValidator) MarkdownDescription(_ context.Context) string {
+	return "Enforces that this resource should not be used with JAAS"
+}
+
+func (v AvoidJAASValidator) ValidateDataSource(ctx context.Context, req datasource.ValidateConfigRequest, resp *datasource.ValidateConfigResponse) {
+	resp.Diagnostics = v.Validate(ctx, req.Config)
+}
+
+func (v AvoidJAASValidator) ValidateProvider(ctx context.Context, req provider.ValidateConfigRequest, resp *provider.ValidateConfigResponse) {
+	resp.Diagnostics = v.Validate(ctx, req.Config)
+}
+
+func (v AvoidJAASValidator) ValidateResource(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	resp.Diagnostics = v.Validate(ctx, req.Config)
+}
+
+func (v AvoidJAASValidator) Validate(ctx context.Context, config tfsdk.Config) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	if v.Client != nil {
+		if v.Client.IsJAAS() {
+			hint := ""
+			if v.PreferredObject != "" {
+				hint = "Try the " + v.PreferredObject + " resource instead."
+			}
+			diags.AddWarning("Invalid use of resource with JAAS.",
+				"It is not supported to use this resource with a JAAS setup. "+
+					hint+
+					"JAAS offers additional enterprise features through the use of dedicated resources. "+
+					"See the provider documentation for more details.")
+		}
+	}
+	return diags
+}

--- a/internal/provider/validator_avoid_jaas.go
+++ b/internal/provider/validator_avoid_jaas.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+
 	"github.com/juju/terraform-provider-juju/internal/juju"
 )
 
@@ -35,28 +35,30 @@ func (v AvoidJAASValidator) MarkdownDescription(_ context.Context) string {
 
 // ValidateResource performs the validation on the data source.
 func (v AvoidJAASValidator) ValidateDataSource(ctx context.Context, req datasource.ValidateConfigRequest, resp *datasource.ValidateConfigResponse) {
-	resp.Diagnostics = v.Validate(ctx, req.Config)
+	resp.Diagnostics = v.validate()
 }
 
 // ValidateResource performs the validation on the resource.
 func (v AvoidJAASValidator) ValidateResource(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
-	resp.Diagnostics = v.Validate(ctx, req.Config)
+	resp.Diagnostics = v.validate()
 }
 
-// Validate runs the main validation logic of the validator, reading configuration data out of `config` and returning with diagnostics.
-func (v AvoidJAASValidator) Validate(ctx context.Context, config tfsdk.Config) diag.Diagnostics {
+// validate runs the main validation logic of the validator, reading configuration data out of `config` and returning with diagnostics.
+func (v AvoidJAASValidator) validate() diag.Diagnostics {
 	var diags diag.Diagnostics
 
+	// Return without error if a nil client is detected.
+	// This is possible since validation is called at various points throughout resource creation.
 	if v.Client != nil && v.Client.IsJAAS() {
 		hint := ""
 		if v.PreferredObject != "" {
 			hint = "Try the " + v.PreferredObject + " resource instead."
 		}
 		diags.AddError("Invalid use of resource with JAAS.",
-			"It is not supported to use this resource with a JAAS setup. "+
+			"This resource is not supported with JAAS. "+
 				hint+
 				"JAAS offers additional enterprise features through the use of dedicated resources. "+
-				"See the provider documentation for more details.")
+				"See https://jaas.ai/ for more details.")
 	}
 	return diags
 }

--- a/internal/provider/validator_avoid_jaas.go
+++ b/internal/provider/validator_avoid_jaas.go
@@ -8,14 +8,12 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/juju/terraform-provider-juju/internal/juju"
 )
 
 var _ datasource.ConfigValidator = &AvoidJAASValidator{}
-var _ provider.ConfigValidator = &AvoidJAASValidator{}
 var _ resource.ConfigValidator = &AvoidJAASValidator{}
 
 // AvoidJAASValidator enforces that the resource is not used with JAAS.
@@ -25,41 +23,40 @@ type AvoidJAASValidator struct {
 	PreferredObject string
 }
 
+// Description returns a plain text description of the validator's behavior, suitable for a practitioner to understand its impact.
 func (v AvoidJAASValidator) Description(ctx context.Context) string {
 	return v.MarkdownDescription(ctx)
 }
 
+// MarkdownDescription returns a markdown formatted description of the validator's behavior, suitable for a practitioner to understand its impact.
 func (v AvoidJAASValidator) MarkdownDescription(_ context.Context) string {
 	return "Enforces that this resource should not be used with JAAS"
 }
 
+// ValidateResource performs the validation on the data source.
 func (v AvoidJAASValidator) ValidateDataSource(ctx context.Context, req datasource.ValidateConfigRequest, resp *datasource.ValidateConfigResponse) {
 	resp.Diagnostics = v.Validate(ctx, req.Config)
 }
 
-func (v AvoidJAASValidator) ValidateProvider(ctx context.Context, req provider.ValidateConfigRequest, resp *provider.ValidateConfigResponse) {
-	resp.Diagnostics = v.Validate(ctx, req.Config)
-}
-
+// ValidateResource performs the validation on the resource.
 func (v AvoidJAASValidator) ValidateResource(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
 	resp.Diagnostics = v.Validate(ctx, req.Config)
 }
 
+// Validate runs the main validation logic of the validator, reading configuration data out of `config` and returning with diagnostics.
 func (v AvoidJAASValidator) Validate(ctx context.Context, config tfsdk.Config) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	if v.Client != nil {
-		if v.Client.IsJAAS() {
-			hint := ""
-			if v.PreferredObject != "" {
-				hint = "Try the " + v.PreferredObject + " resource instead."
-			}
-			diags.AddWarning("Invalid use of resource with JAAS.",
-				"It is not supported to use this resource with a JAAS setup. "+
-					hint+
-					"JAAS offers additional enterprise features through the use of dedicated resources. "+
-					"See the provider documentation for more details.")
+	if v.Client != nil && v.Client.IsJAAS() {
+		hint := ""
+		if v.PreferredObject != "" {
+			hint = "Try the " + v.PreferredObject + " resource instead."
 		}
+		diags.AddError("Invalid use of resource with JAAS.",
+			"It is not supported to use this resource with a JAAS setup. "+
+				hint+
+				"JAAS offers additional enterprise features through the use of dedicated resources. "+
+				"See the provider documentation for more details.")
 	}
 	return diags
 }

--- a/internal/provider/validator_require_jaas.go
+++ b/internal/provider/validator_require_jaas.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+
 	"github.com/juju/terraform-provider-juju/internal/juju"
 )
 
@@ -26,28 +26,30 @@ func (v RequiresJAASValidator) Description(ctx context.Context) string {
 	return v.MarkdownDescription(ctx)
 }
 
-// // MarkdownDescription returns a markdown formatted description of the validator's behavior, suitable for a practitioner to understand its impact.
+// MarkdownDescription returns a markdown formatted description of the validator's behavior, suitable for a practitioner to understand its impact.
 func (v RequiresJAASValidator) MarkdownDescription(_ context.Context) string {
 	return "Enforces that this resource can only be used with JAAS"
 }
 
 // ValidateResource performs the validation on the data source.
 func (v RequiresJAASValidator) ValidateDataSource(ctx context.Context, req datasource.ValidateConfigRequest, resp *datasource.ValidateConfigResponse) {
-	resp.Diagnostics = v.Validate(ctx, req.Config)
+	resp.Diagnostics = v.validate()
 }
 
 // ValidateResource performs the validation on the resource.
 func (v RequiresJAASValidator) ValidateResource(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
-	resp.Diagnostics = v.Validate(ctx, req.Config)
+	resp.Diagnostics = v.validate()
 }
 
-// Validate runs the main validation logic of the validator, reading configuration data out of `config` and returning with diagnostics.
-func (v RequiresJAASValidator) Validate(ctx context.Context, config tfsdk.Config) diag.Diagnostics {
+// validate runs the main validation logic of the validator, reading configuration data out of `config` and returning with diagnostics.
+func (v RequiresJAASValidator) validate() diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	if v.Client != nil && v.Client.IsJAAS() {
+	// Return without error if a nil client is detected.
+	// This is possible since validation is called at various points throughout resource creation.
+	if v.Client != nil && !v.Client.IsJAAS() {
 		diags.AddError("Attempted use of resource without JAAS.",
-			"This resource can only be used with a JAAS setup offering additional enterprise features - see https://jaas.ai/ for more details.")
+			"This resource can only be used with JAAS, which offers additional enterprise features - see https://jaas.ai/ for more details.")
 	}
 
 	return diags

--- a/internal/provider/validator_require_jaas.go
+++ b/internal/provider/validator_require_jaas.go
@@ -8,14 +8,12 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/juju/terraform-provider-juju/internal/juju"
 )
 
 var _ datasource.ConfigValidator = &RequiresJAASValidator{}
-var _ provider.ConfigValidator = &RequiresJAASValidator{}
 var _ resource.ConfigValidator = &RequiresJAASValidator{}
 
 // RequiresJAASValidator enforces that the resource can only be used with JAAS.
@@ -23,34 +21,33 @@ type RequiresJAASValidator struct {
 	Client *juju.Client
 }
 
+// Description returns a plain text description of the validator's behavior, suitable for a practitioner to understand its impact.
 func (v RequiresJAASValidator) Description(ctx context.Context) string {
 	return v.MarkdownDescription(ctx)
 }
 
+// // MarkdownDescription returns a markdown formatted description of the validator's behavior, suitable for a practitioner to understand its impact.
 func (v RequiresJAASValidator) MarkdownDescription(_ context.Context) string {
 	return "Enforces that this resource can only be used with JAAS"
 }
 
+// ValidateResource performs the validation on the data source.
 func (v RequiresJAASValidator) ValidateDataSource(ctx context.Context, req datasource.ValidateConfigRequest, resp *datasource.ValidateConfigResponse) {
 	resp.Diagnostics = v.Validate(ctx, req.Config)
 }
 
-func (v RequiresJAASValidator) ValidateProvider(ctx context.Context, req provider.ValidateConfigRequest, resp *provider.ValidateConfigResponse) {
-	resp.Diagnostics = v.Validate(ctx, req.Config)
-}
-
+// ValidateResource performs the validation on the resource.
 func (v RequiresJAASValidator) ValidateResource(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
 	resp.Diagnostics = v.Validate(ctx, req.Config)
 }
 
+// Validate runs the main validation logic of the validator, reading configuration data out of `config` and returning with diagnostics.
 func (v RequiresJAASValidator) Validate(ctx context.Context, config tfsdk.Config) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	if v.Client != nil {
-		if v.Client.IsJAAS() {
-			diags.AddError("Attempted use of resource without JAAS.",
-				"This resource can only be used with a JAAS setup offering additional enterprise features - see https://jaas.ai/ for more details.")
-		}
+	if v.Client != nil && v.Client.IsJAAS() {
+		diags.AddError("Attempted use of resource without JAAS.",
+			"This resource can only be used with a JAAS setup offering additional enterprise features - see https://jaas.ai/ for more details.")
 	}
 
 	return diags

--- a/internal/provider/validator_require_jaas.go
+++ b/internal/provider/validator_require_jaas.go
@@ -1,0 +1,57 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the Apache License, Version 2.0, see LICENCE file for details.
+
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/juju/terraform-provider-juju/internal/juju"
+)
+
+var _ datasource.ConfigValidator = &RequiresJAASValidator{}
+var _ provider.ConfigValidator = &RequiresJAASValidator{}
+var _ resource.ConfigValidator = &RequiresJAASValidator{}
+
+// RequiresJAASValidator enforces that the resource can only be used with JAAS.
+type RequiresJAASValidator struct {
+	Client *juju.Client
+}
+
+func (v RequiresJAASValidator) Description(ctx context.Context) string {
+	return v.MarkdownDescription(ctx)
+}
+
+func (v RequiresJAASValidator) MarkdownDescription(_ context.Context) string {
+	return "Enforces that this resource can only be used with JAAS"
+}
+
+func (v RequiresJAASValidator) ValidateDataSource(ctx context.Context, req datasource.ValidateConfigRequest, resp *datasource.ValidateConfigResponse) {
+	resp.Diagnostics = v.Validate(ctx, req.Config)
+}
+
+func (v RequiresJAASValidator) ValidateProvider(ctx context.Context, req provider.ValidateConfigRequest, resp *provider.ValidateConfigResponse) {
+	resp.Diagnostics = v.Validate(ctx, req.Config)
+}
+
+func (v RequiresJAASValidator) ValidateResource(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	resp.Diagnostics = v.Validate(ctx, req.Config)
+}
+
+func (v RequiresJAASValidator) Validate(ctx context.Context, config tfsdk.Config) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	if v.Client != nil {
+		if v.Client.IsJAAS() {
+			diags.AddError("Attempted use of resource without JAAS.",
+				"This resource can only be used with a JAAS setup offering additional enterprise features - see https://jaas.ai/ for more details.")
+		}
+	}
+
+	return diags
+}


### PR DESCRIPTION

## Description

This PR adds two new validators related to JAAS.
1. `AvoidJAASValidator` in validator_avoid_jaas.go - This validator can be used to ensure a resource is **not** used with JAAS. E.g. juju_access_model should not be used with JAAS as there is a JAAS specific type for that.
2. `RequiresJAASValidator` in validator_require_jaas.go - This validator can be used to ensure a resource is **only** used with JAAS. For example, new JAAS specific resources should not be used when communicating with a regular Juju controller.

The output error messages require input from a technical author.

## Type of change

- Other: Adds new validator.

## Additional notes

https://warthogs.atlassian.net/browse/CSS-9768
