### PR TITLE
test(jaas-integration): bump concurrency to 3 for jaas integration tests

### DIFF
--- a/.github/workflows/test_integration_jaas.yaml
+++ b/.github/workflows/test_integration_jaas.yaml
@@ -112,5 +112,5 @@ jobs:
       - env:
           TF_ACC: "1"
           TEST_CLOUD: "lxd"
-        run: go test -parallel 1 -timeout 90m -v -cover ./internal/provider/
+        run: go test -parallel 3 -timeout 90m -v -cover ./internal/provider/
         timeout-minutes: 90


### PR DESCRIPTION
# Description

Bump concurrency for JAAS integration tests.

We can finally do it because we wait for machine deletion, which decreases a lot the possibility of running of disk space during tests.


