### PR TITLE
fix: reset app config map

### DIFF
--- a/internal/juju/applications.go
+++ b/internal/juju/applications.go
@@ -1224,6 +1224,30 @@ func (c applicationsClient) UpdateApplication(input *UpdateApplicationInput) err
 			c.Errorf(err, "setting configuration params")
 			return err
 		}
+	} else {
+		// if auxConfig populated from input.Config is nil, we need to reset previously set config
+		c.Debugf("Empty input config detected. Checking for config keys to reset..")
+		configMaps, err := applicationAPIClient.GetConfig("master", input.AppName)
+		if err != nil {
+			c.Errorf(err, "getting config to check for reset")
+			return err
+		}
+		if len(configMaps) > 0 {
+			// config map from GetConfig API is a slice of maps. We only need our one app's keys
+			firstConfigMap := configMaps[0]
+			keys := make([]string, 0, len(firstConfigMap))
+			for key := range firstConfigMap {
+				// collect all keys into a string slice to pass to the API
+				keys = append(keys, key)
+			}
+			if len(keys) > 0 {
+				c.Debugf("Resetting config keys", map[string]interface{}{"keys": keys})
+				if err := applicationAPIClient.UnsetApplicationConfig("master", input.AppName, keys); err != nil {
+					c.Errorf(err, "unsetting config")
+					return err
+				}
+			}
+		}
 	}
 
 	if len(input.EndpointBindings) > 0 {

--- a/internal/juju/interfaces.go
+++ b/internal/juju/interfaces.go
@@ -59,6 +59,8 @@ type ApplicationAPIClient interface {
 	ScaleApplication(in apiapplication.ScaleApplicationParams) (params.ScaleApplicationResult, error)
 	SetCharm(branchName string, cfg apiapplication.SetCharmConfig) error
 	SetConfig(branchName, application, configYAML string, config map[string]string) error
+	GetConfig(branchName string, appNames ...string) ([]map[string]interface{}, error)
+	UnsetApplicationConfig(branchName, application string, keys []string) error
 	SetConstraints(application string, constraints constraints.Value) error
 	Unexpose(application string, endpoints []string) error
 }

--- a/internal/juju/mock_test.go
+++ b/internal/juju/mock_test.go
@@ -415,6 +415,26 @@ func (mr *MockApplicationAPIClientMockRecorder) GetCharmURLOrigin(branchName, ap
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCharmURLOrigin", reflect.TypeOf((*MockApplicationAPIClient)(nil).GetCharmURLOrigin), branchName, applicationName)
 }
 
+// GetConfig mocks base method.
+func (m *MockApplicationAPIClient) GetConfig(branchName string, appNames ...string) ([]map[string]any, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{branchName}
+	for _, a := range appNames {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "GetConfig", varargs...)
+	ret0, _ := ret[0].([]map[string]any)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetConfig indicates an expected call of GetConfig.
+func (mr *MockApplicationAPIClientMockRecorder) GetConfig(branchName any, appNames ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{branchName}, appNames...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConfig", reflect.TypeOf((*MockApplicationAPIClient)(nil).GetConfig), varargs...)
+}
+
 // GetConstraints mocks base method.
 func (m *MockApplicationAPIClient) GetConstraints(applications ...string) ([]constraints.Value, error) {
 	m.ctrl.T.Helper()
@@ -517,6 +537,20 @@ func (m *MockApplicationAPIClient) Unexpose(application string, endpoints []stri
 func (mr *MockApplicationAPIClientMockRecorder) Unexpose(application, endpoints any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Unexpose", reflect.TypeOf((*MockApplicationAPIClient)(nil).Unexpose), application, endpoints)
+}
+
+// UnsetApplicationConfig mocks base method.
+func (m *MockApplicationAPIClient) UnsetApplicationConfig(branchName, application string, keys []string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UnsetApplicationConfig", branchName, application, keys)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UnsetApplicationConfig indicates an expected call of UnsetApplicationConfig.
+func (mr *MockApplicationAPIClientMockRecorder) UnsetApplicationConfig(branchName, application, keys any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnsetApplicationConfig", reflect.TypeOf((*MockApplicationAPIClient)(nil).UnsetApplicationConfig), branchName, application, keys)
 }
 
 // MockModelConfigAPIClient is a mock of ModelConfigAPIClient interface.


### PR DESCRIPTION

## Description

This PR is a fix for an issue: #393 
It fixes the UpdateApplication method in applications.go file, to handle the case where an app's config map is set to an empty value in the terraform, after being previously set. This case should now be handled correctly, with the config values being actually reset as expected.

Fixes: #393 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Environment

- Juju controller version: no change

- Terraform version: no change

## QA steps

1. Please follow the steps mentioned in the issue description to first re-create the issue and observe current state. 
2. Next, to test the changes introduced in this PR, please build and utilize this local version of the provider in your terraform file, and repeat the `terraform plan` and `terraform apply` steps. Now, doing a `juju config <app-name>` should yield the required result, with the config value reset.

## Additional notes


