### PR TITLE
fix(goreleaser): fix goreleaser to enable prerelease for the terraform provider.

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,11 +2,8 @@
 # behavior.
 before:
   hooks:
-  # TODO: don't tidy beforehand to avoid current ambiguous import error
-  # - go mod tidy
+  - go mod tidy
 git:
-  # What should be used to sort tags when gathering the current and previous
-  # tags if there are more than one tag in the same commit.
   tag_sort: -version:creatordate
 builds:
 - env:
@@ -26,12 +23,16 @@ builds:
     - linux
     - darwin
   goarch:
+    - '386'
     - amd64
+    - arm
     - arm64
   ignore:
     # TODO: disabled => juju/utils symlink_windows.go:54:8: undefined: createSymbolicLink
     - goos: windows
       goarch: arm64
+    - goos: windows
+      goarch: arm
   binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
   - format: zip
@@ -55,11 +56,10 @@ signs:
       - "--detach-sign"
       - "${artifact}"
 release:
+  prerelease: auto
   extra_files:
     - glob: 'terraform-registry-manifest.json'
       name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
-  # If you want to manually examine the release before its live, uncomment this line:
-  draft: true
 changelog:
   disable: true
 version: 2


### PR DESCRIPTION
## Description

Copying from: https://github.com/ansible/terraform-provider-aap/blob/main/.goreleaser.yml. They have prereleases https://registry.terraform.io/providers/ansible/aap/latest

it seems that we have this draft option set to true, maybe that's the reason why we can't release prerelease.

