### PR TITLE
test: version updates in GitHub actions.

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -35,7 +35,7 @@ jobs:
       fail-fast: false
       matrix:
         terraform:
-          - "1.8.*"
+          - "1.9.*"
         include:
           - cloud: "lxd"
             cloud-channel: "5.19/stable"

--- a/.github/workflows/k8s_tunnel.yml
+++ b/.github/workflows/k8s_tunnel.yml
@@ -44,7 +44,7 @@ jobs:
         cloud:
           - "microk8s"
         terraform:
-          - "1.8.*"
+          - "1.9.*"
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test_add_machine.yml
+++ b/.github/workflows/test_add_machine.yml
@@ -49,7 +49,7 @@ jobs:
         cloud:
           - "lxd"
         terraform:
-          - "1.8.*"
+          - "1.9.*"
         juju:
           - "2.9/stable"
           - "3/stable"

--- a/.github/workflows/test_integration.yml
+++ b/.github/workflows/test_integration.yml
@@ -47,10 +47,10 @@ jobs:
       matrix:
         terraform: ["1.6.*", "1.7.*", "1.8.*"]
         action-operator:
-          - { lxd-channel: "5.19/stable", cloud: "lxd", cloud-channel: "5.19", juju: "2.9" }
-          - { lxd-channel: "5.19/stable", cloud: "lxd", cloud-channel: "5.19", juju: "3" }
-          - { lxd-channel: "5.19/stable", cloud: "microk8s", cloud-channel: "1.28", juju: "2.9" }
-          - { lxd-channel: "5.19/stable", cloud: "microk8s", cloud-channel: "1.28-strict", juju: "3" }
+          - { lxd-channel: "5.21/stable", cloud: "lxd", cloud-channel: "5.21", juju: "2.9" }
+          - { lxd-channel: "5.21/stable", cloud: "lxd", cloud-channel: "5.21", juju: "3" }
+          - { lxd-channel: "5.21/stable", cloud: "microk8s", cloud-channel: "1.28-strict", juju: "3.1" }
+          - { lxd-channel: "5.21/stable", cloud: "microk8s", cloud-channel: "1.28-strict", juju: "3" }
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test_integration.yml
+++ b/.github/workflows/test_integration.yml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        terraform: ["1.6.*", "1.7.*", "1.8.*"]
+        terraform: ["1.7.*", "1.8.*", "1.9.*"]
         action-operator:
           - { lxd-channel: "5.21/stable", cloud: "lxd", cloud-channel: "5.21", juju: "2.9" }
           - { lxd-channel: "5.21/stable", cloud: "lxd", cloud-channel: "5.21", juju: "3" }


### PR DESCRIPTION
- Charms we need to test with microk8s do not support juju2.9, thus test against juju 3.1 for legacy code paths with microk8s.
- Update to use terraform version 1.9 rather than 1.8. For integration tests use the latest 3 versions.

