### PR TITLE
feat: add "avoid jaas" validator to existing resources

### DIFF
--- a/internal/provider/resource_access_generic.go
+++ b/internal/provider/resource_access_generic.go
@@ -79,7 +79,7 @@ type genericJAASAccessModel struct {
 // ConfigValidators sets validators for the resource.
 func (r *genericJAASAccessResource) ConfigValidators(ctx context.Context) []resource.ConfigValidator {
 	return []resource.ConfigValidator{
-		RequiresJAASValidator{Client: r.client},
+		NewRequiresJAASValidator(r.client),
 		resourcevalidator.AtLeastOneOf(
 			path.MatchRoot("users"),
 			path.MatchRoot("groups"),

--- a/internal/provider/resource_access_jaas_model.go
+++ b/internal/provider/resource_access_jaas_model.go
@@ -20,6 +20,7 @@ import (
 // Ensure provider defined types fully satisfy framework interfaces.
 var _ resource.Resource = &jaasAccessModelResource{}
 var _ resource.ResourceWithConfigure = &jaasAccessModelResource{}
+var _ resource.ResourceWithConfigValidators = &jaasAccessModelResource{}
 
 // NewJAASAccessModelResource returns a new resource for JAAS model access.
 func NewJAASAccessModelResource() resource.Resource {

--- a/internal/provider/resource_access_model.go
+++ b/internal/provider/resource_access_model.go
@@ -52,6 +52,13 @@ func (a *accessModelResource) Metadata(_ context.Context, req resource.MetadataR
 	resp.TypeName = req.ProviderTypeName + "_access_model"
 }
 
+// ConfigValidators sets validators for the resource.
+func (r *accessModelResource) ConfigValidators(ctx context.Context) []resource.ConfigValidator {
+	return []resource.ConfigValidator{
+		NewAvoidJAASValidator(r.client, "juju_jaas_access_model"),
+	}
+}
+
 func (a *accessModelResource) Schema(_ context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Description: "A resource that represent a Juju Access Model.",

--- a/internal/provider/resource_access_model.go
+++ b/internal/provider/resource_access_model.go
@@ -27,6 +27,7 @@ import (
 var _ resource.Resource = &accessModelResource{}
 var _ resource.ResourceWithConfigure = &accessModelResource{}
 var _ resource.ResourceWithImportState = &accessModelResource{}
+var _ resource.ResourceWithConfigValidators = &accessModelResource{}
 
 func NewAccessModelResource() resource.Resource {
 	return &accessModelResource{}

--- a/internal/provider/resource_access_model_test.go
+++ b/internal/provider/resource_access_model_test.go
@@ -106,6 +106,30 @@ func TestAcc_ResourceAccessModel_UpgradeProvider(t *testing.T) {
 	})
 }
 
+func TestAcc_ResourceAccessModel_ErrorWhenUsedWithJAAS(t *testing.T) {
+	OnlyTestAgainstJAAS(t)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: frameworkProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccResourceAccessModelFixedUser(),
+				ExpectError: regexp.MustCompile("This resource is not supported with JAAS"),
+			},
+		},
+	})
+}
+
+func testAccResourceAccessModelFixedUser() string {
+	return `
+resource "juju_access_model" "test" {
+  access = "write"
+  model = "foo"
+  users = ["bob"]
+}`
+}
+
 func testAccResourceAccessModel(userName, userPassword, modelName, access string) string {
 	return fmt.Sprintf(`
 resource "juju_user" "test-user" {

--- a/internal/provider/resource_user.go
+++ b/internal/provider/resource_user.go
@@ -24,6 +24,7 @@ import (
 var _ resource.Resource = &userResource{}
 var _ resource.ResourceWithConfigure = &userResource{}
 var _ resource.ResourceWithImportState = &userResource{}
+var _ resource.ResourceWithConfigValidators = &userResource{}
 
 func NewUserResource() resource.Resource {
 	return &userResource{}

--- a/internal/provider/resource_user.go
+++ b/internal/provider/resource_user.go
@@ -51,6 +51,14 @@ func (r *userResource) Metadata(ctx context.Context, req resource.MetadataReques
 	resp.TypeName = req.ProviderTypeName + "_user"
 }
 
+// ConfigValidators sets validators for the resource.
+func (r *userResource) ConfigValidators(ctx context.Context) []resource.ConfigValidator {
+	return []resource.ConfigValidator{
+		// There is no JAAS object that replaces the user resource since JAAS users come from an external identity provider.
+		NewAvoidJAASValidator(r.client, ""),
+	}
+}
+
 func (r *userResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	// The User resource maps to a juju user that is operated via
 	// `juju add-user`, `juju remove-user`

--- a/internal/provider/resource_user_test.go
+++ b/internal/provider/resource_user_test.go
@@ -5,6 +5,7 @@ package provider
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -26,7 +27,6 @@ func TestAcc_ResourceUser(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", userName),
 				),
-				PreConfig: func() { testAccPreCheck(t) },
 			},
 			{
 				Destroy:                 true,
@@ -74,6 +74,23 @@ func TestAcc_ResourceUser_UpgradeProvider(t *testing.T) {
 				ProtoV6ProviderFactories: frameworkProviderFactories,
 				Config:                   testAccResourceUser(userName, userPassword),
 				PlanOnly:                 true,
+			},
+		},
+	})
+}
+
+func TestAcc_ResourceUser_ErrorWhenUsedWithJAAS(t *testing.T) {
+	OnlyTestAgainstJAAS(t)
+	userName := acctest.RandomWithPrefix("tfuser")
+	userPassword := acctest.RandomWithPrefix("tf-test-user")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: frameworkProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccResourceUser(userName, userPassword),
+				ExpectError: regexp.MustCompile("This resource is not supported with JAAS"),
 			},
 		},
 	})

--- a/internal/provider/validator_require_jaas.go
+++ b/internal/provider/validator_require_jaas.go
@@ -18,7 +18,13 @@ var _ resource.ConfigValidator = &RequiresJAASValidator{}
 
 // RequiresJAASValidator enforces that the resource can only be used with JAAS.
 type RequiresJAASValidator struct {
-	Client *juju.Client
+	client *juju.Client
+}
+
+func NewRequiresJAASValidator(client *juju.Client) RequiresJAASValidator {
+	return RequiresJAASValidator{
+		client: client,
+	}
 }
 
 // Description returns a plain text description of the validator's behavior, suitable for a practitioner to understand its impact.
@@ -47,7 +53,7 @@ func (v RequiresJAASValidator) validate() diag.Diagnostics {
 
 	// Return without error if a nil client is detected.
 	// This is possible since validation is called at various points throughout resource creation.
-	if v.Client != nil && !v.Client.IsJAAS() {
+	if v.client != nil && !v.client.IsJAAS() {
 		diags.AddError("Attempted use of resource without JAAS.",
 			"This resource can only be used with JAAS, which offers additional enterprise features - see https://jaas.ai/ for more details.")
 	}

--- a/internal/provider/validator_require_jaas.go
+++ b/internal/provider/validator_require_jaas.go
@@ -21,6 +21,8 @@ type RequiresJAASValidator struct {
 	client *juju.Client
 }
 
+// NewRequiresJAASValidator returns a new validator that enforces a resource can
+// only be created against JAAS.
 func NewRequiresJAASValidator(client *juju.Client) RequiresJAASValidator {
 	return RequiresJAASValidator{
 		client: client,


### PR DESCRIPTION
## Description

This PR adds "Avoid JAAS" validator to all resources that cannot be used with JAAS. Specifically:
- Ensure certain resources cannot be used with JAAS and add tests for this.
- Tweak the error messaging based on previous feedback in [this discussion](https://github.com/juju/terraform-provider-juju/pull/541#discussion_r1715287183).

Fixes: [CSS-10238](https://warthogs.atlassian.net/browse/CSS-10238)

## Type of change

- Logic changes in resources (additional validation for JAAS)

[CSS-10238]: https://warthogs.atlassian.net/browse/CSS-10238?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ