### PR TITLE
feat(endpoints): breaking change from endpoint to endpoints for offer's schema

### DIFF
--- a/docs-rtd/reference/terraform-provider/data-sources/offer.md
+++ b/docs-rtd/reference/terraform-provider/data-sources/offer.md
@@ -28,7 +28,7 @@ data "juju_offer" "this" {
 ### Read-Only
 
 - `application_name` (String) The name of the application.
-- `endpoint` (String) The endpoint name.
+- `endpoints` (Set of String) The endpoint names. Changing this value will cause the offer to be destroyed and recreated by terraform.
 - `id` (String) The ID of this resource.
 - `model` (String) The name of the model to operate in.
 - `name` (String) The name of the offer.

--- a/docs-rtd/reference/terraform-provider/resources/offer.md
+++ b/docs-rtd/reference/terraform-provider/resources/offer.md
@@ -39,7 +39,7 @@ resource "juju_integration" "myintegration" {
 ### Required
 
 - `application_name` (String) The name of the application. Changing this value will cause the offer to be destroyed and recreated by terraform.
-- `endpoint` (String) The endpoint name. Changing this value will cause the offer to be destroyed and recreated by terraform.
+- `endpoints` (Set of String) The endpoint names. Changing this value will cause the offer to be destroyed and recreated by terraform.
 - `model` (String) The name of the model to operate in. Changing this value will cause the offer to be destroyed and recreated by terraform.
 
 ### Optional

--- a/docs/data-sources/offer.md
+++ b/docs/data-sources/offer.md
@@ -28,7 +28,7 @@ data "juju_offer" "this" {
 ### Read-Only
 
 - `application_name` (String) The name of the application.
-- `endpoint` (String) The endpoint name.
+- `endpoints` (Set of String) The endpoint names. Changing this value will cause the offer to be destroyed and recreated by terraform.
 - `id` (String) The ID of this resource.
 - `model` (String) The name of the model to operate in.
 - `name` (String) The name of the offer.

--- a/docs/resources/offer.md
+++ b/docs/resources/offer.md
@@ -39,7 +39,7 @@ resource "juju_integration" "myintegration" {
 ### Required
 
 - `application_name` (String) The name of the application. Changing this value will cause the offer to be destroyed and recreated by terraform.
-- `endpoint` (String) The endpoint name. Changing this value will cause the offer to be destroyed and recreated by terraform.
+- `endpoints` (Set of String) The endpoint names. Changing this value will cause the offer to be destroyed and recreated by terraform.
 - `model` (String) The name of the model to operate in. Changing this value will cause the offer to be destroyed and recreated by terraform.
 
 ### Optional

--- a/internal/juju/offers.go
+++ b/internal/juju/offers.go
@@ -33,7 +33,7 @@ type offersClient struct {
 
 type CreateOfferInput struct {
 	ApplicationName string
-	Endpoint        string
+	Endpoints       []string
 	ModelName       string
 	ModelOwner      string
 	OfferOwner      string
@@ -51,7 +51,7 @@ type ReadOfferInput struct {
 
 type ReadOfferResponse struct {
 	ApplicationName string
-	Endpoint        string
+	Endpoints       []string
 	ModelName       string
 	Name            string
 	OfferURL        string
@@ -128,7 +128,7 @@ func (c offersClient) CreateOffer(input *CreateOfferInput) (*CreateOfferResponse
 		return nil, append(errs, err)
 	}
 
-	result, err := client.Offer(modelUUID, input.ApplicationName, []string{input.Endpoint}, input.OfferOwner, offerName, "")
+	result, err := client.Offer(modelUUID, input.ApplicationName, input.Endpoints, input.OfferOwner, offerName, "")
 	if err != nil {
 		return nil, append(errs, err)
 	}
@@ -181,7 +181,9 @@ func (c offersClient) ReadOffer(input *ReadOfferInput) (*ReadOfferResponse, erro
 	response.Name = result.OfferName
 	response.ApplicationName = result.ApplicationName
 	response.OfferURL = result.OfferURL
-	response.Endpoint = result.Endpoints[0].Name
+	for _, endpoint := range result.Endpoints {
+		response.Endpoints = append(response.Endpoints, endpoint.Name)
+	}
 	response.Users = result.Users
 
 	//no model name is returned but it can be parsed from the resulting offer URL to ensure parity

--- a/internal/provider/resource_access_jaas_offer_test.go
+++ b/internal/provider/resource_access_jaas_offer_test.go
@@ -118,7 +118,7 @@ resource "juju_application" "appone" {
 resource "juju_offer" "offerone" {
 	model            = juju_model.modelone.name
 	application_name = juju_application.appone.name
-	endpoint         = "sink"
+	endpoints         = ["sink"]
 }
 
 resource "juju_jaas_role" "test" {

--- a/internal/provider/resource_access_offer_test.go
+++ b/internal/provider/resource_access_offer_test.go
@@ -129,7 +129,7 @@ resource "juju_application" "appone" {
 resource "juju_offer" "appone_endpoint" {
   model            = juju_model.{{.ModelName}}.name
   application_name = juju_application.appone.name
-  endpoint         = "sink"
+  endpoints         = ["sink"]
 }
 
 resource "juju_access_offer" "test" {
@@ -181,7 +181,7 @@ resource "juju_application" "appone" {
 resource "juju_offer" "appone_endpoint" {
   model            = juju_model.{{.ModelName}}.name
   application_name = juju_application.appone.name
-  endpoint         = "sink"
+  endpoints         = ["sink"]
 }
 
 resource "juju_access_offer" "access_appone_endpoint" {

--- a/internal/provider/resource_integration_test.go
+++ b/internal/provider/resource_integration_test.go
@@ -193,7 +193,7 @@ resource "juju_application" "b" {
 resource "juju_offer" "b" {
 	model            = juju_model.b.name
 	application_name = juju_application.b.name
-	endpoint         = "sink"
+	endpoints         = ["sink"]
 }
 
 resource "juju_integration" "a" {
@@ -285,7 +285,7 @@ resource "juju_application" "a" {
 resource "juju_offer" "a" {
         model            = juju_model.a.name
         application_name = juju_application.a.name
-        endpoint         = "source"
+        endpoints         = ["source"]
 }
 
 resource "juju_model" "b" {


### PR DESCRIPTION
Moving to endpoints to better mirror juju behaviour. It is now possible to create a single offer with multiple endpoints. The approach here is to use `UpgradeState` to handle the state migration as suggested here https://developer.hashicorp.com/terraform/plugin/framework/resources/state-upgrade

fixes: #712 #713

# QA

## QA migration

```terraform
terraform {
  required_providers {
    juju = {
      source = "juju/juju"
      version = "0.19.0"
    }
    random = {
      source = "random"
    }
  }
}

provider "juju" {}

resource "juju_model" "development" {
  name = "dev1"
}

resource "juju_application" "this" {
  name = "this"

  model = juju_model.development.name

  charm {
    name    = "traefik-k8s"
    channel = "latest/stable"
  }
}

resource "juju_offer" "myoffer" {
  model            = juju_model.development.name
  application_name = juju_application.this.name
  # endpoint         = "ingress"
  endpoint = "ingress"
}
```
`terraform apply --auto-approve`

`make install`

```terraform

terraform {
  required_providers {
    juju = {
      source = "juju/juju"
      version = "0.20.0"
    }
    random = {
      source = "random"
    }
  }
}

provider "juju" {}

resource "juju_model" "development" {
  name = "dev1"
}

resource "juju_application" "this" {
  name = "this"

  model = juju_model.development.name

  charm {
    name    = "traefik-k8s"
    channel = "latest/stable"
  }
}

resource "juju_offer" "myoffer" {
  model            = juju_model.development.name
  application_name = juju_application.this.name
  endpoints = ["ingress"]
}
```

`terraform plan` -> no changes
### QA multiple endpoints

```terraform
resource "juju_offer" "myoffer" {
  model            = juju_model.development.name
  application_name = juju_application.local-test.name
  endpoints = ["ingress", "ingress-per-unit"]
}
```

`terraform apply --auto-approve`


`juju status` -> single offer with multiple endpoints.

