### PR TITLE
fix(juju_access_secret): changes applications field from list to set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ GOOS=$(shell go env GOOS)
 GOARCH=$(shell go env GOARCH)
 GOPATH=$(shell go env GOPATH)
 PARALLEL_TEST_COUNT ?= 3
-EDGE_VERSION ?= 0.21.0
+EDGE_VERSION ?= 0.22.0
 REGISTRY_DIR=~/.terraform.d/plugins/registry.terraform.io/juju/juju/${EDGE_VERSION}/${GOOS}_${GOARCH}
 
 .PHONY: install

--- a/docs-rtd/reference/terraform-provider/resources/access_secret.md
+++ b/docs-rtd/reference/terraform-provider/resources/access_secret.md
@@ -17,7 +17,7 @@ A resource that represents a Juju secret access.
 
 ### Required
 
-- `applications` (List of String) The list of applications to which the secret is granted.
+- `applications` (Set of String) The list of applications to which the secret is granted.
 - `model` (String) The model in which the secret belongs.
 - `secret_id` (String) The ID of the secret. E.g. coj8mulh8b41e8nv6p90
 

--- a/docs/resources/access_secret.md
+++ b/docs/resources/access_secret.md
@@ -17,7 +17,7 @@ A resource that represents a Juju secret access.
 
 ### Required
 
-- `applications` (List of String) The list of applications to which the secret is granted.
+- `applications` (Set of String) The list of applications to which the secret is granted.
 - `model` (String) The model in which the secret belongs.
 - `secret_id` (String) The ID of the secret. E.g. coj8mulh8b41e8nv6p90
 

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	TestProviderStableVersion = "0.20.0"
+	TestProviderStableVersion = "0.21.1"
 	isJaasEnvKey              = "IS_JAAS"
 )
 


### PR DESCRIPTION
## Description

Removes ordering issue for applications in the juju_access_secret resource.

## Type of change

- Change existing resource

## QA steps

1. init and apply the following plan
```tf
terraform {
  required_providers {
    juju = {
      source = "juju/juju"
      version = "0.21.1"
    }
  }
}

provider "juju" {
  # Configuration options
}

resource "juju_model" "test" {
  name = "test-access-secret"
}

resource "juju_application" "jul" {
  name  = "jul"
  model = juju_model.test.name

  charm {
    name     = "ubuntu-lite"
    channel  = "latest/stable"
  }

  units = 1
}

resource "juju_application" "jul2" {
  name  = "jul2"
  model = juju_model.test.name

  charm {
    name     = "ubuntu-lite"
    channel  = "latest/stable"
  }

  units = 1
}

resource "juju_secret" "test_secret" {
  model = juju_model.test.name
  name  = "test_secret_name"
  value = {
    key1 = "value1"
    key2 = "value2"
  }
  info  = "This is my secret"
}

resource "juju_access_secret" "test_access_secret" {
  model = juju_model.test.name
  applications = [
      juju_application.jul2.name, juju_application.jul.name
  ]
  secret_id = juju_secret.test_secret.secret_id
}
```
2. then `make install` to compile and install the modified provider
3. change required provider version in the plan to `0.22.0`
4. run `terraform init --upgrade`
5. apply the modified plan
6. switch the order of applications in the `juju_access_secret` resource
7. run `terraform plan`
8. assert that terraform does not detect any change
