### PR TITLE
chore: remove ignore of darwin arm64

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -25,8 +25,6 @@ builds:
     - amd64
     - arm64
   ignore:
-    - goos: darwin
-      goarch: 'arm64'
     # TODO: disabled => juju/utils symlink_windows.go:54:8: undefined: createSymbolicLink
     - goos: windows
       goarch: arm64


### PR DESCRIPTION
## Description

Add darwin/arm64 back to `goreleaser`. There was a misread of past deprecation notice. There is no reason to not provide this binary.


## Type of change

- Maintenance work (repository related, like Github actions, or revving the Go version, etc.)
