### PR TITLE
feat(resource_secret): adds secret_uri computed field

### DIFF
--- a/docs-rtd/reference/terraform-provider/resources/secret.md
+++ b/docs-rtd/reference/terraform-provider/resources/secret.md
@@ -50,6 +50,7 @@ resource "juju_application" "my-application" {
 
 - `id` (String) The ID of the secret. Used for terraform import.
 - `secret_id` (String) The ID of the secret. E.g. coj8mulh8b41e8nv6p90
+- `secret_uri` (String) The URI of the secret. E.g. secret:coj8mulh8b41e8nv6p90
 
 ## Import
 

--- a/docs/resources/secret.md
+++ b/docs/resources/secret.md
@@ -50,6 +50,7 @@ resource "juju_application" "my-application" {
 
 - `id` (String) The ID of the secret. Used for terraform import.
 - `secret_id` (String) The ID of the secret. E.g. coj8mulh8b41e8nv6p90
+- `secret_uri` (String) The URI of the secret. E.g. secret:coj8mulh8b41e8nv6p90
 
 ## Import
 

--- a/internal/juju/secrets.go
+++ b/internal/juju/secrets.go
@@ -56,7 +56,8 @@ type CreateSecretInput struct {
 }
 
 type CreateSecretOutput struct {
-	SecretId string
+	SecretId  string
+	SecretURI string
 }
 
 type ReadSecretInput struct {
@@ -68,6 +69,7 @@ type ReadSecretInput struct {
 
 type ReadSecretOutput struct {
 	SecretId     string
+	SecretURI    string
 	Name         string
 	Value        map[string]string
 	Applications []string
@@ -141,7 +143,8 @@ func (c *secretsClient) CreateSecret(input *CreateSecretInput) (CreateSecretOutp
 		return CreateSecretOutput{}, typedError(err)
 	}
 	return CreateSecretOutput{
-		SecretId: secretURI.ID,
+		SecretId:  secretURI.ID,
+		SecretURI: secretURI.String(),
 	}, nil
 }
 
@@ -192,6 +195,7 @@ func (c *secretsClient) ReadSecret(input *ReadSecretInput) (ReadSecretOutput, er
 
 	return ReadSecretOutput{
 		SecretId:     results[0].Metadata.URI.ID,
+		SecretURI:    results[0].Metadata.URI.String(),
 		Name:         results[0].Metadata.Label,
 		Value:        decodedValue,
 		Applications: applications,

--- a/internal/provider/resource_secret_test.go
+++ b/internal/provider/resource_secret_test.go
@@ -6,6 +6,7 @@ package provider
 import (
 	"fmt"
 	"os"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -29,6 +30,8 @@ func TestAcc_ResourceSecret_CreateWithoutName(t *testing.T) {
 		"key2": "value2",
 	}
 
+	secretURIregexp := regexp.MustCompile("^secret:.+")
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: frameworkProviderFactories,
@@ -40,6 +43,7 @@ func TestAcc_ResourceSecret_CreateWithoutName(t *testing.T) {
 					resource.TestCheckResourceAttr("juju_secret.noname", "info", secretInfo),
 					resource.TestCheckResourceAttr("juju_secret.noname", "value.key1", "value1"),
 					resource.TestCheckResourceAttr("juju_secret.noname", "value.key2", "value2"),
+					resource.TestMatchResourceAttr("juju_secret.noname", "secret_uri", secretURIregexp),
 				),
 			},
 		},


### PR DESCRIPTION
## Description

Adds the `secret_uri` field to the `juju_secret` resource.

## Type of change

- Change existing resource

## QA steps

Manual QA steps should be done to test this PR.

1. create the following plan and apply it
```tf
terraform {
  required_providers {
    juju = {
      source = "juju/juju"
      version = "0.21.1"
    }
  }
}

provider "juju" {}

resource "juju_model" "test" {
  name = "test-model"
}

resource "juju_secret" "noname" {
  model = juju_model.test.name
  value =  {
    "key1" = "value1"
  }
}
```
2. run `terraform state show juju_secret.noname` and assert that the secret has been create and it's `secret_id` is set
3. run make install to compile and install the updated provider
4. modify the provider version to 0.22.0
5. run `terraform init --upgrade` and apply the plan
6. run `terraform state show juju_secret.noname` and assert that the secret has been create and it's `secret_uri` is set
