### PR TITLE
chore(constraints): constraints are not computed

### DIFF
--- a/internal/provider/resource_application.go
+++ b/internal/provider/resource_application.go
@@ -162,8 +162,6 @@ func (r *applicationResource) Schema(_ context.Context, _ resource.SchemaRequest
 			"constraints": schema.StringAttribute{
 				Description: "Constraints imposed on this application.",
 				Optional:    true,
-				// Set as "computed" to pre-populate and preserve any implicit constraints
-				Computed: true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplaceIfConfigured(),
 					stringplanmodifier.UseStateForUnknown(),


### PR DESCRIPTION
## Description

Fixes: https://github.com/juju/terraform-provider-juju/issues/466

This is one of n proposed solutions to the below bug.

Juju does not distinguish between null constraints and empty string constraints. However, terraform does not consider null to be a computed value, but it does the empty string.

This means that on the occasion we end up with a null value for constraint (such as the import of a subordinate application), on next apply we will erroneously attempt to compute the constraints by setting them.

This leads to failures when updating imported subordinate applications, since we cannot set constraints for subordinates.

Removing the computed flag from constraints informs terraform that null valued constraints are valid and do not need to be computed.

## Type of change

- Change existing resource
- Bug fix (non-breaking change which fixes an issue)

## Environment

- Juju controller version: 3.4.5

- Terraform version: v1.9.5

## QA steps

Manual QA steps should be done to test this PR.

```tf
provider juju {}

resource "juju_application" "telegraf" {
  name  = "telegraf"
  model = "test"

    charm {
    name     = "telegraf"
    revision = 75
  }

  units = 0
}
```

```
$ juju bootstrap lxd
$ juju add-model test

$ juju deploy ubuntu
$ juju deploy telegraf --revision=72 --channel=latest/stable
$ juju relate ubuntu telegraf

# Wait for active/idle status on the two charms

$ terraform init
$ terraform import juju_application.telegraf test:telegraf
$ terraform apply
juju_application.telegraf: Refreshing state... [id=m:telegraf]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # juju_application.telegraf will be updated in-place
  ~ resource "juju_application" "telegraf" {
        id        = "m:telegraf"
        name      = "telegraf"
      + principal = (known after apply)
      + storage   = (known after apply)
        # (4 unchanged attributes hidden)

      ~ charm {
            name     = "telegraf"
          ~ revision = 73 -> 75
            # (3 unchanged attributes hidden)
        }
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

juju_application.telegraf: Modifying... [id=m:telegraf]
juju_application.telegraf: Modifications complete after 1s [id=m:telegraf]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```
^ notice that the apply runs successfully, and `constraints` do not appear as `(known after compute)` 
