### PR TITLE
docs: make menu link point to juju.is/docs

### DIFF
--- a/docs-rtd/conf.py
+++ b/docs-rtd/conf.py
@@ -105,7 +105,7 @@ html_context = {
     # TODO: If there's no such website,
     #       remove the {{ product_page }} link from the page header template
     #       (usually .sphinx/_templates/header.html; also, see README.rst).
-    "product_page": "juju.is",
+    "product_page": "juju.is/docs",
     # Product tag image; the orange part of your logo, shown in the page header
     #
     # TODO: To add a tag image, uncomment and update as needed.


### PR DESCRIPTION
Massi wants us to migrate the docs to the ubuntu domain, for better visibility. Daniele wants us to touch some things up prior to migration. This PR makes the required changes, which include:

- On the homepage: 
  - The "In this documentation" sections starts with a bullet list of topic-based links to the docs and only then continues with the Diataxis categories. 
  - The Diataxis categories are arranged so there's no obvious gap (where Explanation would be when you have the full quadrant).
- The provider reference is promoted one level up -- as it's the only reference we'll ever have, so no need to nest. PS That reference material was only added on RTD recently, so I don't think we need to set up redirects. However, we do need to update the how-to guide links so they don't point to the TF registry anymore but rather to our internal reference; this PR does that.

The PR makes a couple of other drive-by improvements (updating the Menu link to point to juju.is/docs instead of juju.is, as the more natural next zoom out view).