### PR TITLE
fix: jaas tests

### DIFF
--- a/.github/workflows/test_integration_jaas.yaml
+++ b/.github/workflows/test_integration_jaas.yaml
@@ -65,7 +65,7 @@ jobs:
         id: jaas
         with:
           jimm-version: v3.2.2
-          juju-channel: 3/stable
+          juju-channel: 3.6/edge
           ghcr-pat: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup microk8s for juju_kubernetes_cloud test
         run: |

--- a/.github/workflows/test_integration_jaas.yaml
+++ b/.github/workflows/test_integration_jaas.yaml
@@ -64,7 +64,7 @@ jobs:
         uses: canonical/jimm/.github/actions/test-server@v3
         id: jaas
         with:
-          jimm-version: v3.1.10
+          jimm-version: v3.2.2
           juju-channel: 3/stable
           ghcr-pat: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup microk8s for juju_kubernetes_cloud test


### PR DESCRIPTION
## Description

Fix jaas CI tests:
- chore: update the jaas image to latest
- fix: update jaas test action to use 3.6/edge channel because 3.6.3 is currently broken with JAAS

