### PR TITLE
feat(machine): adds machine annotations

### DIFF
--- a/docs/resources/machine.md
+++ b/docs/resources/machine.md
@@ -29,6 +29,7 @@ resource "juju_machine" "this_machine" {
 
 ### Optional
 
+- `annotations` (Map of String) Annotations are key/value pairs that can be used to store additional information about the machine. May not contain dots (.) in keys.
 - `base` (String) The operating system to install on the new machine(s). E.g. ubuntu@22.04. Changing this value will cause the machine to be destroyed and recreated by terraform.
 - `constraints` (String) Machine constraints that overwrite those available from 'juju get-model-constraints' and provider's defaults. Changing this value will cause the application to be destroyed and recreated by terraform.
 - `disks` (String) Storage constraints for disks to attach to the machine(s). Changing this value will cause the machine to be destroyed and recreated by terraform.

--- a/internal/provider/resource_machine_test.go
+++ b/internal/provider/resource_machine_test.go
@@ -275,3 +275,93 @@ resource "juju_machine" "this_machine_1" {
 			"ModelName": modelName,
 		})
 }
+
+func TestAcc_ResourceMachine_Annotations(t *testing.T) {
+	if testingCloud != LXDCloudTesting {
+		t.Skip(t.Name() + " only runs with LXD")
+	}
+	modelName := acctest.RandomWithPrefix("tf-test-machine-annotations")
+	machineName := "testmachine"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: frameworkProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAnnotationsMachine(modelName, machineName, "test", "test"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("juju_machine.testmachine", "name", machineName),
+					resource.TestCheckResourceAttr("juju_machine.testmachine", "annotations.test", "test"),
+				),
+			},
+			{
+				Config: testAccAnnotationsMachine(modelName, machineName, "test", "test-update"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("juju_machine.testmachine", "name", machineName),
+					resource.TestCheckResourceAttr("juju_machine.testmachine", "annotations.test", "test-update"),
+				),
+			},
+			{
+				Config: fmt.Sprintf(`
+resource "juju_model" "testmodel" {
+  name = %q
+}
+  
+resource "juju_machine" "testmachine" {
+  name = %q
+  model = juju_model.testmodel.name
+}
+`, modelName, machineName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("juju_machine.testmachine", "name", machineName),
+					resource.TestCheckNoResourceAttr("juju_machine.testmachine", "annotations.test"),
+				),
+			},
+		},
+	})
+}
+
+func TestAcc_ResourceMachine_UnsetAnnotations(t *testing.T) {
+	if testingCloud != LXDCloudTesting {
+		t.Skip(t.Name() + " only runs with LXD")
+	}
+	modelName := acctest.RandomWithPrefix("tf-test-machine-annotations-unset")
+	machineName := "testmachine"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: frameworkProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAnnotationsMachine(modelName, machineName, "test", "test"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("juju_machine.testmachine", "name", machineName),
+					resource.TestCheckResourceAttr("juju_machine.testmachine", "annotations.test", "test"),
+				),
+			},
+			{
+				Config: testAccAnnotationsMachine(modelName, machineName, "test-another", "test-another"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("juju_machine.testmachine", "name", machineName),
+					resource.TestCheckResourceAttr("juju_machine.testmachine", "annotations.test-another", "test-another"),
+					resource.TestCheckNoResourceAttr("juju_machine.testmachine", "annotations.test"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAnnotationsMachine(modelName, machineName string, annotationKey, annotationValue string) string {
+	return fmt.Sprintf(`
+resource "juju_model" "testmodel" {
+  name = %q
+}
+
+resource "juju_machine" "testmachine" {
+  name = %q
+  model = juju_model.testmodel.name
+
+  
+  annotations = {
+	%q = %q
+  }
+}`, modelName, machineName, annotationKey, annotationValue)
+}


### PR DESCRIPTION
## Description

Adds annotations for `juju_machine` resource.

## Type of change

- Change existing resource

## Environment

- Juju controller version: 3.6.5

- Terraform version: v1.12.1

## QA steps

Manual QA steps should be done to test this PR.

```tf
terraform {
  required_providers {
    juju = {
      version = "0.20.0"
      source  = "juju/juju"
    }
  }
}

provider "juju" {}

resource "juju_model" "test" {
  name = "test-model"
}

resource "juju_machine" "test" {
  name = "test-machine"
  model = juju_model.test.name

  annotations = {
     "key" = "value"
  }
}
```

## Additional notes

*\<Please add relevant notes & information, links to mattermost chats, other related issues/PRs, anything to help understand and QA the PR.\>*
