### PR TITLE
fix: fix id name in SchemaChanges.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/SchemaChanges.yml
+++ b/.github/ISSUE_TEMPLATE/SchemaChanges.yml
@@ -51,7 +51,7 @@ body:
       required: true
 
   - type: textarea
-    id: Example terraform plan
+    id: Example-Terraform-Plan
     attributes:
       label: Example terraform plan
       description: |


### PR DESCRIPTION
The template wasn't available to users as it had an error. https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/common-validation-errors-when-creating-issue-forms#bodyi-id-can-only-contain-numbers-letters---_


