### PR TITLE
WIP fix(access_offer): ignore provider user while reading the resource

### DIFF
--- a/internal/provider/resource_access_offer.go
+++ b/internal/provider/resource_access_offer.go
@@ -220,7 +220,7 @@ func (a *accessOfferResource) Read(ctx context.Context, req resource.ReadRequest
 	users[permission.ReadAccess] = []string{}
 	users[permission.AdminAccess] = []string{}
 	for _, offerUserDetail := range response.Users {
-		if offerUserDetail.UserName == "everyone@external" || offerUserDetail.UserName == "admin" {
+		if offerUserDetail.UserName == "everyone@external" || offerUserDetail.UserName == "admin" || offerUserDetail.UserName == a.client.Username() {
 			continue
 		}
 


### PR DESCRIPTION
**Attention**: I am submitting the PR, but I still need to test it locally to ensure that this is sufficient.


## Description

By default, the user who creates an offer is assigned as its admin. Since this is not explicitly set in the access_offer resource within the plan, during a resource upgrade, the offer is read, and the user appears as an admin. Because this admin assignment is not defined in the resource, it is detected as a change, which triggers an unnecessary update.

This PR modifies that behavior by ignoring the user who created the offer when reading the access_offer resource

Fixes: #662 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Environment

- Juju controller version: 3.6.6

- Terraform version: 1.7.4

## QA steps

Manual QA steps should be done to test this PR.

```tf
provider juju {}
...
```

## Additional notes

*\<Please add relevant notes & information, links to mattermost chats, other related issues/PRs, anything to help understand and QA the PR.\>*
