### PR TITLE
feat(generate-schema): add schema generation to install command.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,11 +18,18 @@ EDGE_VERSION ?= 0.15.0
 REGISTRY_DIR=~/.terraform.d/plugins/registry.terraform.io/juju/juju/${EDGE_VERSION}/${GOOS}_${GOARCH}
 
 .PHONY: install
-install: simplify docs go-install
+install: simplify docs schema go-install
 ## install: Build terraform-provider-juju and copy to ~/.terraform.d using EDGEVERSION
 	@echo "Copied to ~/.terraform.d/plugins/registry.terraform.io/juju/juju/${EDGE_VERSION}/${GOOS}_${GOARCH}"
 	@mkdir -p ${REGISTRY_DIR}
 	@cp ${GOPATH}/bin/terraform-provider-juju ${REGISTRY_DIR}/terraform-provider-juju_v${EDGE_VERSION}
+
+.PHONY: schema
+schema:
+## schema: add provider's schema to terraform provider folder to enable language server features (ex. autocomplete).
+	@mkdir -p ${REGISTRY_DIR}
+	@terraform providers schema -json > ${REGISTRY_DIR}/schema.json
+	@echo "Provider schema generated."
 
 .PHONY: simplify
 # Reformat and simplify source files.


### PR DESCRIPTION
> [!NOTE]  
> This works in VsCode. If a reviewer uses NeoVim or Goland, and can test if it works in there as well it could be great.

## Description

While installing the terraform provider we generate the schema as well, and copy it to the provider's folder. This provides language server's features for editor, IDEs (ex. autocomplete)

Ex in VsCode:
![image](https://github.com/user-attachments/assets/44ad4792-959b-44f8-bc8a-8f777a7e4731)

![image](https://github.com/user-attachments/assets/98396cee-68e1-4db3-880b-1e820b8c94fe)

## QA steps

`make install`

Go to your editor/IDE with terraform language server installed (ex. VSCode + Hashicorp Terraform extension), and the autcomplete should work.

