### PR TITLE
WIP: fix for secret_id of the juju_secret_resource

### DIFF
--- a/.github/workflows/test_integration.yml
+++ b/.github/workflows/test_integration.yml
@@ -45,8 +45,10 @@ jobs:
         action-operator:
           - { lxd-channel: "5.21/stable", cloud: "lxd", cloud-channel: "5.21", juju: "2.9" }
           - { lxd-channel: "5.21/stable", cloud: "lxd", cloud-channel: "5.21", juju: "3" }
+          - { lxd-channel: "latest/stable", cloud: "lxd", cloud-channel: "latest", juju: "3" }
           - { lxd-channel: "5.21/stable", cloud: "microk8s", cloud-channel: "1.28-strict", juju: "3.1" }
           - { lxd-channel: "5.21/stable", cloud: "microk8s", cloud-channel: "1.28-strict", juju: "3" }
+          - { lxd-channel: "latest/stable", cloud: "microk8s", cloud-channel: "1.32-strict", juju: "3" }
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test_integration.yml
+++ b/.github/workflows/test_integration.yml
@@ -103,7 +103,7 @@ jobs:
           TF_ACC: "1"
           TEST_CLOUD: ${{ matrix.action-operator.cloud }}
         run: go test -parallel 1 -timeout 60m -v -cover ./internal/provider/
-        timeout-minutes: 40
+        timeout-minutes: 60
 
   # Run acceptance tests in a matrix with Terraform CLI versions
   add-machine-test:
@@ -189,5 +189,5 @@ jobs:
 
           echo "Running the test"
           cd ./internal/provider/
-          go test ./... -timeout 30m -v -test.run TestAcc_ResourceMachine_AddMachine
-        timeout-minutes: 40
+          go test ./... -timeout 60m -v -test.run TestAcc_ResourceMachine_AddMachine
+        timeout-minutes: 60

--- a/.github/workflows/test_integration_jaas.yaml
+++ b/.github/workflows/test_integration_jaas.yaml
@@ -28,7 +28,7 @@ jobs:
   # Ensure project builds before running test
   build:
     name: Build-JAAS
-    runs-on: [self-hosted, jammy, x64]
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
@@ -103,5 +103,6 @@ jobs:
       - env:
           TF_ACC: "1"
           TEST_CLOUD: "lxd"
-        run: go test -parallel 1 -timeout 40m -v -cover ./internal/provider/
-        timeout-minutes: 40
+        run: go test -parallel 1 -timeout 60m -v -cover ./internal/provider/
+        timeout-minutes: 60
+

--- a/.github/workflows/test_integration_jaas.yaml
+++ b/.github/workflows/test_integration_jaas.yaml
@@ -28,7 +28,7 @@ jobs:
   # Ensure project builds before running test
   build:
     name: Build-JAAS
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, jammy, x64]
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
@@ -41,7 +41,7 @@ jobs:
   test:
     name: Integration-JAAS
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, jammy, x64]
     strategy:
       fail-fast: false
     timeout-minutes: 60
@@ -55,6 +55,10 @@ jobs:
         with:
           terraform_version: "1.9.*"
           terraform_wrapper: false
+      - name: Install docker compose plugin
+        run: |
+          for pkg in docker.io docker-doc docker-compose docker-compose-v2 podman-docker containerd runc; do sudo apt-get remove -y $pkg; done
+          sudo snap install docker --channel latest/stable
       # Starting JAAS will start the JIMM controller and dependencies and create a Juju controller on LXD and connect it to JIMM.
       - name: Setup JAAS
         uses: canonical/jimm/.github/actions/test-server@v3
@@ -68,11 +72,13 @@ jobs:
           sudo snap install microk8s --channel=1.28-strict/stable
           sudo usermod -a -G snap_microk8s $USER
           sudo chown -R $USER ~/.kube
-          sudo microk8s.enable dns storage
-          sudo microk8s.enable dns local-storage
+          sudo microk8s.enable dns
+          sudo microk8s.enable storage
+          sudo microk8s.enable hostpath-storage
           sudo -g snap_microk8s -E microk8s status --wait-ready --timeout=600
+          sudo microk8s.config view | tee /home/$USER/microk8s-config.yaml
           echo "MICROK8S_CONFIG<<EOF" >> $GITHUB_ENV
-          sudo microk8s.config view >> $GITHUB_ENV
+          echo "$(cat /home/${USER}/microk8s-config.yaml)" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
       - name: Create additional networks when testing with LXD
         run: |
@@ -97,5 +103,5 @@ jobs:
       - env:
           TF_ACC: "1"
           TEST_CLOUD: "lxd"
-        run: go test -parallel 10 -timeout 40m -v -cover ./internal/provider/
+        run: go test -parallel 1 -timeout 40m -v -cover ./internal/provider/
         timeout-minutes: 40

--- a/docs/resources/access_secret.md
+++ b/docs/resources/access_secret.md
@@ -19,7 +19,7 @@ A resource that represents a Juju secret access.
 
 - `applications` (List of String) The list of applications to which the secret is granted.
 - `model` (String) The model in which the secret belongs.
-- `secret_id` (String) The ID of the secret. E.g. coj8mulh8b41e8nv6p90
+- `secret_id` (String) The ID of the secret. E.g. secret:coj8mulh8b41e8nv6p90
 
 ### Read-Only
 

--- a/docs/resources/kubernetes_cloud.md
+++ b/docs/resources/kubernetes_cloud.md
@@ -37,8 +37,8 @@ resource "juju_model" "my-model" {
 ### Optional
 
 - `kubernetes_config` (String, Sensitive) The kubernetes config file path for the cloud. Cloud credentials will be added to the Juju controller for you.
-- `parent_cloud_name` (String) The parent cloud name in case adding k8s cluster from existed cloud. Changing this value will cause the cloud to be destroyed and recreated by terraform.
-- `parent_cloud_region` (String) The parent cloud region name in case adding k8s cluster from existed cloud. Changing this value will cause the cloud to be destroyed and recreated by terraform.
+- `parent_cloud_name` (String) The parent cloud name in case adding k8s cluster from existed cloud. Changing this value will cause the cloud to be destroyed and recreated by terraform. *Note* that this value must be set when running against a JAAS controller.
+- `parent_cloud_region` (String) The parent cloud region name in case adding k8s cluster from existed cloud. Changing this value will cause the cloud to be destroyed and recreated by terraform. *Note* that this value must be set when running against a JAAS controller.
 
 ### Read-Only
 

--- a/docs/resources/kubernetes_cloud.md
+++ b/docs/resources/kubernetes_cloud.md
@@ -37,8 +37,8 @@ resource "juju_model" "my-model" {
 ### Optional
 
 - `kubernetes_config` (String, Sensitive) The kubernetes config file path for the cloud. Cloud credentials will be added to the Juju controller for you.
-- `parent_cloud_name` (String) The parent cloud name in case adding k8s cluster from existed cloud. Changing this value will cause the cloud to be destroyed and recreated by terraform. *Note* that this value must be set when running against a JAAS controller.
-- `parent_cloud_region` (String) The parent cloud region name in case adding k8s cluster from existed cloud. Changing this value will cause the cloud to be destroyed and recreated by terraform. *Note* that this value must be set when running against a JAAS controller.
+- `parent_cloud_name` (String) The parent cloud name, for adding a k8s cluster from an existing cloud. Changing this value will cause the cloud to be destroyed and recreated by terraform. *Note* that this value must be set when running against a JAAS controller.
+- `parent_cloud_region` (String) The parent cloud region name, for adding a k8s cluster from an existing cloud. Changing this value will cause the cloud to be destroyed and recreated by terraform. *Note* that this value must be set when running against a JAAS controller.
 
 ### Read-Only
 

--- a/docs/resources/secret.md
+++ b/docs/resources/secret.md
@@ -49,7 +49,7 @@ resource "juju_application" "my-application" {
 ### Read-Only
 
 - `id` (String) The ID of the secret. Used for terraform import.
-- `secret_id` (String) The ID of the secret. E.g. coj8mulh8b41e8nv6p90
+- `secret_id` (String) The ID of the secret. E.g. secret:coj8mulh8b41e8nv6p90
 
 ## Import
 

--- a/internal/juju/secrets_test.go
+++ b/internal/juju/secrets_test.go
@@ -66,7 +66,7 @@ func (s *SecretSuite) TestCreateSecret() {
 	s.Require().NoError(err)
 
 	s.Assert().NotNil(output)
-	s.Assert().Equal(secretURI.ID, output.SecretId)
+	s.Assert().Equal(secretURI.String(), output.SecretURI)
 }
 
 func (s *SecretSuite) TestCreateSecretError() {
@@ -130,7 +130,7 @@ func (s *SecretSuite) TestReadSecret() {
 
 	client := s.getSecretsClient()
 	output, err := client.ReadSecret(&ReadSecretInput{
-		SecretId:  secretId,
+		SecretURI: secretId,
 		ModelName: *s.testModelName,
 		Name:      &secretName,
 		Revision:  &secretRevision,
@@ -162,7 +162,7 @@ func (s *SecretSuite) TestReadSecretError() {
 
 	client := s.getSecretsClient()
 	output, err := client.ReadSecret(&ReadSecretInput{
-		SecretId:  secretId,
+		SecretURI: secretId,
 		ModelName: *s.testModelName,
 	})
 	s.Require().Error(err)
@@ -192,7 +192,7 @@ func (s *SecretSuite) TestUpdateSecretWithRenaming() {
 
 	client := s.getSecretsClient()
 	err = client.UpdateSecret(&UpdateSecretInput{
-		SecretId:  secretId,
+		SecretURI: secretId,
 		ModelName: *s.testModelName,
 		Name:      &newSecretName,
 		Value:     &decodedValue,
@@ -221,7 +221,7 @@ func (s *SecretSuite) TestUpdateSecretWithRenaming() {
 
 	// read secret and check if value is updated
 	output, err := client.ReadSecret(&ReadSecretInput{
-		SecretId:  secretId,
+		SecretURI: secretId,
 		ModelName: *s.testModelName,
 	})
 	s.Require().NoError(err)
@@ -249,7 +249,7 @@ func (s *SecretSuite) TestUpdateSecret() {
 
 	client := s.getSecretsClient()
 	err = client.UpdateSecret(&UpdateSecretInput{
-		SecretId:  secretId,
+		SecretURI: secretId,
 		ModelName: *s.testModelName,
 		Value:     &decodedValue,
 		AutoPrune: &autoPrune,
@@ -278,7 +278,7 @@ func (s *SecretSuite) TestUpdateSecret() {
 
 	// read secret and check if secret info is updated
 	output, err := client.ReadSecret(&ReadSecretInput{
-		SecretId:  secretId,
+		SecretURI: secretId,
 		ModelName: *s.testModelName,
 	})
 	s.Require().NoError(err)
@@ -299,7 +299,7 @@ func (s *SecretSuite) TestDeleteSecret() {
 
 	client := s.getSecretsClient()
 	err = client.DeleteSecret(&DeleteSecretInput{
-		SecretId:  secretId,
+		SecretURI: secretId,
 		ModelName: *s.testModelName,
 	})
 	s.Assert().NoError(err)
@@ -320,14 +320,14 @@ func (s *SecretSuite) TestUpdateAccessSecret() {
 
 	client := s.getSecretsClient()
 	err = client.UpdateAccessSecret(&GrantRevokeAccessSecretInput{
-		SecretId:     secretId,
+		SecretURI:    secretId,
 		ModelName:    *s.testModelName,
 		Applications: applications,
 	}, GrantAccess)
 	s.Require().NoError(err)
 
 	err = client.UpdateAccessSecret(&GrantRevokeAccessSecretInput{
-		SecretId:     secretId,
+		SecretURI:    secretId,
 		ModelName:    *s.testModelName,
 		Applications: applications,
 	}, RevokeAccess)

--- a/internal/provider/data_source_secrets.go
+++ b/internal/provider/data_source_secrets.go
@@ -112,7 +112,7 @@ func (d *secretDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 	if data.SecretId.ValueString() == "" {
 		readSecretInput.Name = data.Name.ValueStringPointer()
 	} else {
-		readSecretInput.SecretId = data.SecretId.ValueString()
+		readSecretInput.SecretURI = data.SecretId.ValueString()
 	}
 
 	readSecretOutput, err := d.client.Secrets.ReadSecret(&readSecretInput)
@@ -122,7 +122,7 @@ func (d *secretDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 	}
 	d.trace(fmt.Sprintf("read secret data source %q", data.SecretId))
 
-	data.SecretId = types.StringValue(readSecretOutput.SecretId)
+	data.SecretId = types.StringValue(readSecretOutput.SecretURI)
 
 	// Save state into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/internal/provider/resource_kubernetes_cloud.go
+++ b/internal/provider/resource_kubernetes_cloud.go
@@ -100,11 +100,11 @@ func (r *kubernetesCloudResource) Schema(_ context.Context, req resource.SchemaR
 				Sensitive:   true,
 			},
 			"parent_cloud_name": schema.StringAttribute{
-				Description: "The parent cloud name in case adding k8s cluster from existed cloud. Changing this value will cause the cloud to be destroyed and recreated by terraform. *Note* that this value must be set when running against a JAAS controller.",
+				Description: "The parent cloud name, for adding a k8s cluster from an existing cloud. Changing this value will cause the cloud to be destroyed and recreated by terraform. *Note* that this value must be set when running against a JAAS controller.",
 				Optional:    true,
 			},
 			"parent_cloud_region": schema.StringAttribute{
-				Description: "The parent cloud region name in case adding k8s cluster from existed cloud. Changing this value will cause the cloud to be destroyed and recreated by terraform. *Note* that this value must be set when running against a JAAS controller.",
+				Description: "The parent cloud region name, for adding a k8s cluster from an existing cloud. Changing this value will cause the cloud to be destroyed and recreated by terraform. *Note* that this value must be set when running against a JAAS controller.",
 				Optional:    true,
 			},
 			"id": schema.StringAttribute{

--- a/internal/provider/resource_kubernetes_cloud_test.go
+++ b/internal/provider/resource_kubernetes_cloud_test.go
@@ -14,6 +14,12 @@ import (
 )
 
 func TestAcc_ResourceKubernetesCloud(t *testing.T) {
+	// Note (alesstimec): Skipping this test, because the default
+	// hosted cloud tf provider adds is "other", which cannot
+	// be parsed by JIMM - it needs a valid cloud/region to determine
+	// which controller to add the cloud to.
+	SkipJAAS(t)
+
 	// TODO: This test is not adding model as a resource, which is required.
 	// The reason in the race that we (potentially) have in the Juju side.
 	// Once the problem is fixed (https://bugs.launchpad.net/juju/+bug/2084448),

--- a/internal/provider/resource_kubernetes_cloud_test.go
+++ b/internal/provider/resource_kubernetes_cloud_test.go
@@ -5,6 +5,7 @@ package provider
 
 import (
 	"os"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -14,12 +15,37 @@ import (
 )
 
 func TestAcc_ResourceKubernetesCloud(t *testing.T) {
-	// Note (alesstimec): Skipping this test, because the default
-	// hosted cloud tf provider adds is "other", which cannot
-	// be parsed by JIMM - it needs a valid cloud/region to determine
-	// which controller to add the cloud to.
-	SkipJAAS(t)
+	// TODO: This test is not adding model as a resource, which is required.
+	// The reason in the race that we (potentially) have in the Juju side.
+	// Once the problem is fixed (https://bugs.launchpad.net/juju/+bug/2084448),
+	// we should add the model as a resource.
+	if testingCloud != LXDCloudTesting {
+		t.Skip(t.Name() + " only runs with LXD")
+	}
+	cloudName := acctest.RandomWithPrefix("tf-test-k8scloud")
+	cloudConfig := os.Getenv("MICROK8S_CONFIG")
 
+	jaasTest := false
+	if _, ok := os.LookupEnv("IS_JAAS"); ok {
+		jaasTest = true
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: frameworkProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceKubernetesCloudWithoutModel(cloudName, cloudConfig, jaasTest),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("juju_kubernetes_cloud."+cloudName, "name", cloudName),
+				),
+			},
+		},
+	})
+}
+
+func TestAcc_ResourceKubernetesCloudWithJAASIncompleteConfig(t *testing.T) {
+	OnlyTestAgainstJAAS(t)
 	// TODO: This test is not adding model as a resource, which is required.
 	// The reason in the race that we (potentially) have in the Juju side.
 	// Once the problem is fixed (https://bugs.launchpad.net/juju/+bug/2084448),
@@ -35,22 +61,39 @@ func TestAcc_ResourceKubernetesCloud(t *testing.T) {
 		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceKubernetesCloudWithoutModel(cloudName, cloudConfig),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("juju_kubernetes_cloud."+cloudName, "name", cloudName),
-				),
+				Config:      testAccResourceKubernetesCloudWithoutParentCloud(cloudName, cloudConfig),
+				ExpectError: regexp.MustCompile("parent_cloud_region must be specified when applying to a JAAS controller"),
 			},
 		},
 	})
 }
 
-func testAccResourceKubernetesCloudWithoutModel(cloudName string, config string) string {
+func testAccResourceKubernetesCloudWithoutModel(cloudName string, config string, jaasTest bool) string {
 	return internaltesting.GetStringFromTemplateWithData(
 		"testAccResourceSecret",
 		`
 resource "juju_kubernetes_cloud" "{{.CloudName}}" {
  name = "{{.CloudName}}"
  kubernetes_config = file("~/microk8s-config.yaml")
+ {{ if .JAASTest }}
+ parent_cloud_name = "lxd"
+ parent_cloud_region = "localhost"
+ {{ end }}
+}
+`, internaltesting.TemplateData{
+			"CloudName": cloudName,
+			"Config":    config,
+			"JAASTest":  jaasTest,
+		})
+}
+
+func testAccResourceKubernetesCloudWithoutParentCloud(cloudName string, config string) string {
+	return internaltesting.GetStringFromTemplateWithData(
+		"testAccResourceSecret",
+		`
+resource "juju_kubernetes_cloud" "{{.CloudName}}" {
+ name = "{{.CloudName}}"
+ kubernetes_config = "test config"
 }
 `, internaltesting.TemplateData{
 			"CloudName": cloudName,


### PR DESCRIPTION

## Description

The `secret_id` field of the `juju_secret_resource` should hold the secret URI instead of the ID
so that other resources can use it without having to manually prefix it with `secret:`.

Fixes: #644 

## Type of change

- Change existing resource

## Environment

- Juju controller version: 

- Terraform version: 

## QA steps

Manual QA steps should be done to test this PR.

```tf
provider juju {}
...
```

## Additional notes

*\<Please add relevant notes & information, links to mattermost chats, other related issues/PRs, anything to help understand and QA the PR.\>*
