### PR TITLE
fix(machine): increases machine creation timeout to 30min

### DIFF
--- a/internal/juju/machines.go
+++ b/internal/juju/machines.go
@@ -179,7 +179,7 @@ func (c machinesClient) CreateMachine(ctx context.Context, input *CreateMachineI
 		IsFatalError: func(err error) bool {
 			return !errors.As(err, &KeepWaitingForError)
 		},
-		Attempts: 180,
+		Attempts: 720,
 		Delay:    defaultModelStatusCacheRetryInterval,
 		Clock:    clock.WallClock,
 		Stop:     ctx.Done(),


### PR DESCRIPTION
## Description

Increases machine creation timeout to 30min.

fix #715

## Type of change

- Logic changes in resources (the API interaction with Juju has been changed)

## Environment

- Juju controller version: 3.6

- Terraform version: v1.11.3

## QA steps

1. Create a terraform plan
```
terraform {
  required_providers {
    juju = {
      version = "0.18.0"
      source  = "juju/juju"
    }
  }
}

provider "juju" {}

resource "juju_model" "test" {
  name = "test-machine"
}


resource "juju_machine" "machine" {
  model       = resource.juju_model.test.name
  name        = "m1"
  base        = "ubuntu@22.04"
}

resource "juju_application" "appone" {
  model = resource.juju_model.test.name

  charm {
    name = "juju-qa-test"
    base = "ubuntu@22.04"
  }

  machines = [resource.juju_machine.machine.machine_id]
}
```
2. Apply the plan to a juju controller on MAAS
3. Verify the machines are created and application is deployed