### PR TITLE
docs: add contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ You will need a GitHub account ([sign up](https://github.com/signup)).
 
 ### Open an issue for docs
 
-To open an issue for a specific doc, find [the published doc](https://canonical-terraform-provider-juju.readthedocs-hosted.com/en/latest/tutorial/), then use the **Give feedback** button.
+To open an issue for a specific doc, find the docs in the [the published docs](https://canonical-terraform-provider-juju.readthedocs-hosted.com), then use the **Give feedback** button.
 
 To open an issue for docs in general, do the same for the homepage of the docs
 or go to https://github.com/juju/terraform-provider-juju/issues, click on **New issue** (top right corner


### PR DESCRIPTION
This repo did not have a CONTRIBUTING.md guide. This PR adds it, covering the usual PR process. 

The guide also contains a details dropdown with details specific to docs. In the future we'll want to add another one with details specific to code, as we do in the Juju repo.