### PR TITLE
chore(update-cla-ci): update the CLA workflow to v2

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -12,7 +12,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check if CLA signed
-        uses: canonical/has-signed-canonical-cla@1.2.3
-        with:
-          accept-existing-contributors: true
+        uses: canonical/has-signed-canonical-cla@v2
 


### PR DESCRIPTION
As per this announcement we need to update to the new CLA workflow https://discourse.canonical.com/t/new-contributor-license-agreement-cla-service/5247

I've removed the `accept-existing-contributors: true` option because i couldn't find documentation for it in v2:
https://github.com/canonical/has-signed-canonical-cla
