### PR TITLE
chore: allow tests to disable wait-for resources

### DIFF
--- a/internal/juju/client.go
+++ b/internal/juju/client.go
@@ -131,16 +131,9 @@ type sharedClient struct {
 // NewClient returns a client which can talk to the juju controller
 // represented by controllerConfig. A context is required for logging in the
 // terraform framework.
-func NewClient(ctx context.Context, config ControllerConfiguration) (*Client, error) {
+func NewClient(ctx context.Context, config ControllerConfiguration, waitForResources bool) (*Client, error) {
 	if ctx == nil {
 		return nil, errors.NotValidf("missing context")
-	}
-	waitForResources := true
-	if waitVal, ok := os.LookupEnv(waitForResourcesKey); ok {
-		parsed, err := strconv.ParseBool(waitVal)
-		if err == nil {
-			waitForResources = parsed
-		}
 	}
 	sc := &sharedClient{
 		controllerConfig: config,

--- a/internal/juju/client.go
+++ b/internal/juju/client.go
@@ -6,6 +6,7 @@ package juju
 import (
 	"context"
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -33,6 +34,8 @@ const (
 	PrefixApplication                    = "application-"
 	PrefixStorage                        = "storage-"
 	UnspecifiedRevision                  = -1
+	customTimeoutKey                     = "JUJU_CONNECTION_TIMEOUT"
+	waitForResourcesKey                  = "JUJU_WAIT_FOR_RESOURCES"
 	connectionTimeout                    = 30 * time.Second
 	serviceAccountSuffix                 = "@serviceaccount"
 	defaultModelStatusCacheInterval      = 5 * time.Second
@@ -111,6 +114,7 @@ func (j jujuModel) String() string {
 
 type sharedClient struct {
 	controllerConfig ControllerConfiguration
+	waitForResources bool
 
 	modelUUIDcache map[string]jujuModel
 	modelUUIDmu    sync.Mutex
@@ -131,8 +135,16 @@ func NewClient(ctx context.Context, config ControllerConfiguration) (*Client, er
 	if ctx == nil {
 		return nil, errors.NotValidf("missing context")
 	}
+	waitForResources := true
+	if waitVal, ok := os.LookupEnv(waitForResourcesKey); ok {
+		parsed, err := strconv.ParseBool(waitVal)
+		if err == nil {
+			waitForResources = parsed
+		}
+	}
 	sc := &sharedClient{
 		controllerConfig: config,
+		waitForResources: waitForResources,
 		modelUUIDcache:   make(map[string]jujuModel),
 		modelStatusCache: cache.New(defaultModelStatusCacheInterval),
 		subCtx:           tflog.NewSubsystem(ctx, LogJujuClient),
@@ -192,6 +204,25 @@ func (sc *sharedClient) IsJAAS(defaultVal bool) bool {
 	return sc.isJAAS
 }
 
+func getConnectionTimeout() time.Duration {
+	if timeout, ok := os.LookupEnv(customTimeoutKey); ok {
+		if t, err := strconv.Atoi(timeout); err == nil && t > 0 {
+			return time.Duration(t) * time.Second
+		}
+		tflog.Warn(context.Background(), "Invalid JUJU_CONNECTION_TIMEOUT value, using default", map[string]interface{}{
+			"JUJU_CONNECTION_TIMEOUT": timeout,
+			"default":                 connectionTimeout,
+		})
+	}
+	return connectionTimeout
+}
+
+// WaitForResource returns a bool indicating whether the client
+// should wait for resources to be available/destroyed before proceeding.
+func (sc *sharedClient) WaitForResource() bool {
+	return sc.waitForResources
+}
+
 // GetConnection returns a juju connection for use creating juju
 // api clients given the provided model uuid, name, or neither.
 // Allowing a model name is a fallback behavior until the name
@@ -208,7 +239,7 @@ func (sc *sharedClient) GetConnection(modelIdentifier *string) (api.Connection, 
 
 	dialOptions := func(do *api.DialOpts) {
 		//this is set as a const above, in case we need to use it elsewhere to manage connection timings
-		do.Timeout = connectionTimeout
+		do.Timeout = getConnectionTimeout()
 		//default is 2 seconds, as we are changing the overall timeout it makes sense to reduce this as well
 		do.RetryDelay = 1 * time.Second
 	}

--- a/internal/juju/interfaces.go
+++ b/internal/juju/interfaces.go
@@ -38,6 +38,7 @@ type SharedClient interface {
 	Warnf(msg string, additionalFields ...map[string]interface{})
 
 	JujuLogger() *jujuLoggerShim
+	WaitForResource() bool
 }
 
 type ClientAPIClient interface {

--- a/internal/juju/machines.go
+++ b/internal/juju/machines.go
@@ -155,6 +155,9 @@ func (c *machinesClient) CreateMachine(ctx context.Context, input *CreateMachine
 	// information is not available until it reaches the "running" state.
 	retryErr := retry.Call(retry.CallArgs{
 		Func: func() error {
+			if !c.WaitForResource() {
+				return nil
+			}
 			modelStatus, err := c.ModelStatus(input.ModelName, conn)
 			if err != nil {
 				return errors.Annotatef(err, "failed to get model status.")

--- a/internal/juju/mock_test.go
+++ b/internal/juju/mock_test.go
@@ -203,6 +203,20 @@ func (mr *MockSharedClientMockRecorder) Tracef(msg any, additionalFields ...any)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tracef", reflect.TypeOf((*MockSharedClient)(nil).Tracef), varargs...)
 }
 
+// WaitForResource mocks base method.
+func (m *MockSharedClient) WaitForResource() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WaitForResource")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// WaitForResource indicates an expected call of WaitForResource.
+func (mr *MockSharedClientMockRecorder) WaitForResource() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForResource", reflect.TypeOf((*MockSharedClient)(nil).WaitForResource))
+}
+
 // Warnf mocks base method.
 func (m *MockSharedClient) Warnf(msg string, additionalFields ...map[string]any) {
 	m.ctrl.T.Helper()

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -32,6 +32,10 @@ const (
 // acceptance testing.
 var frameworkProviderFactories map[string]func() (tfprotov6.ProviderServer, error)
 
+// frameworkProviderFactoriesNoResourceWait are used to instantiate the Framework provider during
+// acceptance testing but configures the provider to not wait for resources to be ready or destroyed.
+var frameworkProviderFactoriesNoResourceWait map[string]func() (tfprotov6.ProviderServer, error)
+
 // Provider makes a separate provider available for tests.
 // Note that testAccPreCheck needs to invoked before use.
 var Provider provider.Provider
@@ -41,10 +45,14 @@ var Provider provider.Provider
 var TestClient *juju.Client
 
 func init() {
-	Provider = NewJujuProvider("dev")
+	waitForResources := true
+	Provider = NewJujuProvider("dev", waitForResources)
 
 	frameworkProviderFactories = map[string]func() (tfprotov6.ProviderServer, error){
-		"juju": providerserver.NewProtocol6WithError(NewJujuProvider("dev")),
+		"juju": providerserver.NewProtocol6WithError(NewJujuProvider("dev", true)),
+	}
+	frameworkProviderFactoriesNoResourceWait = map[string]func() (tfprotov6.ProviderServer, error){
+		"juju": providerserver.NewProtocol6WithError(NewJujuProvider("dev", false)),
 	}
 }
 
@@ -68,7 +76,7 @@ func OnlyTestAgainstJAAS(t *testing.T) {
 
 func TestProviderConfigure(t *testing.T) {
 	testAccPreCheck(t)
-	jujuProvider := NewJujuProvider("dev")
+	jujuProvider := NewJujuProvider("dev", true)
 	confResp := configureProvider(t, jujuProvider)
 	assert.Equal(t, confResp.Diagnostics.HasError(), false)
 }
@@ -76,7 +84,7 @@ func TestProviderConfigure(t *testing.T) {
 func TestProviderConfigureUsernameFromEnv(t *testing.T) {
 	SkipJAAS(t)
 	testAccPreCheck(t)
-	jujuProvider := NewJujuProvider("dev")
+	jujuProvider := NewJujuProvider("dev", true)
 	userNameValue := "the-username"
 	t.Setenv(JujuUsernameEnvKey, userNameValue)
 
@@ -91,7 +99,7 @@ func TestProviderConfigureUsernameFromEnv(t *testing.T) {
 func TestProviderConfigurePasswordFromEnv(t *testing.T) {
 	SkipJAAS(t)
 	testAccPreCheck(t)
-	jujuProvider := NewJujuProvider("dev")
+	jujuProvider := NewJujuProvider("dev", true)
 	passwordValue := "the-password"
 	t.Setenv(JujuPasswordEnvKey, passwordValue)
 	confResp := configureProvider(t, jujuProvider)
@@ -105,7 +113,7 @@ func TestProviderConfigurePasswordFromEnv(t *testing.T) {
 func TestProviderConfigureClientIDAndSecretFromEnv(t *testing.T) {
 	SkipJAAS(t)
 	testAccPreCheck(t)
-	jujuProvider := NewJujuProvider("dev")
+	jujuProvider := NewJujuProvider("dev", true)
 	emptyValue := ""
 	t.Setenv(JujuUsernameEnvKey, emptyValue)
 	t.Setenv(JujuPasswordEnvKey, emptyValue)
@@ -127,7 +135,7 @@ func TestProviderConfigureAddresses(t *testing.T) {
 	testAccPreCheck(t)
 	os.Setenv("JUJU_CONNECTION_TIMEOUT", "2") // 2s timeout
 	defer os.Unsetenv("JUJU_CONNECTION_TIMEOUT")
-	jujuProvider := NewJujuProvider("dev")
+	jujuProvider := NewJujuProvider("dev", true)
 	// This IP is from a test network that should never be routed. https://www.rfc-editor.org/rfc/rfc5737#section-3
 	t.Setenv(JujuControllerEnvKey, "192.0.2.100:17070")
 	confResp := configureProvider(t, jujuProvider)
@@ -151,7 +159,7 @@ func TestProviderConfigurex509FromEnv(t *testing.T) {
 		//https://github.com/golang/go/issues/52010
 		t.Skip("This test does not work on MacOS")
 	}
-	jujuProvider := NewJujuProvider("dev")
+	jujuProvider := NewJujuProvider("dev", true)
 	t.Setenv(JujuCACertEnvKey, invalidCA)
 	confResp := configureProvider(t, jujuProvider)
 	// This is a live test, expect that the client connection will fail.
@@ -164,7 +172,7 @@ func TestProviderConfigurex509FromEnv(t *testing.T) {
 
 func TestProviderConfigurex509InvalidFromEnv(t *testing.T) {
 	SkipJAAS(t)
-	jujuProvider := NewJujuProvider("dev")
+	jujuProvider := NewJujuProvider("dev", true)
 	//Set the CA to the invalid one above
 	//Juju will ignore the system trust store if we set the CA property
 	t.Setenv(JujuCACertEnvKey, invalidCA)
@@ -180,7 +188,7 @@ func TestProviderConfigurex509InvalidFromEnv(t *testing.T) {
 
 func TestProviderAllowsEmptyCACert(t *testing.T) {
 	SkipJAAS(t)
-	jujuProvider := NewJujuProvider("dev")
+	jujuProvider := NewJujuProvider("dev", true)
 	//Set the CA cert to be empty and check that the provider still tries to connect.
 	t.Setenv(JujuCACertEnvKey, "")
 	t.Setenv("JUJU_CA_CERT_FILE", "")
@@ -272,7 +280,7 @@ func configureProvider(t *testing.T, p provider.Provider) provider.ConfigureResp
 
 func TestFrameworkProviderSchema(t *testing.T) {
 	testAccPreCheck(t)
-	jujuProvider := NewJujuProvider("dev")
+	jujuProvider := NewJujuProvider("dev", true)
 	req := provider.SchemaRequest{}
 	resp := provider.SchemaResponse{}
 	jujuProvider.Schema(context.Background(), req, &resp)

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -125,6 +125,8 @@ func TestProviderConfigureClientIDAndSecretFromEnv(t *testing.T) {
 
 func TestProviderConfigureAddresses(t *testing.T) {
 	testAccPreCheck(t)
+	os.Setenv("JUJU_CONNECTION_TIMEOUT", "2") // 2s timeout
+	defer os.Unsetenv("JUJU_CONNECTION_TIMEOUT")
 	jujuProvider := NewJujuProvider("dev")
 	// This IP is from a test network that should never be routed. https://www.rfc-editor.org/rfc/rfc5737#section-3
 	t.Setenv(JujuControllerEnvKey, "192.0.2.100:17070")

--- a/internal/provider/resource_application_test.go
+++ b/internal/provider/resource_application_test.go
@@ -1810,10 +1810,10 @@ func TestAcc_ResourceApplication_ParallelDeploy(t *testing.T) {
 	var charm, channel string
 	switch testingCloud {
 	case MicroK8sTesting:
-		charm = "traefik-k8s"
-		channel = "1.0/candidate"
+		charm = "juju-qa-test"
+		channel = "latest/stable"
 	case LXDCloudTesting:
-		charm = "github-runner"
+		charm = "juju-qa-test"
 		channel = "latest/stable"
 	default:
 		t.Fatalf("unknown test cloud")

--- a/internal/provider/resource_machine_test.go
+++ b/internal/provider/resource_machine_test.go
@@ -5,7 +5,6 @@ package provider
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -71,13 +70,11 @@ func TestAcc_ResourceMachine_WithPlacement(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
-	os.Setenv("JUJU_WAIT_FOR_RESOURCES", "false")
-	defer os.Unsetenv("JUJU_WAIT_FOR_RESOURCES")
 	modelName := acctest.RandomWithPrefix("tf-test-machine")
 	resourceName := "juju_machine.this_machine_1"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: frameworkProviderFactories,
+		ProtoV6ProviderFactories: frameworkProviderFactoriesNoResourceWait,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccResourceMachineWithPlacement(modelName),

--- a/internal/provider/resource_machine_test.go
+++ b/internal/provider/resource_machine_test.go
@@ -5,6 +5,7 @@ package provider
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -70,6 +71,8 @@ func TestAcc_ResourceMachine_WithPlacement(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
+	os.Setenv("JUJU_WAIT_FOR_RESOURCES", "false")
+	defer os.Unsetenv("JUJU_WAIT_FOR_RESOURCES")
 	modelName := acctest.RandomWithPrefix("tf-test-machine")
 	resourceName := "juju_machine.this_machine_1"
 	resource.ParallelTest(t, resource.TestCase{

--- a/main.go
+++ b/main.go
@@ -46,9 +46,10 @@ func main() {
 		zerolog.SetGlobalLevel(zerolog.DebugLevel)
 	}
 
+	waitForResources := true
 	if err := tf6server.Serve(
 		"registry.terraform.io/juju/juju",
-		providerserver.NewProtocol6(provider.NewJujuProvider(version)),
+		providerserver.NewProtocol6(provider.NewJujuProvider(version, waitForResources)),
 		serveOpts...,
 	); err != nil {
 		log.Fatal().Msg(err.Error())


### PR DESCRIPTION
## Description
This PR speeds up tests by doing 3 things,
- Allow skipping wait-for machine readiness
- Allow connection timeout to be specified
- Replace some test charms with juju-qa-test

To enable tests to disable waiting for resources to be ready, I've done some digging and it seems the most straightforward way is to extend the provider struct with a new boolean that gets passed down to the shared client and can then be inspected by the various resource-specific clients. For the tests, there is a provider factory that is configured, I've kept the current provider factory and created a new one that always disables waiting for resources, any tests that want to disable waiting can then use this one.

## Type of change

- Change in tests (one or several tests have been changed)

