### PR TITLE
feat: add model UUID validation

### DIFF
--- a/internal/provider/data_source_application.go
+++ b/internal/provider/data_source_application.go
@@ -9,9 +9,11 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
+	"github.com/juju/names/v5"
 	"github.com/juju/terraform-provider-juju/internal/juju"
 )
 
@@ -52,6 +54,9 @@ func (d *applicationDataSource) Schema(_ context.Context, _ datasource.SchemaReq
 			"model_uuid": schema.StringAttribute{
 				Description: "The uuid of the model where the application is deployed.",
 				Required:    true,
+				Validators: []validator.String{
+					ValidatorMatchString(names.IsValidModel, "must be a valid UUID"),
+				},
 			},
 		},
 	}

--- a/internal/provider/data_source_machine.go
+++ b/internal/provider/data_source_machine.go
@@ -9,9 +9,11 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
+	"github.com/juju/names/v5"
 	"github.com/juju/terraform-provider-juju/internal/juju"
 )
 
@@ -48,6 +50,9 @@ func (d *machineDataSource) Schema(_ context.Context, _ datasource.SchemaRequest
 			"model_uuid": schema.StringAttribute{
 				Description: "The UUID of the model.",
 				Required:    true,
+				Validators: []validator.String{
+					ValidatorMatchString(names.IsValidModel, "must be a valid UUID"),
+				},
 			},
 			"machine_id": schema.StringAttribute{
 				Description: "The Juju id of the machine.",

--- a/internal/provider/data_source_secrets.go
+++ b/internal/provider/data_source_secrets.go
@@ -9,9 +9,11 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
+	"github.com/juju/names/v5"
 	"github.com/juju/terraform-provider-juju/internal/juju"
 )
 
@@ -53,6 +55,9 @@ func (d *secretDataSource) Schema(_ context.Context, _ datasource.SchemaRequest,
 			"model_uuid": schema.StringAttribute{
 				Description: "The uuid of the model containing the secret.",
 				Required:    true,
+				Validators: []validator.String{
+					ValidatorMatchString(names.IsValidModel, "must be a valid UUID"),
+				},
 			},
 			"name": schema.StringAttribute{
 				Description: "The name of the secret.",

--- a/internal/provider/resource_access_jaas_model.go
+++ b/internal/provider/resource_access_jaas_model.go
@@ -106,7 +106,7 @@ func (a *jaasAccessModelResource) Schema(ctx context.Context, req resource.Schem
 		Description: "The uuid of the model for access management. If this is changed the resource will be deleted and a new resource will be created.",
 		Required:    true,
 		Validators: []validator.String{
-			ValidatorMatchString(names.IsValidModel, "model must be a valid UUID"),
+			ValidatorMatchString(names.IsValidModel, "must be a valid UUID"),
 		},
 		PlanModifiers: []planmodifier.String{
 			stringplanmodifier.RequiresReplace(),

--- a/internal/provider/resource_access_model.go
+++ b/internal/provider/resource_access_model.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
+	"github.com/juju/names/v5"
 	"github.com/juju/terraform-provider-juju/internal/juju"
 )
 
@@ -86,6 +87,9 @@ func (a *accessModelResource) Schema(_ context.Context, req resource.SchemaReque
 				Required:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
+				},
+				Validators: []validator.String{
+					ValidatorMatchString(names.IsValidModel, "must be a valid UUID"),
 				},
 			},
 			"users": schema.SetAttribute{

--- a/internal/provider/resource_access_secret.go
+++ b/internal/provider/resource_access_secret.go
@@ -13,9 +13,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/juju/collections/set"
+	"github.com/juju/names/v5"
 
 	"github.com/juju/terraform-provider-juju/internal/juju"
 )
@@ -137,6 +139,9 @@ func (s *accessSecretResource) Schema(_ context.Context, req resource.SchemaRequ
 				Required:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
+				},
+				Validators: []validator.String{
+					ValidatorMatchString(names.IsValidModel, "must be a valid UUID"),
 				},
 			},
 			"secret_id": schema.StringAttribute{

--- a/internal/provider/resource_application.go
+++ b/internal/provider/resource_application.go
@@ -29,6 +29,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/juju/core/constraints"
 	jujustorage "github.com/juju/juju/storage"
+	"github.com/juju/names/v5"
 
 	"github.com/juju/terraform-provider-juju/internal/juju"
 	"github.com/juju/terraform-provider-juju/internal/wait"
@@ -175,6 +176,9 @@ func (r *applicationResource) Schema(_ context.Context, _ resource.SchemaRequest
 				Required: true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplaceIfConfigured(),
+				},
+				Validators: []validator.String{
+					ValidatorMatchString(names.IsValidModel, "must be a valid UUID"),
 				},
 			},
 			"model_type": schema.StringAttribute{

--- a/internal/provider/resource_integration.go
+++ b/internal/provider/resource_integration.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/juju/juju/core/crossmodel"
+	"github.com/juju/names/v5"
 
 	"github.com/juju/terraform-provider-juju/internal/juju"
 	"github.com/juju/terraform-provider-juju/internal/wait"
@@ -129,6 +130,9 @@ func (r *integrationResource) Schema(_ context.Context, _ resource.SchemaRequest
 			"model_uuid": schema.StringAttribute{
 				Description: "The UUID of the model to operate in.",
 				Required:    true,
+				Validators: []validator.String{
+					ValidatorMatchString(names.IsValidModel, "must be a valid UUID"),
+				},
 			},
 			"via": schema.StringAttribute{
 				Description: "A comma separated list of CIDRs for outbound traffic.",

--- a/internal/provider/resource_machine.go
+++ b/internal/provider/resource_machine.go
@@ -141,6 +141,9 @@ func (r *machineResource) Schema(_ context.Context, req resource.SchemaRequest, 
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
+				Validators: []validator.String{
+					ValidatorMatchString(names.IsValidModel, "must be a valid UUID"),
+				},
 			},
 			ConstraintsKey: schema.StringAttribute{
 				CustomType: CustomConstraintsType{},

--- a/internal/provider/resource_offer.go
+++ b/internal/provider/resource_offer.go
@@ -15,10 +15,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
+	"github.com/juju/names/v5"
 	"github.com/juju/terraform-provider-juju/internal/juju"
 )
 
@@ -80,6 +82,9 @@ func (o *offerResource) Schema(_ context.Context, req resource.SchemaRequest, re
 				Required: true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
+				},
+				Validators: []validator.String{
+					ValidatorMatchString(names.IsValidModel, "must be a valid UUID"),
 				},
 			},
 			"name": schema.StringAttribute{

--- a/internal/provider/resource_secret.go
+++ b/internal/provider/resource_secret.go
@@ -12,9 +12,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
+	"github.com/juju/names/v5"
 	"github.com/juju/terraform-provider-juju/internal/juju"
 )
 
@@ -135,6 +137,9 @@ func (s *secretResource) Schema(_ context.Context, req resource.SchemaRequest, r
 				Required: true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
+				},
+				Validators: []validator.String{
+					ValidatorMatchString(names.IsValidModel, "must be a valid UUID"),
 				},
 			},
 			"name": schema.StringAttribute{

--- a/internal/provider/resource_ssh_key.go
+++ b/internal/provider/resource_ssh_key.go
@@ -14,9 +14,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
+	"github.com/juju/names/v5"
 	"github.com/juju/terraform-provider-juju/internal/juju"
 	"github.com/juju/utils/v3/ssh"
 )
@@ -91,6 +93,9 @@ func (s *sshKeyResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 				Required:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
+				},
+				Validators: []validator.String{
+					ValidatorMatchString(names.IsValidModel, "must be a valid UUID"),
 				},
 			},
 			"payload": schema.StringAttribute{


### PR DESCRIPTION
## Description

This PR adds a validator to all resources that reference a model uuid. The validator checks that the string is a valid uuid.

I've only added 1 test within the application resource to test the case of an invalid model UUID. It will be a lot of extra setup and test time to spin up all the necessary prerequisites if we want to write a test case for each resource.

Fixes: [JUJU-8425](https://warthogs.atlassian.net/browse/JUJU-8425)

## Type of change

- Change existing resources


[JUJU-8425]: https://warthogs.atlassian.net/browse/JUJU-8425?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ