### PR TITLE
Clarifies error for finding application offers

### DIFF
--- a/internal/juju/offers.go
+++ b/internal/juju/offers.go
@@ -252,8 +252,12 @@ func findApplicationOffers(client *applicationoffers.Client, filter crossmodel.A
 		return nil, err
 	}
 
-	if len(offers) > 1 || len(offers) == 0 {
+	if len(offers) == 0 {
 		return nil, fmt.Errorf("unable to find offer after creation")
+	}
+
+	if len(offers) > 1 {
+		return nil, fmt.Errorf("%d offers found using filter after creation", len(offers))
 	}
 
 	return offers[0], nil


### PR DESCRIPTION

## Description

Currently, the same error message is being return if no offer is found or more than 1 offer is found when using the given filter, and there's no way to distinguish the 2 cases if it occurs.

Fixes: 

## Type of change

*\<What type of a change is this? Please keep one or more relevant lines from below and delete the others.\>*

- Bug fix (non-breaking change which fixes an issue)

## Environment

- Juju controller version: 3.6.9

- Terraform version: v1.5.7

## QA steps

None

## Additional notes

*\<Please add relevant notes & information, links to mattermost chats, other related issues/PRs, anything to help understand and QA the PR.\>*
