### PR TITLE
feat: allow querying models owned by other users

### DIFF
--- a/internal/juju/interfaces.go
+++ b/internal/juju/interfaces.go
@@ -23,7 +23,7 @@ import (
 )
 
 type SharedClient interface {
-	AddModel(modelName, modelUUID string, modelType model.ModelType)
+	AddModel(modelName, modelOwner, modelUUID string, modelType model.ModelType)
 	GetConnection(modelName *string) (api.Connection, error)
 	ModelType(modelName string) (model.ModelType, error)
 	ModelUUID(modelName string) (string, error)

--- a/internal/juju/mock_test.go
+++ b/internal/juju/mock_test.go
@@ -54,15 +54,15 @@ func (m *MockSharedClient) EXPECT() *MockSharedClientMockRecorder {
 }
 
 // AddModel mocks base method.
-func (m *MockSharedClient) AddModel(arg0, arg1 string, arg2 model.ModelType) {
+func (m *MockSharedClient) AddModel(arg0, arg1, arg2 string, arg3 model.ModelType) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "AddModel", arg0, arg1, arg2)
+	m.ctrl.Call(m, "AddModel", arg0, arg1, arg2, arg3)
 }
 
 // AddModel indicates an expected call of AddModel.
-func (mr *MockSharedClientMockRecorder) AddModel(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockSharedClientMockRecorder) AddModel(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddModel", reflect.TypeOf((*MockSharedClient)(nil).AddModel), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddModel", reflect.TypeOf((*MockSharedClient)(nil).AddModel), arg0, arg1, arg2, arg3)
 }
 
 // Debugf mocks base method.

--- a/internal/juju/modelcache/cache.go
+++ b/internal/juju/modelcache/cache.go
@@ -1,0 +1,146 @@
+package modelcache
+
+import (
+	"strings"
+	"sync"
+
+	"github.com/juju/errors"
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/core/model"
+)
+
+// ModelLookup contains request parameters to gather info on a model.
+type ModelLookup struct {
+	name  string
+	owner string
+}
+
+// String returns a string representation of a ModelLookup object.
+func (m ModelLookup) String() string {
+	if m.owner == "" {
+		return m.name
+	}
+	return m.owner + "/" + m.name
+}
+
+// NewModelLookup returns a ModelLookup object from a model name.
+// It is expected that the model name is either fully specified
+// as <model-owner>/<model-name> or just <model-name>.
+// Excluding the model owner will influence the behavior of the Lookup function.
+func NewModelLookup(modelName string) ModelLookup {
+	res := strings.Split(modelName, "/")
+	if len(res) == 1 {
+		return ModelLookup{
+			name: res[0],
+		}
+	}
+	return ModelLookup{
+		name:  res[1],
+		owner: res[0],
+	}
+}
+
+// Cache is a model cache that can be used to query for models by UUID or model owner and name.
+type Cache struct {
+	modelsMu sync.Mutex
+	// modelMap is a map from model names to a modelSlice object.
+	// The key represents a model's name and the modelSlice contains
+	// all the models with that name but with unique owners.
+	modelMap map[string]modelSlice
+}
+
+// NewModelCache returns a new cache object.
+func NewModelCache() Cache {
+	return Cache{modelMap: make(map[string]modelSlice)}
+}
+
+// FillCache populates the cache based on the supplied modelSummaries.
+func (m *Cache) FillCache(modelSummaries []base.UserModelSummary) {
+	for _, modelSummary := range modelSummaries {
+		modelInfo := jujuModel{
+			Name:      modelSummary.Name,
+			Owner:     modelSummary.Owner,
+			UUID:      modelSummary.UUID,
+			ModelType: modelSummary.Type,
+		}
+		models := m.modelMap[modelSummary.Name]
+		models.addModel(modelInfo)
+		m.modelMap[modelSummary.Name] = models
+	}
+}
+
+// Lookup retrieves model information based on a ModelLookup object.
+// In the ModelLookup object, the owner can be empty but if multiple models
+// with the same name are found then a NotAssigned error will be returned.
+// If a model is not found then a NotFound error will be returned.
+func (m *Cache) Lookup(lookup ModelLookup) (jujuModel, error) {
+	m.modelsMu.Lock()
+	defer m.modelsMu.Unlock()
+	models, ok := m.modelMap[lookup.name]
+	if !ok {
+		return jujuModel{}, errors.NotFoundf("model %q", lookup)
+	}
+	if len(models.models) == 1 && lookup.owner == "" {
+		return models.models[0], nil
+	}
+	if len(models.models) > 1 && lookup.owner == "" {
+		return jujuModel{}, errors.NotAssignedf("multiple models with name %q found, please specify a model owner", lookup.name)
+	}
+	for _, model := range models.models {
+		if model.Owner == lookup.owner {
+			return model, nil
+		}
+	}
+	return jujuModel{}, errors.NotFoundf("model %q", lookup)
+}
+
+type lookupByUUIDResult struct {
+	modelSlice modelSlice
+	index      int
+	name       string
+}
+
+func (m *Cache) lookupByUUID(uuid string) (lookupByUUIDResult, bool) {
+	for _, models := range m.modelMap {
+		for i, model := range models.models {
+			if model.UUID == uuid {
+				return lookupByUUIDResult{
+					modelSlice: models,
+					index:      i,
+					name:       model.Name,
+				}, true
+			}
+		}
+	}
+	return lookupByUUIDResult{}, false
+}
+
+// RemoveModel removes a model from the cache based on UUID.
+func (m *Cache) RemoveModel(uuid string) {
+	m.modelsMu.Lock()
+	defer m.modelsMu.Unlock()
+	res, ok := m.lookupByUUID(uuid)
+	if !ok {
+		return
+	}
+	res.modelSlice.removeByIndex(res.index)
+	m.modelMap[res.name] = res.modelSlice
+}
+
+// AddModel adds a model to the cache.
+func (m *Cache) AddModel(modelName, modelOwner, modelUUID string, modelType model.ModelType) {
+	m.modelsMu.Lock()
+	defer m.modelsMu.Unlock()
+	_, ok := m.lookupByUUID(modelUUID)
+	if ok {
+		return
+	}
+	models := m.modelMap[modelName]
+	models.addModel(jujuModel{
+		Name:      modelName,
+		Owner:     modelOwner,
+		UUID:      modelUUID,
+		ModelType: modelType,
+	})
+	m.modelMap[modelName] = models
+}

--- a/internal/juju/modelcache/cache.go
+++ b/internal/juju/modelcache/cache.go
@@ -1,3 +1,7 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the Apache License, Version 2.0, see LICENCE file for details.
+
+// modelcache provides a means of caching Juju model information.
 package modelcache
 
 import (

--- a/internal/juju/modelcache/cache_test.go
+++ b/internal/juju/modelcache/cache_test.go
@@ -1,3 +1,6 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the Apache License, Version 2.0, see LICENCE file for details.
+
 package modelcache_test
 
 import (

--- a/internal/juju/modelcache/cache_test.go
+++ b/internal/juju/modelcache/cache_test.go
@@ -1,0 +1,280 @@
+package modelcache_test
+
+import (
+	"testing"
+
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/core/model"
+	"github.com/juju/terraform-provider-juju/internal/juju/modelcache"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestModelLookup(t *testing.T) {
+	lookup := modelcache.NewModelLookup("foo")
+	assert.Equal(t, lookup.String(), "foo")
+	assert.Equal(t, lookup.Name(), "foo")
+	assert.Equal(t, lookup.Owner(), "")
+
+	lookup = modelcache.NewModelLookup("owner/foo")
+	assert.Equal(t, lookup.String(), "owner/foo")
+	assert.Equal(t, lookup.Name(), "foo")
+	assert.Equal(t, lookup.Owner(), "owner")
+}
+
+func TestFillCache(t *testing.T) {
+	testCases := []struct {
+		desc                  string
+		modelSummaries        []base.UserModelSummary
+		expectedMapLength     int
+		expectedModelsPerName map[string]int
+	}{
+		{
+			desc: "Basic fill",
+			modelSummaries: []base.UserModelSummary{
+				{Name: "fox", UUID: "1", Owner: "user-1"},
+				{Name: "wolf", UUID: "2", Owner: "user-2"},
+				{Name: "bird", UUID: "3", Owner: "user-3"},
+			},
+			expectedMapLength: 3,
+			expectedModelsPerName: map[string]int{
+				"fox":  1,
+				"wolf": 1,
+				"bird": 1,
+			},
+		},
+		{
+			desc: "Fill with duplicates",
+			modelSummaries: []base.UserModelSummary{
+				{Name: "fox", UUID: "1", Owner: "user-1"},
+				{Name: "fox", UUID: "1", Owner: "user-1"},
+				{Name: "fox", UUID: "1", Owner: "user-1"},
+			},
+			expectedMapLength: 1,
+			expectedModelsPerName: map[string]int{
+				"fox": 1,
+			},
+		},
+		{
+			desc: "Multiple models with same name but different owner",
+			modelSummaries: []base.UserModelSummary{
+				{Name: "fox", UUID: "1", Owner: "user-1"},
+				{Name: "fox", UUID: "2", Owner: "user-2"},
+				{Name: "fox", UUID: "3", Owner: "user-3"},
+			},
+			expectedMapLength: 1,
+			expectedModelsPerName: map[string]int{
+				"fox": 3,
+			},
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			modelCache := modelcache.NewModelCache()
+			modelCache.FillCache(tC.modelSummaries)
+			assert.Equal(t, tC.expectedMapLength, modelCache.Length())
+			for name, expectedModels := range tC.expectedModelsPerName {
+				assert.Equal(t, expectedModels, modelCache.LengthByName(name))
+			}
+		})
+	}
+}
+
+func TestLookup(t *testing.T) {
+	testCases := []struct {
+		desc          string
+		lookup        modelcache.ModelLookup
+		cacheValues   []base.UserModelSummary
+		expectedModel modelcache.JujuModel
+		expectedError string
+	}{
+		{
+			desc:   "lookup by name only",
+			lookup: modelcache.NewModelLookup("fox"),
+			cacheValues: []base.UserModelSummary{
+				{Name: "fox", UUID: "1", Owner: "user-1", Type: "myType"},
+				{Name: "wolf", UUID: "2", Owner: "user-2"},
+				{Name: "bird", UUID: "3", Owner: "user-3"},
+			},
+			expectedModel: modelcache.JujuModel{
+				Name:      "fox",
+				Owner:     "user-1",
+				UUID:      "1",
+				ModelType: "myType",
+			},
+		},
+		{
+			desc:   "lookup by name and owner",
+			lookup: modelcache.NewModelLookup("user-1/fox"),
+			cacheValues: []base.UserModelSummary{
+				{Name: "fox", UUID: "1", Owner: "user-1", Type: "myType"},
+				{Name: "wolf", UUID: "2", Owner: "user-2"},
+				{Name: "bird", UUID: "3", Owner: "user-3"},
+			},
+			expectedModel: modelcache.JujuModel{
+				Name:      "fox",
+				Owner:     "user-1",
+				UUID:      "1",
+				ModelType: "myType",
+			},
+		},
+		{
+			desc:   "lookup by name when multiple models have the same name",
+			lookup: modelcache.NewModelLookup("fox"),
+			cacheValues: []base.UserModelSummary{
+				{Name: "fox", UUID: "1", Owner: "user-1"},
+				{Name: "fox", UUID: "2", Owner: "user-2"},
+				{Name: "bird", UUID: "3", Owner: "user-3"},
+			},
+			expectedError: `multiple models with name "fox" found, please specify a model owner`,
+		},
+		{
+			desc:   "lookup by name and owner when multiple models have the same name",
+			lookup: modelcache.NewModelLookup("user-2/fox"),
+			cacheValues: []base.UserModelSummary{
+				{Name: "fox", UUID: "1", Owner: "user-1"},
+				{Name: "fox", UUID: "2", Owner: "user-2", Type: "myType"},
+				{Name: "fox", UUID: "3", Owner: "user-3"},
+			},
+			expectedModel: modelcache.JujuModel{
+				Name:      "fox",
+				Owner:     "user-2",
+				UUID:      "2",
+				ModelType: "myType",
+			},
+		},
+		{
+			desc:          "lookup with no values",
+			lookup:        modelcache.NewModelLookup("fox"),
+			cacheValues:   []base.UserModelSummary{},
+			expectedError: "not found",
+		},
+		{
+			desc:   "lookup model that doesn't exist",
+			lookup: modelcache.NewModelLookup("whale"),
+			cacheValues: []base.UserModelSummary{
+				{Name: "fox", UUID: "1", Owner: "user-1"},
+				{Name: "wolf", UUID: "2", Owner: "user-2"},
+				{Name: "bird", UUID: "3", Owner: "user-3"},
+			},
+			expectedError: "not found",
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			cache := modelcache.NewModelCache()
+			cache.FillCache(tC.cacheValues)
+			model, err := cache.Lookup(tC.lookup)
+			if tC.expectedError != "" {
+				assert.ErrorContains(t, err, tC.expectedError)
+			} else {
+				assert.EqualValues(t, model, tC.expectedModel)
+			}
+		})
+	}
+}
+
+func TestRemoveModel2(t *testing.T) {
+	testCases := []struct {
+		desc           string
+		uuidToRemove   string
+		initialvalues  []base.UserModelSummary
+		checkModelName string
+		expectedLens   int
+	}{
+		{
+			desc:         "remove model",
+			uuidToRemove: "2",
+			initialvalues: []base.UserModelSummary{
+				{Name: "fox", UUID: "1", Owner: "user-1"},
+				{Name: "wolf", UUID: "2", Owner: "user-2"},
+				{Name: "bird", UUID: "3", Owner: "user-3"},
+			},
+			checkModelName: "wolf",
+			expectedLens:   0,
+		},
+		{
+			desc:         "remove model when multiple of the same name exist",
+			uuidToRemove: "2",
+			initialvalues: []base.UserModelSummary{
+				{Name: "wolf", UUID: "1", Owner: "user-1"},
+				{Name: "wolf", UUID: "2", Owner: "user-2"},
+				{Name: "wolf", UUID: "3", Owner: "user-3"},
+			},
+			checkModelName: "wolf",
+			expectedLens:   2,
+		},
+		{
+			desc:         "remove model that doesn't exist",
+			uuidToRemove: "10",
+			initialvalues: []base.UserModelSummary{
+				{Name: "wolf", UUID: "1", Owner: "user-1"},
+				{Name: "wolf", UUID: "2", Owner: "user-2"},
+				{Name: "wolf", UUID: "3", Owner: "user-3"},
+			},
+			checkModelName: "wolf",
+			expectedLens:   3,
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			cache := modelcache.NewModelCache()
+			cache.FillCache(tC.initialvalues)
+			cache.RemoveModel(tC.uuidToRemove)
+			assert.Equal(t, tC.expectedLens, cache.LengthByName(tC.checkModelName))
+		})
+	}
+}
+
+func TestAddModel(t *testing.T) {
+	type addModelParams struct {
+		name  string
+		uuid  string
+		mtype string
+		owner string
+	}
+	testCases := []struct {
+		desc          string
+		initialvalues []base.UserModelSummary
+		params        []addModelParams
+		expectedLens  map[string]int
+	}{
+		{
+			desc: "add 1 model",
+			params: []addModelParams{
+				{name: "wolf", uuid: "1", mtype: "myType", owner: "user-1"},
+			},
+			expectedLens: map[string]int{"wolf": 1},
+		},
+		{
+			desc: "add multiple models",
+			params: []addModelParams{
+				{name: "wolf", uuid: "1", mtype: "myType", owner: "user-1"},
+				{name: "wolf", uuid: "2", mtype: "myType", owner: "user-2"},
+				{name: "bird", uuid: "3", mtype: "myType", owner: "user-2"},
+			},
+			expectedLens: map[string]int{"wolf": 2, "bird": 1},
+		},
+		{
+			desc: "add 2 models with the same UUID",
+			params: []addModelParams{
+				{name: "wolf", uuid: "1", mtype: "myType", owner: "user-1"},
+				{name: "wolf-1", uuid: "1", mtype: "myType", owner: "user-2"},
+			},
+			expectedLens: map[string]int{"wolf": 1, "wolf-1": 0},
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			cache := modelcache.NewModelCache()
+			if tC.initialvalues != nil {
+				cache.FillCache(tC.initialvalues)
+			}
+			for _, param := range tC.params {
+				cache.AddModel(param.name, param.owner, param.uuid, model.ModelType(param.mtype))
+			}
+			for name, expectedLen := range tC.expectedLens {
+				assert.Equal(t, expectedLen, cache.LengthByName(name))
+			}
+		})
+	}
+}

--- a/internal/juju/modelcache/export_test.go
+++ b/internal/juju/modelcache/export_test.go
@@ -1,3 +1,6 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the Apache License, Version 2.0, see LICENCE file for details.
+
 package modelcache
 
 type JujuModel jujuModel

--- a/internal/juju/modelcache/export_test.go
+++ b/internal/juju/modelcache/export_test.go
@@ -1,0 +1,23 @@
+package modelcache
+
+type JujuModel jujuModel
+
+func (m ModelLookup) Name() string {
+	return m.name
+}
+
+func (m ModelLookup) Owner() string {
+	return m.owner
+}
+
+func (m *Cache) Length() int {
+	return len(m.modelMap)
+}
+
+func (m *Cache) LengthByName(name string) int {
+	models, ok := m.modelMap[name]
+	if !ok {
+		return 0
+	}
+	return len(models.models)
+}

--- a/internal/juju/modelcache/utilities.go
+++ b/internal/juju/modelcache/utilities.go
@@ -1,0 +1,37 @@
+package modelcache
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/juju/juju/core/model"
+)
+
+type jujuModel struct {
+	Name      string
+	Owner     string
+	UUID      string
+	ModelType model.ModelType
+}
+
+func (j jujuModel) String() string {
+	return fmt.Sprintf("uuid(%s) type(%s)", j.UUID, j.ModelType.String())
+}
+
+type modelSlice struct {
+	models []jujuModel
+}
+
+func (m *modelSlice) removeByIndex(index int) {
+	m.models = slices.Delete(m.models, index, index+1)
+}
+
+func (m *modelSlice) addModel(modelInfo jujuModel) {
+	exists := slices.ContainsFunc(m.models, func(m jujuModel) bool {
+		return m.UUID == modelInfo.UUID
+	})
+	if exists {
+		return
+	}
+	m.models = append(m.models, modelInfo)
+}

--- a/internal/juju/modelcache/utilities.go
+++ b/internal/juju/modelcache/utilities.go
@@ -1,3 +1,6 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the Apache License, Version 2.0, see LICENCE file for details.
+
 package modelcache
 
 import (

--- a/internal/juju/models.go
+++ b/internal/juju/models.go
@@ -176,7 +176,7 @@ func (c *modelsClient) CreateModel(input CreateModelInput) (CreateModelResponse,
 	resp.UUID = modelInfo.UUID
 
 	// Add a model object on the client internal to the provider
-	c.AddModel(modelInfo.Name, modelInfo.UUID, modelInfo.Type)
+	c.AddModel(modelInfo.Name, modelInfo.Owner, modelInfo.UUID, modelInfo.Type)
 
 	// set constraints when required
 	if input.Constraints.String() == "" {


### PR DESCRIPTION
## Description

This PR aims to solve #504 to handle scenarios where a user has access to multiple models with the same name.
Juju namespaces models by username, i.e. user-1 and user-2 can both have a model called "foo". Currently the provider doesn't handle such cases properly.

This PR addresses the issue by:
- Adjust the model cache to understand that multiple models with the same name but different owners can exist. 
- Allow a model name to be either `<model-name>` or `<model-owner>/<model-name>`. This keeps backwards compatibility with the existing provider semantics.

Consider a scenario where a user-1 creates a model and grants user-2 with admin access to that model. User-2 can now write "user-1/model-name" in their plan to reference user-1's model. This is mainly useful when you are not creating the model in your plan, just referencing one that already exists. See "Additional notes" below for the scenario where the plan uses a reference to a model rather than hardcoding strings.

The concrete changes implemented:
- Move model cache into a separate package
- Rework model cache to handle multiple models with the same name but different owners
- Small tweak to testAccPreCheck to use sync.Once to fix potential race condition
- Add test for deploying to a model owned by a different user

Fixes: #504, [CSS-10769](https://warthogs.atlassian.net/browse/CSS-10769)

## Type of change

- Logic changes in resources (the API interaction with Juju has been changed)
- Bug fix (non-breaking change which fixes an issue)
- Requires a documentation update

## QA steps

The change allows for the following TF plan. Assuming you are the admin user on the controller,

``` terraform
resource "juju_model" "this" {
	name = "test"
}
	
resource "juju_application" "this" {
	name = "myApp"
	model = "admin/${juju_model.this.name}"
	charm {
	name = "jameinel-ubuntu-lite"
	}
	trust = true
	expose{}
}
```
If you have access to 2 models called `test` you can specify the model by switching the model owner from `admin`.

## Additional notes

I am still looking at how best to update the documentation.

There is 1 scenario worth mentioning:
- When referencing a model like `juju_model.model-name.name`, the model name does not contain the owner. If the Juju user has access to 2 models with this name, there will be an error returned to the user. The fix for this would be to do something like `"<username>/${juju_model.this.name}"` in your plan as is done in the tests.

There are two acceptance tests for the new behaviour.
1. A simple test that deploys an application referencing a model by a fully specified name
2. A more involved test that creates a new Juju user and creates a model as that user. Then grant the original user with access to the model and deploying to the model with Terraform. This test requires shelling out to the CLI. Possibly this is overdoing things and not necessary but open to opinions here.

[CSS-10769]: https://warthogs.atlassian.net/browse/CSS-10769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ