### PR TITLE
docs: add related links

### DIFF
--- a/docs-rtd/index.md
+++ b/docs-rtd/index.md
@@ -1,5 +1,5 @@
 ---
-relatedlinks: "[Juju &nbsp; ecosystem &nbsp; docs](https://juju.is/docs), [Terraform &nbsp; Provider &nbsp; Juju &nbsp; docs](https://documentation.ubuntu.com/terraform-provider-juju/), [JAAS &nbsp; docs](https://documentation.ubuntu.com/jaas/), [Jubilant &nbsp; docs](https://documentation.ubuntu.com/jubilant/), [Charmcraft &nbsp; docs](https://documentation.ubuntu.com/charmcraft/), [Ops &nbsp; docs](https://documentation.ubuntu.com/ops/), [Charmlibs &nbsp; docs](https://canonical-charmlibs.readthedocs-hosted.com/)"
+relatedlinks: "[Juju &nbsp; ecosystem &nbsp; docs](https://juju.is/docs), [Juju &nbsp; docs](https://documentation.ubuntu.com/juju/), [JAAS &nbsp; docs](https://documentation.ubuntu.com/jaas/), [Jubilant &nbsp; docs](https://documentation.ubuntu.com/jubilant/), [Charmcraft &nbsp; docs](https://documentation.ubuntu.com/charmcraft/), [Ops &nbsp; docs](https://documentation.ubuntu.com/ops/), [Charmlibs &nbsp; docs](https://canonical-charmlibs.readthedocs-hosted.com/)"
 ---
 
 (home)=


### PR DESCRIPTION
Following https://github.com/juju/juju/pull/20358 , this PR updates the homepage to have a right-hand side RELATED LINKS block with links to all the relevant doc sets.