### PR TITLE
fix: fix the use of a hardcoded admin user

### DIFF
--- a/internal/juju/offers.go
+++ b/internal/juju/offers.go
@@ -36,6 +36,7 @@ type CreateOfferInput struct {
 	Endpoint        string
 	ModelName       string
 	ModelOwner      string
+	OfferOwner      string
 	Name            string
 }
 
@@ -117,7 +118,8 @@ func (c offersClient) CreateOffer(input *CreateOfferInput) (*CreateOfferResponse
 	if err != nil {
 		return nil, append(errs, err)
 	}
-	result, err := client.Offer(modelUUID, input.ApplicationName, []string{input.Endpoint}, "admin", offerName, "")
+
+	result, err := client.Offer(modelUUID, input.ApplicationName, []string{input.Endpoint}, input.OfferOwner, offerName, "")
 	if err != nil {
 		return nil, append(errs, err)
 	}

--- a/internal/provider/resource_offer.go
+++ b/internal/provider/resource_offer.go
@@ -143,6 +143,7 @@ func (o *offerResource) Create(ctx context.Context, req resource.CreateRequest, 
 		Name:            offerName,
 		ApplicationName: plan.ApplicationName.ValueString(),
 		Endpoint:        plan.EndpointName.ValueString(),
+		OfferOwner:      o.client.Username(),
 	})
 	if errs != nil {
 		// TODO 10-Aug-2023

--- a/internal/provider/resource_ssh_key.go
+++ b/internal/provider/resource_ssh_key.go
@@ -122,6 +122,7 @@ func (s *sshKeyResource) Create(ctx context.Context, req resource.CreateRequest,
 	modelName := plan.ModelName.ValueString()
 
 	if err := s.client.SSHKeys.CreateSSHKey(&juju.CreateSSHKeyInput{
+		Username:  s.client.Username(),
 		ModelName: modelName,
 		Payload:   payload,
 	}); err != nil {
@@ -173,6 +174,7 @@ func (s *sshKeyResource) Read(ctx context.Context, req resource.ReadRequest, res
 	}
 
 	result, err := s.client.SSHKeys.ReadSSHKey(&juju.ReadSSHKeyInput{
+		Username:      s.client.Username(),
 		ModelName:     modelName,
 		KeyIdentifier: keyIdentifier,
 	})
@@ -221,6 +223,7 @@ func (s *sshKeyResource) Update(ctx context.Context, req resource.UpdateRequest,
 
 	// Delete the key
 	if err := s.client.SSHKeys.DeleteSSHKey(&juju.DeleteSSHKeyInput{
+		Username:      s.client.Username(),
 		ModelName:     modelName,
 		KeyIdentifier: keyIdentifier,
 	}); err != nil {
@@ -231,6 +234,7 @@ func (s *sshKeyResource) Update(ctx context.Context, req resource.UpdateRequest,
 
 	// Create a new key
 	if err := s.client.SSHKeys.CreateSSHKey(&juju.CreateSSHKeyInput{
+		Username:  s.client.Username(),
 		ModelName: plan.ModelName.ValueString(),
 		Payload:   plan.Payload.ValueString(),
 	}); err != nil {
@@ -274,6 +278,7 @@ func (s *sshKeyResource) Delete(ctx context.Context, req resource.DeleteRequest,
 
 	// Delete the key
 	if err := s.client.SSHKeys.DeleteSSHKey(&juju.DeleteSSHKeyInput{
+		Username:      s.client.Username(),
 		ModelName:     modelName,
 		KeyIdentifier: keyIdentifier,
 	}); err != nil {


### PR DESCRIPTION
## Description

The terraform provider code used a hardcoded `admin` user in a number of place, which caused issues
if a different username (or client credentails) was used. With this change we use the username (or
clientID) as specified in the provider.

3.6 does not associate ssh keys with users - ssh keys are global per model - so the username 
is ignored. For consistency we pass in the username that is used to log in to the
controller because in Juju 4 ssh keys will be associated with users.

## Type of change

- Logic changes in resources (the API interaction with Juju has been changed)


## QA steps

Run JAAS integration tests.

