### PR TITLE
CSS-10638 remaining jaas resources

### DIFF
--- a/internal/provider/helpers.go
+++ b/internal/provider/helpers.go
@@ -33,6 +33,7 @@ const (
 	LogResourceAccessSecret = "resource-access-secret"
 
 	LogResourceJAASAccessModel = "resource-jaas-access-model"
+	LogResourceJAASAccessCloud = "resource-jaas-access-cloud"
 	LogResourceJAASGroup       = "resource-jaas-group"
 )
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -379,6 +379,7 @@ func (p *jujuProvider) Resources(_ context.Context) []func() resource.Resource {
 		func() resource.Resource { return NewSecretResource() },
 		func() resource.Resource { return NewAccessSecretResource() },
 		func() resource.Resource { return NewJAASAccessModelResource() },
+		func() resource.Resource { return NewJAASAccessCloudResource() },
 		func() resource.Resource { return NewJAASGroupResource() },
 	}
 }

--- a/internal/provider/resource_access_generic_test.go
+++ b/internal/provider/resource_access_generic_test.go
@@ -4,8 +4,13 @@
 package provider
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/canonical/jimm-go-sdk/v3/api"
+	"github.com/canonical/jimm-go-sdk/v3/api/params"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -64,5 +69,106 @@ func TestAvoidAtSymbolValidation(t *testing.T) {
 		t.Run(tC.desc, func(t *testing.T) {
 			assert.Equal(t, avoidAtSymbolRe.MatchString(tC.input), tC.matches)
 		})
+	}
+}
+
+// ===============================
+// Helpers for jaas resource tests
+
+// newCheckAttribute returns a fetchComputedAttribute object that can be used in tests
+// where you want to obtain the value of a computed attributed.
+//
+// The tag and resourceID fields are empty until this object is passed to a function
+// like testAccCheckAttributeNotEmpty.
+//
+// The relationBuilder parameter allows you to create a custom string
+// from the retrieved attribute value that can be used elsewhere in your test.
+// The output of this function is stored on the tag field.
+func newCheckAttribute(resourceName, attribute string, relationBuilder func(s string) string) fetchComputedAttribute {
+	var resourceID string
+	var tag string
+	return fetchComputedAttribute{
+		resourceName:   resourceName,
+		attribute:      attribute,
+		resourceID:     &resourceID,
+		tag:            &tag,
+		tagConstructor: relationBuilder,
+	}
+}
+
+type fetchComputedAttribute struct {
+	resourceName   string
+	attribute      string
+	resourceID     *string
+	tag            *string
+	tagConstructor func(s string) string
+}
+
+// testAccCheckAttributeNotEmpty is used used alongside newCheckAttribute
+// to fetch an attribute value and verify that it is not empty.
+func testAccCheckAttributeNotEmpty(check fetchComputedAttribute) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		// retrieve the resource by name from state
+		rs, ok := s.RootModule().Resources[check.resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", check.resourceName)
+		}
+
+		val, ok := rs.Primary.Attributes[check.attribute]
+		if !ok {
+			return fmt.Errorf("%s is not set", check.attribute)
+		}
+		if val == "" {
+			return fmt.Errorf("%s is empty", check.attribute)
+		}
+		if check.resourceID == nil || check.tag == nil {
+			return fmt.Errorf("cannot set resource info, nil poiner")
+		}
+		*check.resourceID = val
+		*check.tag = check.tagConstructor(val)
+		return nil
+	}
+}
+
+// testAccCheckJaasResourceAccess verifies that no direct relations exist
+// between the object and target.
+// Object and target are expected to be Juju tags of the form <resource-type>:<id>
+// Use newCheckAttribute to fetch and format resource tags from computed resources.
+func testAccCheckJaasResourceAccess(relation string, object, target *string, expectedAccess bool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if object == nil {
+			return fmt.Errorf("no object set")
+		}
+		if target == nil {
+			return fmt.Errorf("no target set")
+		}
+		conn, err := TestClient.Models.GetConnection(nil)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = conn.Close() }()
+		jc := api.NewClient(conn)
+		req := params.ListRelationshipTuplesRequest{
+			Tuple: params.RelationshipTuple{
+				Object:       *object,
+				Relation:     relation,
+				TargetObject: *target,
+			},
+		}
+		resp, err := jc.ListRelationshipTuples(&req)
+		if err != nil {
+			return err
+		}
+		hasAccess := len(resp.Tuples) != 0
+		if hasAccess != expectedAccess {
+			var accessMsg string
+			if expectedAccess {
+				accessMsg = "access"
+			} else {
+				accessMsg = "no access"
+			}
+			return fmt.Errorf("expected %s for %s as %s to resource (%s), but access is %t", accessMsg, *object, relation, *target, hasAccess)
+		}
+		return nil
 	}
 }

--- a/internal/provider/resource_access_jaas_cloud.go
+++ b/internal/provider/resource_access_jaas_cloud.go
@@ -1,0 +1,111 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the Apache License, Version 2.0, see LICENCE file for details.
+
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/juju/names/v5"
+)
+
+// Ensure provider defined types fully satisfy framework interfaces.
+var _ resource.Resource = &jaasAccessCloudResource{}
+var _ resource.ResourceWithConfigure = &jaasAccessCloudResource{}
+var _ resource.ResourceWithImportState = &jaasAccessCloudResource{}
+var _ resource.ResourceWithConfigValidators = &jaasAccessCloudResource{}
+
+// NewJAASAccessCloudResource returns a new resource for JAAS cloud access.
+func NewJAASAccessCloudResource() resource.Resource {
+	return &jaasAccessCloudResource{genericJAASAccessResource: genericJAASAccessResource{
+		targetResource:  cloudInfo{},
+		resourceLogName: LogResourceJAASAccessCloud,
+	}}
+}
+
+type cloudInfo struct{}
+
+// Info implements the [resourceInfo] interface, used to extract the info from a Terraform plan/state.
+func (j cloudInfo) Info(ctx context.Context, getter Getter, diag *diag.Diagnostics) (genericJAASAccessData, names.Tag) {
+	cloudAccess := jaasAccessCloudResourceCloud{}
+	diag.Append(getter.Get(ctx, &cloudAccess)...)
+	accessCloud := genericJAASAccessData{
+		ID:              cloudAccess.ID,
+		Users:           cloudAccess.Users,
+		Groups:          cloudAccess.Groups,
+		ServiceAccounts: cloudAccess.ServiceAccounts,
+		Access:          cloudAccess.Access,
+	}
+	// When importing, the cloud name will be empty
+	var tag names.Tag
+	if cloudAccess.CloudName.ValueString() != "" {
+		tag = names.NewCloudTag(cloudAccess.CloudName.ValueString())
+	}
+	return accessCloud, tag
+}
+
+// Save implements the [resourceInfo] interface, used to save info on Terraform's state.
+func (j cloudInfo) Save(ctx context.Context, setter Setter, info genericJAASAccessData, tag names.Tag) diag.Diagnostics {
+	cloudAccess := jaasAccessCloudResourceCloud{
+		CloudName:       basetypes.NewStringValue(tag.Id()),
+		ID:              info.ID,
+		Users:           info.Users,
+		Groups:          info.Groups,
+		ServiceAccounts: info.ServiceAccounts,
+		Access:          info.Access,
+	}
+	return setter.Set(ctx, cloudAccess)
+}
+
+// ImportHint implements [resourceInfo] and provides a hint to users on the import string format.
+func (j cloudInfo) ImportHint() string {
+	return "cloud-<name>:<access-level>"
+}
+
+type jaasAccessCloudResource struct {
+	genericJAASAccessResource
+}
+
+type jaasAccessCloudResourceCloud struct {
+	CloudName       types.String `tfsdk:"cloud_name"`
+	Users           types.Set    `tfsdk:"users"`
+	ServiceAccounts types.Set    `tfsdk:"service_accounts"`
+	Groups          types.Set    `tfsdk:"groups"`
+	Access          types.String `tfsdk:"access"`
+
+	// ID required for imports
+	ID types.String `tfsdk:"id"`
+}
+
+// Metadata returns metadata about the JAAS cloud access resource.
+func (a *jaasAccessCloudResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_jaas_access_cloud"
+}
+
+// Schema defines the schema for the JAAS cloud access resource.
+func (a *jaasAccessCloudResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	attributes := a.partialAccessSchema()
+	attributes["cloud_name"] = schema.StringAttribute{
+		Description: "The name of the cloud for access management. If this is changed the resource will be deleted and a new resource will be created.",
+		Required:    true,
+		Validators: []validator.String{
+			ValidatorMatchString(names.IsValidCloud, "cloud must be a valid name"),
+		},
+		PlanModifiers: []planmodifier.String{
+			stringplanmodifier.RequiresReplace(),
+		},
+	}
+	schema := schema.Schema{
+		Description: "A resource that represent access to a cloud when using JAAS.",
+		Attributes:  attributes,
+	}
+	resp.Schema = schema
+}

--- a/internal/provider/resource_access_jaas_cloud_test.go
+++ b/internal/provider/resource_access_jaas_cloud_test.go
@@ -1,0 +1,169 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the Apache License, Version 2.0, see LICENCE file for details.
+
+package provider
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"testing"
+
+	jimmnames "github.com/canonical/jimm-go-sdk/v3/names"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/juju/names/v5"
+	internaltesting "github.com/juju/terraform-provider-juju/internal/testing"
+)
+
+func TestAcc_ResourceJaasAccessCloud(t *testing.T) {
+	OnlyTestAgainstJAAS(t)
+	if testingCloud != LXDCloudTesting {
+		t.Skip(t.Name() + " only runs with LXD")
+	}
+	// Resource names
+	cloudAccessResourceName := "juju_jaas_access_cloud.test"
+	groupResourcename := "juju_jaas_group.test"
+	cloudName := "localhost"
+	accessSuccess := "can_addmodel"
+	accessFail := "bogus"
+	user := "foo@domain.com"
+	group := acctest.RandomWithPrefix("myGroup")
+	svcAcc := "test"
+	svcAccWithDomain := svcAcc + "@serviceaccount"
+
+	// Objects for checking access
+	groupRelationF := func(s string) string { return jimmnames.NewGroupTag(s).String() + "#member" }
+	groupCheck := newCheckAttribute(groupResourcename, "uuid", groupRelationF)
+	userTag := names.NewUserTag(user).String()
+	svcAccTag := names.NewUserTag(svcAccWithDomain).String()
+	cloudTag := names.NewCloudTag(cloudName).String()
+
+	// Test 0: Test an invalid access string.
+	// Test 1: Test adding a valid set user, group and service account.
+	// Test 2: Test importing works.
+	// Destroy: Test access is removed.
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: frameworkProviderFactories,
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			testAccCheckJaasResourceAccess(accessSuccess, &userTag, &cloudTag, false),
+			testAccCheckJaasResourceAccess(accessSuccess, groupCheck.tag, &cloudTag, false),
+			testAccCheckJaasResourceAccess(accessSuccess, &svcAccTag, &cloudTag, false),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccResourceJaasAccessCloud(cloudName, accessFail, user, group, svcAcc),
+				ExpectError: regexp.MustCompile(fmt.Sprintf("(?s)unknown.*relation %s", accessFail)),
+			},
+			{
+				Config: testAccResourceJaasAccessCloud(cloudName, accessSuccess, user, group, svcAcc),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAttributeNotEmpty(groupCheck),
+					testAccCheckJaasResourceAccess(accessSuccess, &userTag, &cloudTag, true),
+					testAccCheckJaasResourceAccess(accessSuccess, groupCheck.tag, &cloudTag, true),
+					testAccCheckJaasResourceAccess(accessSuccess, &svcAccTag, &cloudTag, true),
+					resource.TestCheckResourceAttr(cloudAccessResourceName, "access", accessSuccess),
+					resource.TestCheckTypeSetElemAttr(cloudAccessResourceName, "users.*", user),
+					resource.TestCheckResourceAttr(cloudAccessResourceName, "users.#", "1"),
+					// Wrap this check so that the pointer has deferred evaluation.
+					func(s *terraform.State) error {
+						return resource.TestCheckTypeSetElemAttr(cloudAccessResourceName, "groups.*", *groupCheck.resourceID)(s)
+					},
+					resource.TestCheckResourceAttr(cloudAccessResourceName, "groups.#", "1"),
+					resource.TestCheckTypeSetElemAttr(cloudAccessResourceName, "service_accounts.*", svcAcc),
+					resource.TestCheckResourceAttr(cloudAccessResourceName, "service_accounts.#", "1"),
+				),
+				// The plan will not be empty because JAAS sets the special user "everyone@external"
+				// to have access to clouds by default.
+				// This behavior is tested in TestAcc_ResourceJaasAccessCloudImportState.
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAcc_ResourceJaasAccessCloudImportState(t *testing.T) {
+	OnlyTestAgainstJAAS(t)
+	if testingCloud != LXDCloudTesting {
+		t.Skip(t.Name() + " only runs with LXD")
+	}
+	cloudName := "localhost"
+	access := "can_addmodel"
+
+	resourceName := "juju_jaas_access_cloud.test"
+
+	// Test 0: Test importing works.
+	// Note that because JAAS allows the special user "everyone@external" to have add model access
+	// to clouds, we check that this user is present when we do an import with an empty config.
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: frameworkProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:            testAccResourceJaasAccessCloudEmpty(cloudName, access),
+				ImportStateVerify: false,
+				ImportStateCheck: func(is []*terraform.InstanceState) error {
+					if len(is) != 1 {
+						return errors.New("expected 1 instance in import state")
+					}
+					state := is[0]
+					checker := func(key, expected string) error {
+						if value, ok := state.Attributes[key]; !ok {
+							return fmt.Errorf("did not find attribute %s", key)
+						} else if value != expected {
+							return fmt.Errorf("value for attribute %s did not match, got %s expected %s", key, value, expected)
+						}
+						return nil
+					}
+					errs := make([]error, 1)
+					errs = append(errs, checker("users.0", "everyone@external"))
+					errs = append(errs, checker("users.#", "1"))
+					return errors.Join(errs...)
+				},
+				ImportState:   true,
+				ImportStateId: fmt.Sprintf("%s:%s", "cloud-"+cloudName, access),
+				ResourceName:  resourceName,
+			},
+		},
+	})
+}
+
+func testAccResourceJaasAccessCloud(cloudName, access, user, group, svcAcc string) string {
+	return internaltesting.GetStringFromTemplateWithData(
+		"testAccResourceJaasAccessCloud",
+		`
+resource "juju_jaas_group" "test" {
+  name = "{{ .Group }}"
+}
+
+resource "juju_jaas_access_cloud" "test" {
+  cloud_name          = "{{.Cloud}}"
+  access              = "{{.Access}}"
+  users               = ["{{.User}}"]
+  groups              = [juju_jaas_group.test.uuid]
+  service_accounts    = ["{{.SvcAcc}}"]
+}
+`, internaltesting.TemplateData{
+			"Cloud":  cloudName,
+			"Access": access,
+			"User":   user,
+			"Group":  group,
+			"SvcAcc": svcAcc,
+		})
+}
+
+func testAccResourceJaasAccessCloudEmpty(cloudName, access string) string {
+	return internaltesting.GetStringFromTemplateWithData(
+		"testAccResourceJaasAccessCloudEmpty",
+		`
+resource "juju_jaas_access_cloud" "test" {
+  cloud_name          = "{{.Cloud}}"
+  access              = "{{.Access}}"
+}
+`, internaltesting.TemplateData{
+			"Cloud":  cloudName,
+			"Access": access,
+		})
+}

--- a/internal/provider/resource_access_jaas_cloud_test.go
+++ b/internal/provider/resource_access_jaas_cloud_test.go
@@ -17,6 +17,12 @@ import (
 	internaltesting "github.com/juju/terraform-provider-juju/internal/testing"
 )
 
+// This file has bare minimum tests for cloud access
+// verifying that users, service accounts and groups
+// can access a cloud. More extensive tests for
+// generic jaas access are available in
+// resource_access_jaas_model_test.go
+
 func TestAcc_ResourceJaasAccessCloud(t *testing.T) {
 	OnlyTestAgainstJAAS(t)
 	if testingCloud != LXDCloudTesting {

--- a/internal/provider/resource_access_jaas_model.go
+++ b/internal/provider/resource_access_jaas_model.go
@@ -34,10 +34,10 @@ func NewJAASAccessModelResource() resource.Resource {
 type modelInfo struct{}
 
 // Info implements the [resourceInfo] interface, used to extract the info from a Terraform plan/state.
-func (j modelInfo) Info(ctx context.Context, getter Getter, diag *diag.Diagnostics) (genericJAASAccessModel, names.Tag) {
+func (j modelInfo) Info(ctx context.Context, getter Getter, diag *diag.Diagnostics) (genericJAASAccessData, names.Tag) {
 	modelAccess := jaasAccessModelResourceModel{}
 	diag.Append(getter.Get(ctx, &modelAccess)...)
-	accessModel := genericJAASAccessModel{
+	accessModel := genericJAASAccessData{
 		ID:              modelAccess.ID,
 		Users:           modelAccess.Users,
 		Groups:          modelAccess.Groups,
@@ -48,7 +48,7 @@ func (j modelInfo) Info(ctx context.Context, getter Getter, diag *diag.Diagnosti
 }
 
 // Save implements the [resourceInfo] interface, used to save info on Terraform's state.
-func (j modelInfo) Save(ctx context.Context, setter Setter, info genericJAASAccessModel, tag names.Tag) diag.Diagnostics {
+func (j modelInfo) Save(ctx context.Context, setter Setter, info genericJAASAccessData, tag names.Tag) diag.Diagnostics {
 	modelAccess := jaasAccessModelResourceModel{
 		ModelUUID:       basetypes.NewStringValue(tag.Id()),
 		ID:              info.ID,


### PR DESCRIPTION
## Description

This PR adds a new resource `juju_jaas_access_cloud` building on top of the generic access structure. Note that in Juju clouds are a bit unique compared to models. Whereas model have a unique UUID, clouds do not and are unique based on the cloud name. Remaining resources for jaas_access include `app-offers`, `controller`, `group`, `service-account`. They will all follow the same structure and tests.

The full list of changes include:
- Add new `juju_jaas_access_cloud` resource and tests.
- Rename genericJAASAccessModel to genericJAASAccessData to avoid overloading the word model.
- Remove AtLeastOneOf validator to allow users to remove all direct access to a resource.
- Add test helper functions.
- Add jaas model access test that includes a user, group and service account.

Partially resolves:  [CSS-10638](https://warthogs.atlassian.net/browse/CSS-10638)

## Type of change

- Add new resource
- Change in tests (one or several tests have been changed)


[CSS-10638]: https://warthogs.atlassian.net/browse/CSS-10638?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ