### PR TITLE
feat: add variable wait when destroying offers

### DIFF
--- a/.github/workflows/test_integration.yml
+++ b/.github/workflows/test_integration.yml
@@ -79,6 +79,7 @@ jobs:
         run: |
           CONTROLLER=$(juju whoami --format yaml | yq .controller)
 
+          echo "FAST_DESTROY=true" >> $GITHUB_ENV
           echo "JUJU_AGENT_VERSION=$(juju show-controller | yq .$CONTROLLER.details.agent-version |tr -d '"')" >> $GITHUB_ENV
           echo "JUJU_CONTROLLER_ADDRESSES=$(juju show-controller | yq .$CONTROLLER.details.api-endpoints | yq -r '. | join(",")')" >> $GITHUB_ENV
           echo "JUJU_USERNAME=$(juju show-controller | yq .$CONTROLLER.account.user)"  >> $GITHUB_ENV

--- a/internal/juju/offers.go
+++ b/internal/juju/offers.go
@@ -28,6 +28,13 @@ const (
 	OfferApiTickWait = time.Second * 5
 )
 
+var (
+	// OfferWaitUntilForceDestroy decides how long to wait for all connections
+	// on an offer to go away before destroying the offer with force.
+	// Override this from tests to speed things up.
+	OfferWaitUntilForceDestroy = 5 * time.Minute
+)
+
 type offersClient struct {
 	SharedClient
 }
@@ -197,9 +204,9 @@ func (c offersClient) DestroyOffer(input *DestroyOfferInput) error {
 	}
 
 	forceDestroy := false
-	//This code loops until it detects 0 connections in the offer or 3 minutes elapses
+	//This code loops until it detects 0 connections in the offer or a deadline elapses.
 	if len(offer.Connections) > 0 {
-		end := time.Now().Add(5 * time.Minute)
+		end := time.Now().Add(OfferWaitUntilForceDestroy)
 		for ok := true; ok; ok = len(offer.Connections) > 0 {
 			//if we have been failing to destroy offer for 5 minutes then force destroy
 			//TODO: investigate cleaner solution (acceptance tests fail even if timeout set to 20m)

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -23,7 +24,10 @@ import (
 	"github.com/juju/terraform-provider-juju/internal/juju"
 )
 
-const TestProviderStableVersion = "0.13.0"
+const (
+	TestProviderStableVersion = "0.13.0"
+	FastDestroyEnvKey         = "FAST_DESTROY"
+)
 
 // providerFactories are used to instantiate the Framework provider during
 // acceptance testing.
@@ -43,6 +47,13 @@ func init() {
 	frameworkProviderFactories = map[string]func() (tfprotov6.ProviderServer, error){
 		"juju": providerserver.NewProtocol6WithError(NewJujuProvider("dev")),
 	}
+	if _, ok := os.LookupEnv(FastDestroyEnvKey); ok {
+		setupFastDestroy()
+	}
+}
+
+func setupFastDestroy() {
+	juju.OfferWaitUntilForceDestroy = 30 * time.Second
 }
 
 func TestProviderConfigure(t *testing.T) {


### PR DESCRIPTION
## Description

As a follow-up to #560, this PR aims to speed up tests when destroying offers. Instead of changing the hardcoded value of 5 minutes, we opt to use a variable instead.

This variable can be changed from the test init to speed up destroying offers. It is gated behind an environment variable so that tests can still be run with the same behaviour as production if desired.

## Type of change

- Change in tests (one or several tests have been changed)
