### PR TITLE
feat: improve test speed

### DIFF
--- a/internal/provider/data_source_offer_test.go
+++ b/internal/provider/data_source_offer_test.go
@@ -73,7 +73,7 @@ resource "juju_application" "this" {
 	name  = "this"
 
 	charm {
-		name = "postgresql"
+		name = "juju-qa-dummy-source"
 		%s
 	}
 }
@@ -81,7 +81,7 @@ resource "juju_application" "this" {
 resource "juju_offer" "this" {
 	model            = juju_model.this.name
 	application_name = juju_application.this.name
-	endpoint         = "db"
+	endpoint         = "sink"
 	name             = %q
 }
 

--- a/internal/provider/resource_offer_test.go
+++ b/internal/provider/resource_offer_test.go
@@ -37,7 +37,7 @@ func TestAcc_ResourceOffer(t *testing.T) {
 					resource.TestCheckResourceAttr("juju_integration.int", "model", destModelName),
 
 					resource.TestCheckTypeSetElemNestedAttrs("juju_integration.int", "application.*",
-						map[string]string{"name": "apptwo", "endpoint": "db", "offer_url": ""}),
+						map[string]string{"name": "apptwo", "endpoint": "source", "offer_url": ""}),
 
 					resource.TestCheckTypeSetElemNestedAttrs("juju_integration.int", "application.*",
 						map[string]string{"name": "", "endpoint": "", "offer_url": fmt.Sprintf("%v/%v.%v", "admin",
@@ -65,7 +65,7 @@ resource "juju_application" "appone" {
 	name  = "appone"
 
 	charm {
-		name = "postgresql"
+		name = "juju-qa-dummy-source"
 		base = "ubuntu@22.04"
 	}
 }
@@ -73,7 +73,7 @@ resource "juju_application" "appone" {
 resource "juju_offer" "offerone" {
 	model            = juju_model.modelone.name
 	application_name = juju_application.appone.name
-	endpoint         = "db"
+	endpoint         = "sink"
 }
 
 resource "juju_model" "modeldest" {
@@ -85,8 +85,8 @@ resource "juju_application" "apptwo" {
 	name = "apptwo"
 
 	charm {
-		name = "hello-juju"
-		base = "ubuntu@20.04"
+		name = "juju-qa-dummy-sink"
+		base = "ubuntu@22.04"
 	}
 }
 
@@ -95,6 +95,7 @@ resource "juju_integration" "int" {
 
 	application {
 		name = juju_application.apptwo.name
+		endpoint = "source"
 	}
 
 	application {


### PR DESCRIPTION
## Description

This PR aims to improve the speed of several slow tests (tested using LXD, Microk8s specific tests have not been worked on). The current largest offenders are below (tests that takes >= 100s) based on running them locally on my laptop:
```
TestAcc_ResourceOffer (300.84s)
TestAcc_DataSourceOffer (146.42s)
TestAcc_ResourceIntegrationWithMultipleConsumers (298.13s)
TestAcc_ResourceIntegrationWithViaCIDRs (325.72s)
TestAcc_ResourceApplication_UpdatesRevisionConfig (139.34s)
```

The offer based tests are slow because they deploy the postgres charm and the provider then waits for the application storage to be ready which takes a while. Here we can opt to use the `juju-qa-dummy-source` and `juju-qa-dummy-sink` charms since the goal is to test offers rather than the postgres charm and storage (if there is a need to test the postgres charm it would likely be better suited for a separate test).

The second offender for the slow tests was the very lenient code in the client code `offers.go` which would wait up to 5m for an offer's connections to drop to 0. If the connections didn't drop to 0 within these 5 minutes, it would destroy an offer with the `force` flag set to true. I've dropped this to a more aggressive 30s.

## Type of change

- Change in tests (one or several tests have been changed)