### PR TITLE
feat: update model resource to use uuid

### DIFF
--- a/docs-rtd/reference/terraform-provider/resources/model.md
+++ b/docs-rtd/reference/terraform-provider/resources/model.md
@@ -66,8 +66,8 @@ Optional:
 Import is supported using the following syntax:
 
 ```shell
-# Models can be imported using the model name
-$ terraform import juju_model.development development
+# Models can be imported using the model's uuid
+$ terraform import juju_model.development a3c2c72a-75f6-43b9-9b2d-d85d5449cb2f
 ```
 
 ### Limitations of Import

--- a/docs/resources/model.md
+++ b/docs/resources/model.md
@@ -66,8 +66,8 @@ Optional:
 Import is supported using the following syntax:
 
 ```shell
-# Models can be imported using the model name
-$ terraform import juju_model.development development
+# Models can be imported using the model's uuid
+$ terraform import juju_model.development a3c2c72a-75f6-43b9-9b2d-d85d5449cb2f
 ```
 
 ### Limitations of Import

--- a/examples/resources/juju_model/import.sh
+++ b/examples/resources/juju_model/import.sh
@@ -1,2 +1,2 @@
-# Models can be imported using the model name
-$ terraform import juju_model.development development
+# Models can be imported using the model's uuid
+$ terraform import juju_model.development a3c2c72a-75f6-43b9-9b2d-d85d5449cb2f

--- a/internal/provider/resource_model.go
+++ b/internal/provider/resource_model.go
@@ -27,7 +27,6 @@ import (
 	"github.com/juju/clock"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/names/v5"
-	"github.com/juju/utils/v3"
 
 	"github.com/juju/terraform-provider-juju/internal/juju"
 	"github.com/juju/terraform-provider-juju/internal/retry"
@@ -320,26 +319,22 @@ func (r *modelResource) Read(ctx context.Context, req resource.ReadRequest, resp
 		return
 	}
 
-	// Find the model name. If the Id is a UUID, this is
-	// not an Import followed by a Read. If the Id string
-	// is not a UUID, find the model name in the Id, rather
-	// than Name as we're doing a Read after Import. Either
-	// way, we need the model name.
-	var modelName string
-	var imported bool
-	if utils.IsValidUUIDString(state.ID.ValueString()) {
-		modelName = state.Name.ValueString()
-	} else {
-		imported = true
-		modelName = state.ID.ValueString()
-	}
+	// Check if the model was imported. If the model was imported
+	// we store model details like the model's cloud and constraints.
+	// Otherwise we only read this info if plan specified them,
+	// in which case they will be set on create.
+	//
+	// This allows a user to create models without specifying a cloud
+	// or constraints, relying on the controller to choose defaults.
 
-	response, err := r.client.Models.ReadModel(modelName)
+	imported := state.UUID.ValueString() == "" && state.ID.ValueString() != ""
+	modelUUID := state.ID.ValueString()
+	response, err := r.client.Models.ReadModel(modelUUID)
 	if err != nil {
 		resp.Diagnostics.Append(handleModelNotFoundError(ctx, err, &resp.State)...)
 		return
 	}
-	r.trace(fmt.Sprintf("found model: %v", modelName))
+	r.trace(fmt.Sprintf("found model: %v", modelUUID))
 
 	// Acquire cloud, credential, and config
 	tag, err := names.ParseCloudCredentialTag(response.ModelInfo.CloudCredentialTag)
@@ -415,7 +410,7 @@ func (r *modelResource) Read(ctx context.Context, req resource.ReadRequest, resp
 
 	annotations, err := r.client.Annotations.GetAnnotations(&juju.GetAnnotationsInput{
 		EntityTag: names.NewModelTag(response.ModelInfo.UUID),
-		ModelUUID: modelName,
+		ModelUUID: modelUUID,
 	})
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to get model's annotations, got error: %s", err))
@@ -432,12 +427,12 @@ func (r *modelResource) Read(ctx context.Context, req resource.ReadRequest, resp
 		state.Annotations = annotationsMapValue
 	}
 	// Name, Type, Credential, and Id.
-	state.Name = types.StringValue(modelName)
+	state.Name = types.StringValue(response.ModelInfo.Name)
 	state.Type = types.StringValue(response.ModelInfo.Type)
 	state.Credential = types.StringValue(credential)
 	state.UUID = types.StringValue(response.ModelInfo.UUID)
 	state.ID = types.StringValue(response.ModelInfo.UUID)
-	r.trace(fmt.Sprintf("Read model resource for: %v", modelName))
+	r.trace(fmt.Sprintf("Read model resource for: %v", response.ModelInfo.Name))
 	// Set the state onto the Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }

--- a/internal/provider/resource_model_test.go
+++ b/internal/provider/resource_model_test.go
@@ -50,11 +50,7 @@ func TestAcc_ResourceModel(t *testing.T) {
 			{
 				ImportStateVerify: true,
 				ImportState:       true,
-				ImportStateVerifyIgnore: []string{
-					"config.%",
-					"config.logging-config"},
-				ImportStateId: modelName,
-				ResourceName:  resourceName,
+				ResourceName:      resourceName,
 			},
 		},
 	})


### PR DESCRIPTION
## Description

This PR updates the model resource's `Read()` method to always use a model UUID rather than a model name. It also updates the import syntax for a model from model name -> model UUID.

It's worth noting that existing import logic set the user provided string (i.e. the model name) onto the ID field, retrieved the model info then replaced the ID field with the model UUID. So there is no change in the final result here except for a change in documentation that the import must be a model UUID.

## Type of change

- Change existing resource
