### PR TITLE
chore: setup cloud credentials in test

### DIFF
--- a/internal/juju/credentials.go
+++ b/internal/juju/credentials.go
@@ -31,13 +31,6 @@ type CreateCredentialResponse struct {
 	CloudName       string
 }
 
-// ListCredentialInput is used as input to list
-// credentials for the client or controller.
-type ListCredentialInput struct {
-	ClientCredential     bool
-	ControllerCredential bool
-}
-
 // ListCredentialResponse is the response from listing credentials.
 type ListCredentialResponse struct {
 	// CloudCredentials contain all credentials, keyed by cloud name.

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -246,9 +246,7 @@ func createCloudCredential(t *testing.T) {
 	cloudName := canonicalCloudName(os.Getenv(TestCloudEnvKey))
 
 	// List controller credentials to bail out early if one already exists.
-	listControllerCreds, _ := TestClient.Credentials.ListCredentials(juju.ListCredentialInput{
-		ControllerCredential: true,
-	})
+	listControllerCreds, _ := TestClient.Credentials.ListControllerCredentials()
 	// skip checking the error here, because the controller
 	// returns a not found error if no credentials exist
 	// and for any other errors we want to continue anyway.
@@ -262,9 +260,7 @@ func createCloudCredential(t *testing.T) {
 	}
 
 	// List client credentials to check if we have any cloud-credentials.
-	listClientCreds, err := TestClient.Credentials.ListCredentials(juju.ListCredentialInput{
-		ClientCredential: true,
-	})
+	listClientCreds, err := TestClient.Credentials.ListClientCredentials()
 	if err != nil {
 		t.Fatalf("failed to read cloud-credential from client store: %v", err)
 	}

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -246,12 +246,12 @@ func createCloudCredential(t *testing.T) {
 	cloudName := canonicalCloudName(os.Getenv(TestCloudEnvKey))
 
 	// List controller credentials to bail out early if one already exists.
-	listControllerCreds, _ := TestClient.Credentials.ListControllerCredentials()
+	controllerCreds, _ := TestClient.Credentials.ListControllerCredentials()
 	// skip checking the error here, because the controller
 	// returns a not found error if no credentials exist
 	// and for any other errors we want to continue anyway.
-	if listControllerCreds != nil {
-		for cloud := range listControllerCreds.CloudCredentials {
+	if controllerCreds != nil {
+		for cloud := range controllerCreds.CloudCredentials {
 			if cloud == cloudName {
 				t.Logf("successfully found cloud-credential in controller for cloud %s", cloudName)
 				return
@@ -260,18 +260,18 @@ func createCloudCredential(t *testing.T) {
 	}
 
 	// List client credentials to check if we have any cloud-credentials.
-	listClientCreds, err := TestClient.Credentials.ListClientCredentials()
+	clientCreds, err := TestClient.Credentials.ListClientCredentials()
 	if err != nil {
 		t.Fatalf("failed to read cloud-credential from client store: %v", err)
 	}
-	if len(listClientCreds.CloudCredentials[cloudName].AuthCredentials) == 0 {
+	if len(clientCreds.CloudCredentials[cloudName].AuthCredentials) == 0 {
 		t.Fatalf("no cloud-credentials for cloud %q found in client store", cloudName)
 	}
 
 	// Create a new credential on the controller using the
 	// first available client credential.
 	var createCredential juju.CreateCredentialInput
-	for credentialName, cred := range listClientCreds.CloudCredentials[cloudName].AuthCredentials {
+	for credentialName, cred := range clientCreds.CloudCredentials[cloudName].AuthCredentials {
 		createCredential.AuthType = string(cred.AuthType())
 		createCredential.Attributes = cred.Attributes()
 		createCredential.Name = credentialName


### PR DESCRIPTION
## Description

This PR introduces a change to the acceptance test setup that allows tests to be run by a user who doesn't already have a cloud-credential present in the controller. This is useful for running tests as a non-admin user or as a service account in JAAS.

We enable this by adding a helper method to the test setup to scan the local client store for a client credential matching the cloud-under-test and uploading it to the controller. We first check if an appropriate credential exists, in which case we skip the remainder of the operation.

One quirk is that Juju controller's have some convoluted logic around model creation and selection of a cloud-credential which can be seen [here](https://github.com/juju/juju/blob/3.6/apiserver/facades/client/modelmanager/modelmanager.go#L283). In summary:
- If a cloud-credential is specified, use that.
- Else
  - If the user making the createModel request is the same as the model owner of the _controller_ model, use the controller model's credential.
  -  Else
     - Require the user to specify a cloud-credential unless the cloud doesn't require it.

So, this change is not very helpful when testing as a non-admin user against a Juju controller because model creation will fail. But, this behaviour is not the same with JAAS, where if a user has only 1 cloud-credential for a cloud, that will be used by default. 

## Type of change

- Change in tests (one or several tests have been changed)