### PR TITLE
fix(failure using ipv6 in tests): fix controller addresses resolution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ endif
 
 JUJU=juju
 CONTROLLER=$(shell ${JUJU} whoami | yq .Controller)
-CONTROLLER_ADDRESSES="$(shell ${JUJU} show-controller | yq '.${CONTROLLER}.details."api-endpoints"' | tr -d "[]' "|tr -d '"'|tr -d '\n')"
+CONTROLLER_ADDRESSES="$(shell juju show-controller | yq .${CONTROLLER}.details.api-endpoints | yq -r '. | join(",")')"
 USERNAME="$(shell cat ~/.local/share/juju/accounts.yaml | yq '.controllers.${CONTROLLER}.user'|tr -d '"')"
 PASSWORD="$(shell cat ~/.local/share/juju/accounts.yaml | yq '.controllers.${CONTROLLER}.password'|tr -d '"')"
 CA_CERT="$(shell ${JUJU} show-controller $(echo ${CONTROLLER}|tr -d '"')| yq '.${CONTROLLER}.details."ca-cert"'|tr -d '"'|sed 's/\\n/\n/g')"

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,7 +47,7 @@ Define the Juju controller credentials in the provider definition in your terraf
 
 ``` terraform
 provider "juju" {
-  controller_addresses = "10.225.205.241:17070,10.225.205.242:17070"
+  controller_addresses = "10.225.205.241:17070,10.225.205.242:17070,[fd42:791:fa5e:6834:216:3eff:fe7a:8e6a]:17070"
   username = "jujuuser"
   password = "password1"
   ca_certificate = file("~/ca-cert.pem")
@@ -62,7 +62,7 @@ Define the client credentials in the provider definition in your terraform plan.
 
 ``` terraform
 provider "juju" {
-  controller_addresses = "10.225.205.241:17070,10.225.205.242:17070"
+  controller_addresses = "10.225.205.241:17070,10.225.205.242:17070,[fd42:791:fa5e:6834:216:3eff:fe7a:8e6a]:17070"
   client_id = "jujuclientid"
   client_secret = "jujuclientsecret"
   ca_certificate = file("~/ca-cert.pem")
@@ -75,7 +75,7 @@ Define the Juju controller credentials in the provider definition via environmen
 
 ```shell
 export CONTROLLER=$(juju whoami | yq .Controller)
-export JUJU_CONTROLLER_ADDRESSES="$(juju show-controller | yq '.[$CONTROLLER]'.details.\"api-endpoints\" | tr -d "[]' "|tr -d '"'|tr -d '\n')"
+export JUJU_CONTROLLER_ADDRESSES=$(juju show-controller | yq .$CONTROLLER.details.api-endpoints | yq -r '. | join(",")')
 export JUJU_USERNAME="$(cat ~/.local/share/juju/accounts.yaml | yq .controllers.$CONTROLLER.user|tr -d '"')"
 export JUJU_PASSWORD="$(cat ~/.local/share/juju/accounts.yaml | yq .controllers.$CONTROLLER.password|tr -d '"')"
 export JUJU_CA_CERT="$(juju show-controller $(echo $CONTROLLER|tr -d '"') | yq '.[$CONTROLLER]'.details.\"ca-cert\"|tr -d '"'|sed 's/\\n/\n/g')"

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -47,7 +47,7 @@ Define the Juju controller credentials in the provider definition in your terraf
 
 ``` terraform
 provider "juju" {
-  controller_addresses = "10.225.205.241:17070,10.225.205.242:17070"
+  controller_addresses = "10.225.205.241:17070,10.225.205.242:17070,[fd42:791:fa5e:6834:216:3eff:fe7a:8e6a]:17070"
   username = "jujuuser"
   password = "password1"
   ca_certificate = file("~/ca-cert.pem")
@@ -62,7 +62,7 @@ Define the client credentials in the provider definition in your terraform plan.
 
 ``` terraform
 provider "juju" {
-  controller_addresses = "10.225.205.241:17070,10.225.205.242:17070"
+  controller_addresses = "10.225.205.241:17070,10.225.205.242:17070,[fd42:791:fa5e:6834:216:3eff:fe7a:8e6a]:17070"
   client_id = "jujuclientid"
   client_secret = "jujuclientsecret"
   ca_certificate = file("~/ca-cert.pem")
@@ -75,7 +75,7 @@ Define the Juju controller credentials in the provider definition via environmen
 
 ```shell
 export CONTROLLER=$(juju whoami | yq .Controller)
-export JUJU_CONTROLLER_ADDRESSES="$(juju show-controller | yq '.[$CONTROLLER]'.details.\"api-endpoints\" | tr -d "[]' "|tr -d '"'|tr -d '\n')"
+export JUJU_CONTROLLER_ADDRESSES=$(juju show-controller | yq .$CONTROLLER.details.api-endpoints | yq -r '. | join(",")')
 export JUJU_USERNAME="$(cat ~/.local/share/juju/accounts.yaml | yq .controllers.$CONTROLLER.user|tr -d '"')"
 export JUJU_PASSWORD="$(cat ~/.local/share/juju/accounts.yaml | yq .controllers.$CONTROLLER.password|tr -d '"')"
 export JUJU_CA_CERT="$(juju show-controller $(echo $CONTROLLER|tr -d '"') | yq '.[$CONTROLLER]'.details.\"ca-cert\"|tr -d '"'|sed 's/\\n/\n/g')"


### PR DESCRIPTION
## Description

The previous shell command to extract the ipv6 removed all the '[' regardless.
![image](https://github.com/user-attachments/assets/9166af43-b172-4db0-9448-90ed42d3aac3)
 
The new command removes only the surrounding '[', preserving the `[` for the ipv6.
![image](https://github.com/user-attachments/assets/02fdf06f-8399-4bba-a8e2-383f3aa6bbac)


Fixes: #582 

The shell command was copied from the workflows.
https://github.com/SimoneDutto/terraform-provider-juju/blob/22b76d0d0f67fc22df41a424c0fc0539119320bd/.github/workflows/test_integration.yml#L150

## Type of change

- fix using ipv6 in tests
