### PR TITLE
feat(access_offer): adds admin validator to the juju_access_offer

### DIFF
--- a/internal/provider/validator_access_offer_admin.go
+++ b/internal/provider/validator_access_offer_admin.go
@@ -1,0 +1,94 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the Apache License, Version 2.0, see LICENCE file for details.
+
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/juju/terraform-provider-juju/internal/juju"
+)
+
+var _ resource.ConfigValidator = &AvoidJAASValidator{}
+
+// AdminOfferUserValidator enforces the user specified in the provider is also
+// present in the admin set of the juju_access_offer.
+type AdminOfferUserValidator struct {
+	client *juju.Client
+}
+
+// NewAdminOfferUserValidator creates a new validator that enforces the user
+// specified in the provider is also present in the admin set of the juju_access_offer.
+func NewAdminOfferUserValidator(client *juju.Client) AdminOfferUserValidator {
+	return AdminOfferUserValidator{
+		client: client,
+	}
+}
+
+// Description returns a plain text description of the validator's behavior, suitable for a practitioner to understand its impact.
+func (v AdminOfferUserValidator) Description(ctx context.Context) string {
+	return v.MarkdownDescription(ctx)
+}
+
+// MarkdownDescription returns a markdown formatted description of the validator's behavior, suitable for a practitioner to understand its impact.
+func (v AdminOfferUserValidator) MarkdownDescription(_ context.Context) string {
+	return "Enforces that the admin set includes the identity configured in the provider."
+}
+
+// ValidateResource performs the validation on the resource.
+func (v AdminOfferUserValidator) ValidateResource(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var diags diag.Diagnostics
+
+	var adminSet types.Set
+	diags = req.Config.GetAttribute(ctx, path.Root("admin"), &adminSet)
+	if diags.HasError() {
+		resp.Diagnostics = diags
+		return
+	}
+
+	if adminSet.IsUnknown() || adminSet.IsNull() {
+		diags.AddAttributeError(
+			path.Root("admin"),
+			"List of administrators does not include the identity configured in the provider",
+			"The identity configured in the provider must be included in the admin set.\n\n"+
+				"Ensure that the provider identity is included in the admin set.\n",
+		)
+		return
+	}
+
+	var admins []string
+	diags = adminSet.ElementsAs(ctx, &admins, true)
+	if diags.HasError() {
+		resp.Diagnostics = diags
+		return
+	}
+
+	// Return without error if a nil client is detected.
+	// This is possible since validation is called at various points throughout resource creation.
+	if v.client != nil {
+		providerUser := v.client.Username()
+
+		found := false
+		for _, admin := range admins {
+			if admin == providerUser {
+				found = true
+				break
+			}
+		}
+		if !found {
+			diags.AddAttributeError(
+				path.Root("admin"),
+				"List of administrators does not include the identity configured in the provider",
+				"The identity configured in the provider must be included in the admin set.\n\n"+
+					"Ensure that the user '"+providerUser+"' is included in the admin set.\n",
+			)
+			resp.Diagnostics = diags
+			return
+		}
+	}
+}


### PR DESCRIPTION
## Description

The new validator ensures that the provider configured identity is included in the set of admin users.

## Type of change

- Logic changes in resources (the API interaction with Juju has been changed)

## QA steps
Manual QA steps should be done to test this PR.

1. juju bootstrap lxd
2. juju add-user test
3. juju add-user alice
4. juju add-user eve
5. juju add-user bob
6. juju add-model test-offer-access
7. juju change-user-password test
8. juju grant test admin test-offer-access
9. apply terraform plan
```
provider "juju" {
  controller_addresses = "<controller address>:17070"
  username = "test"
  password = "<password for user test>"
  ca_certificate = <<EOH
<CA cert for the controller>
EOH
}

data "juju_model" "test" {
  name = "test-offer-access"
}

resource "juju_application" "app" {
  name = "appone"
  model = data.juju_model.test.name
  charm {
    name = "juju-qa-dummy-source"
    base = "ubuntu@22.04"
  }
}

resource "juju_offer" "appoffer" {
  model            = data.juju_model.test.name
  application_name = juju_application.app.name
  endpoints         = ["sink"]
}

resource "juju_access_offer" "access_appone_endpoint" {
    offer_url = juju_offer.appoffer.url
    admin = ["alice"]
	  
    consume = ["eve"]

    read = ["bob"]
}
```
10. assert that terraform returns an error because user `test` is not in the admin set
11. modify the plan by adding user `test` to the admin set and apply the plan, which should now succeed.