### PR TITLE
fix: improve ssh key resource ID handling

### DIFF
--- a/internal/provider/resource_ssh_key.go
+++ b/internal/provider/resource_ssh_key.go
@@ -144,7 +144,7 @@ func newSSHKeyID(modelName string, keyIdentifier string) string {
 // the key identifier is currently based on the comment section of the ssh key
 // (e.g. user@hostname) (TODO: issue #267)
 func retrieveModelKeyNameFromID(id string, d *diag.Diagnostics) (string, string) {
-	tokens := strings.Split(id, ":")
+	tokens := strings.SplitN(id, ":", 3)
 	//If importing with an incorrect ID we need to catch and provide a user-friendly error
 	if len(tokens) != 3 {
 		d.AddError("Malformed ID", fmt.Sprintf("unable to parse model name and user from provided ID: %q", id))

--- a/internal/provider/resource_ssh_key_test.go
+++ b/internal/provider/resource_ssh_key_test.go
@@ -41,6 +41,27 @@ func TestAcc_ResourceSSHKey(t *testing.T) {
 	})
 }
 
+func TestAcc_ResourceSSHKey_ColonInKeyIdentifier(t *testing.T) {
+	if testingCloud != LXDCloudTesting {
+		t.Skip(t.Name() + " only runs with LXD")
+	}
+	modelName := acctest.RandomWithPrefix("tf-test-sshkey")
+	sshKey1 := `ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1I8QDP79MaHEIAlfh933zqcE8LyUt9doytF3YySBUDWippk8MAaKAJJtNb+Qsi+Kx/RsSY02VxMy9xRTp9d/Vr+U5BctKqhqf3ZkJdTIcy+z4hYpFS8A4bECJFHOnKIekIHD9glHkqzS5Vm6E4g/KMNkKylHKlDXOafhNZAiJ1ynxaZIuedrceFJNC47HnocQEtusPKpR09HGXXYhKMEubgF5tsTO4ks6pplMPvbdjxYcVOg4Wv0N/LJ4ffAucG9edMcKOTnKqZycqqZPE6KsTpSZMJi2Kl3mBrJE7JbR1YMlNwG6NlUIdIqVoTLZgLsTEkHqWi6OExykbVTqFuoWJJY2BmRAcP9T3FdLYbqcajfWshwvPM2AmYb8V3zBvzEKL1rpvG26fd3kGhk3Vu07qAUhHLMi3P0McEky4cLiEWgI7UyHFLI2yMRZgz23UUtxhRSkvCJagRlVG/s4yoylzBQJir8G3qmb36WjBXxpqAXhfLxw05EQI1JGV3ReYOs= jimmy@somewhere:ssh-rsa`
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: frameworkProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceSSHKey(modelName, sshKey1),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("juju_ssh_key.this", "model", modelName),
+					resource.TestCheckResourceAttr("juju_ssh_key.this", "payload", sshKey1)),
+			},
+		},
+	})
+}
+
 func TestAcc_ResourceSSHKey_ED25519(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")


### PR DESCRIPTION
## Description
This change fixes https://github.com/juju/terraform-provider-juju/issues/815 where an SSH key resource that has a `:` symbol in the key's identifier causes the `retrieveModelKeyNameFromID` function to fail.

To fix this use `SplitN` instead of `Split` to avoid splitting any ':' symbols in the key identifier of the SSH key.

The added test fails before the change and passes afterwards.

Fixes: https://github.com/juju/terraform-provider-juju/issues/815, [JUJU-8335](https://warthogs.atlassian.net/browse/JUJU-8335)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

[JUJU-8335]: https://warthogs.atlassian.net/browse/JUJU-8335?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ