### PR TITLE
feat: add no-service-account flag to k8s resource

### DIFF
--- a/docs-rtd/reference/terraform-provider/resources/kubernetes_cloud.md
+++ b/docs-rtd/reference/terraform-provider/resources/kubernetes_cloud.md
@@ -39,6 +39,7 @@ resource "juju_model" "my-model" {
 - `kubernetes_config` (String, Sensitive) The kubernetes config file path for the cloud. Cloud credentials will be added to the Juju controller for you.
 - `parent_cloud_name` (String) The parent cloud name, for adding a k8s cluster from an existing cloud. Changing this value will cause the cloud to be destroyed and recreated by terraform. *Note* that this value must be set when running against a JAAS controller.
 - `parent_cloud_region` (String) The parent cloud region name, for adding a k8s cluster from an existing cloud. Changing this value will cause the cloud to be destroyed and recreated by terraform. *Note* that this value must be set when running against a JAAS controller.
+- `skip_service_account_creation` (Boolean) If set to true, the Juju Terraform provider will not create a service account and associated role within the K8s cluster and override the authentication info in the K8s config. This way it does not need to connect to the K8s API when adding a k8s cloud.
 
 ### Read-Only
 

--- a/docs/resources/kubernetes_cloud.md
+++ b/docs/resources/kubernetes_cloud.md
@@ -39,6 +39,7 @@ resource "juju_model" "my-model" {
 - `kubernetes_config` (String, Sensitive) The kubernetes config file path for the cloud. Cloud credentials will be added to the Juju controller for you.
 - `parent_cloud_name` (String) The parent cloud name, for adding a k8s cluster from an existing cloud. Changing this value will cause the cloud to be destroyed and recreated by terraform. *Note* that this value must be set when running against a JAAS controller.
 - `parent_cloud_region` (String) The parent cloud region name, for adding a k8s cluster from an existing cloud. Changing this value will cause the cloud to be destroyed and recreated by terraform. *Note* that this value must be set when running against a JAAS controller.
+- `skip_service_account_creation` (Boolean) If set to true, the Juju Terraform provider will not create a service account and associated role within the K8s cluster and override the authentication info in the K8s config. This way it does not need to connect to the K8s API when adding a k8s cloud.
 
 ### Read-Only
 

--- a/internal/provider/resource_kubernetes_cloud_test.go
+++ b/internal/provider/resource_kubernetes_cloud_test.go
@@ -15,10 +15,6 @@ import (
 )
 
 func TestAcc_ResourceKubernetesCloud(t *testing.T) {
-	// TODO: This test is not adding model as a resource, which is required.
-	// The reason in the race that we (potentially) have in the Juju side.
-	// Once the problem is fixed (https://bugs.launchpad.net/juju/+bug/2084448),
-	// we should add the model as a resource.
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
@@ -34,10 +30,70 @@ func TestAcc_ResourceKubernetesCloud(t *testing.T) {
 		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceKubernetesCloudWithoutModel(cloudName, "", jaasTest),
+				Config: testAccResourceKubernetesCloud(cloudName, "", jaasTest, false, true),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("juju_kubernetes_cloud."+cloudName, "name", cloudName),
 				),
+			},
+			{
+				// This step we leverage `removed` to remove the cloud from the state, so we don't issue
+				// a `Destroy` on the cloud, which would fail with "cloud is used by 1 model".
+				// This is a bug in the provider that should be solved once we wait on model's deletion.
+				Config: testAccRemovedResourceKubernetesCloud(cloudName),
+			},
+		}})
+}
+
+func TestAcc_ResourceKubernetesCloudDelete(t *testing.T) {
+	if testingCloud != LXDCloudTesting {
+		t.Skip(t.Name() + " only runs with LXD")
+	}
+	cloudName := acctest.RandomWithPrefix("tf-test-k8scloud")
+
+	jaasTest := false
+	if _, ok := os.LookupEnv("IS_JAAS"); ok {
+		jaasTest = true
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: frameworkProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceKubernetesCloud(cloudName, "", jaasTest, false, false),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("juju_kubernetes_cloud."+cloudName, "name", cloudName),
+				),
+			},
+		}})
+}
+
+func TestAcc_ResourceKubernetesCloudWithoutServiceAccount(t *testing.T) {
+	if testingCloud != LXDCloudTesting {
+		t.Skip(t.Name() + " only runs with LXD")
+	}
+	cloudName := acctest.RandomWithPrefix("tf-test-k8scloud")
+
+	jaasTest := false
+	if _, ok := os.LookupEnv("IS_JAAS"); ok {
+		jaasTest = true
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: frameworkProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceKubernetesCloud(cloudName, "", jaasTest, true, true),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("juju_kubernetes_cloud."+cloudName, "name", cloudName),
+				),
+			},
+			{
+				// This step we leverage `removed` to remove the cloud from the state, so we don't issue
+				// a `Destroy` on the cloud, which would fail with "cloud is used by 1 model".
+				// This is a bug in the provider that should be solved once we wait on model's deletion.
+				Config: testAccRemovedResourceKubernetesCloud(cloudName),
 			},
 		},
 	})
@@ -46,10 +102,6 @@ func TestAcc_ResourceKubernetesCloud(t *testing.T) {
 func TestAcc_ResourceKubernetesCloudUpdate(t *testing.T) {
 	// We don't support cloud update in JAAS.
 	SkipJAAS(t)
-	// TODO: This test is not adding model as a resource, which is required.
-	// The reason is the race that we (potentially) have in the Juju side.
-	// Once the problem is fixed (https://bugs.launchpad.net/juju/+bug/2084448),
-	// we should add the model as a resource.
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
@@ -59,17 +111,23 @@ func TestAcc_ResourceKubernetesCloudUpdate(t *testing.T) {
 		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceKubernetesCloudWithoutModel(cloudName, "", false),
+				Config: testAccResourceKubernetesCloud(cloudName, "", false, false, true),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("juju_kubernetes_cloud."+cloudName, "name", cloudName),
 				),
 			},
 			{
-				Config: testAccResourceKubernetesCloudWithoutModel(cloudName, "test string", false),
+				Config: testAccResourceKubernetesCloud(cloudName, "test string", false, false, true),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("juju_kubernetes_cloud."+cloudName, "name", cloudName),
 					resource.TestMatchResourceAttr("juju_kubernetes_cloud."+cloudName, "kubernetes_config", regexp.MustCompile(".*test string.*")),
 				),
+			},
+			{
+				// This step we leverage `removed` to remove the cloud from the state, so we don't issue
+				// a `Destroy` on the cloud, which would fail with "cloud is used by 1 model".
+				// This is a bug in the provider that should be solved once we wait on model's deletion.
+				Config: testAccRemovedResourceKubernetesCloud(cloudName),
 			},
 		},
 	})
@@ -96,10 +154,10 @@ func TestAcc_ResourceKubernetesCloudWithJAASIncompleteConfig(t *testing.T) {
 	})
 }
 
-// testAccResourceKubernetesCloudWithoutModel creates a terraform plan to test juju_kubernetes_cloud.
+// testAccResourceKubernetesCloud creates a terraform plan to test juju_kubernetes_cloud.
 // stringToAppendToConfig is a string appended as a comment to the microk8s config and it is used to simulate
 // a change in the kubernetes config.
-func testAccResourceKubernetesCloudWithoutModel(cloudName string, stringToAppendToConfig string, jaasTest bool) string {
+func testAccResourceKubernetesCloud(cloudName string, stringToAppendToConfig string, jaasTest bool, noServiceAccount bool, withModel bool) string {
 	return internaltesting.GetStringFromTemplateWithData(
 		"testAccResourceSecret",
 		`
@@ -114,11 +172,42 @@ resource "juju_kubernetes_cloud" "{{.CloudName}}" {
  parent_cloud_name = "lxd"
  parent_cloud_region = "localhost"
  {{ end }}
+ {{ if .NoServiceAccount }}
+ skip_service_account_creation = true
+ {{ end }}
 }
+
+{{ if .WithModel }}
+resource "juju_model" "{{.CloudName}}-model" {
+ name = "{{.CloudName}}-model"
+ cloud {
+		name = "{{.CloudName}}"
+ }
+
+ credential = juju_kubernetes_cloud.{{.CloudName}}.credential
+}
+{{ end }}
+
 `, internaltesting.TemplateData{
 			"CloudName":              cloudName,
 			"StringToAppendToConfig": stringToAppendToConfig,
 			"JAASTest":               jaasTest,
+			"NoServiceAccount":       noServiceAccount,
+			"WithModel":              withModel,
+		})
+}
+
+func testAccRemovedResourceKubernetesCloud(cloudName string) string {
+	return internaltesting.GetStringFromTemplateWithData(
+		"testAccRemovedResourceKubernetesCloud",
+		`
+		removed {
+  from = juju_kubernetes_cloud.{{.CloudName}}
+  lifecycle {
+    destroy = false
+  }
+}`, internaltesting.TemplateData{
+			"CloudName": cloudName,
 		})
 }
 


### PR DESCRIPTION
## Description

This PR addresses #741.
The issue is: 
- to create a k8s cloud and k8s credential the juju client (and the terraform provider) creates a k8s service account granting permissions using the provided k8s config, and then overrides the provided k8s config. 
- to accomplish all of that it needs to reach the k8s cluster API.

There are some environment where you can't reach the k8s cluster API, so we've added this `no_service_account` flag to opt-out of this behavior by using the k8s_config in the resource without creating the service_account and overriding the k8s config.

fix #741 

# QA

```terraform
provider "juju" {
}

resource "juju_kubernetes_cloud" "k8s_cloud" {
  name = "k8s-cloud-no-service-account"
  kubernetes_config = file("microk8s.yaml")
}
```
```
sudo strace -f -e trace=network /snap/terraform/current/terraform apply -auto-approve 2>&1 | grep '<k8s_api_server_ip>'
``` 
-> you should see some `[pid 206447] getsockname(7, {sa_family=AF_INET, sin_port=htons(51551), sin_addr=inet_addr("172.20.10.6")}, [112 => 16]) = 0`


`terraform destroy` and retry with the flag set.


```terraform
provider "juju" {
}

resource "juju_kubernetes_cloud" "k8s_cloud" {
  name = "k8s-cloud-no-service-account"
  kubernetes_config = file("microk8s.yaml")
  skip_service_account_creation = true
}
```

`sudo strace -f -e trace=network /snap/terraform/current/terraform apply -auto-approve 2>&1 | grep '<k8s_api_server_ip>'`  -> you should see nothing




