### PR TITLE
feat(run tests on github runner): move from self-hosted to github runner

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -29,7 +29,7 @@ jobs:
     name: Terraform Provider Acceptance Tests
     needs:
       - build
-    runs-on: [self-hosted, jammy, x64]
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
       fail-fast: false

--- a/.github/workflows/test_integration.yml
+++ b/.github/workflows/test_integration.yml
@@ -22,7 +22,7 @@ jobs:
   # turn around time for self-hosted PS6 runners.
   build:
     name: Build
-    runs-on: [ubuntu-latest]
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
@@ -37,7 +37,7 @@ jobs:
   test:
     name: Integration
     needs: build
-    runs-on: [self-hosted, jammy, x64]
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -109,7 +109,7 @@ jobs:
   add-machine-test:
     name: Add Machine
     needs: build
-    runs-on: [self-hosted, jammy, x64]
+    runs-on: ubuntu-latest
     env:
       ACTIONS_ALLOW_IPV6: false
     strategy:

--- a/.github/workflows/test_integration_jaas.yaml
+++ b/.github/workflows/test_integration_jaas.yaml
@@ -41,7 +41,7 @@ jobs:
   test:
     name: Integration-JAAS
     needs: build
-    runs-on: [self-hosted, jammy, x64]
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
     timeout-minutes: 60
@@ -65,7 +65,7 @@ jobs:
         id: jaas
         with:
           jimm-version: v3.1.10
-          juju-channel: 3/stable
+          juju-channel: 3.5/stable
           ghcr-pat: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup microk8s for juju_kubernetes_cloud test
         run: |


### PR DESCRIPTION
## Description
We temporary move to github runner, because self-hosted runners are not working.

We will go back to self-hosted once the situation goes back to normal.

