### PR TITLE
chore(juju-version): use the 3/stable channel for juju in jaas integration tests

### DIFF
--- a/.github/workflows/test_integration_jaas.yaml
+++ b/.github/workflows/test_integration_jaas.yaml
@@ -66,7 +66,7 @@ jobs:
         uses: canonical/jimm/.github/actions/test-server@v3
         id: jaas
         with:
-          juju-channel: 3.6/edge
+          juju-channel: 3/stable
           jimm-version: v3.2.6
           ghcr-pat: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup microk8s for juju_kubernetes_cloud test


### PR DESCRIPTION
The reason we had 3.6/edge was that we needed the very latest version of juju, because jaas/juju interaction was broken. Now that 3.6.5 is release we can go back to 3/stable