### PR TITLE
feat: add tf-upgrader support for data sources

### DIFF
--- a/tf-upgrader/README.md
+++ b/tf-upgrader/README.md
@@ -15,6 +15,13 @@ This tool automatically transforms Juju provider resources that use `model = juj
 - `juju_secret`
 - `juju_machine`
 
+It also transforms Juju provider data sources from name to uuid references:
+
+- `juju_model`
+- `juju_application`
+- `juju_secret`
+- `juju_machine`
+
 It also upgrades output blocks that reference `juju_model.*.name` to use `juju_model.*.uuid`.
 
 ## Usage

--- a/tf-upgrader/in/juju_data_application_test.tf
+++ b/tf-upgrader/in/juju_data_application_test.tf
@@ -1,0 +1,32 @@
+# Test file for juju_application data source transformations
+data "juju_model" "existing" {
+  name = "existing-model"
+}
+
+resource "juju_model" "test" {
+  name = "test-model"
+}
+
+# juju_application with resource reference (should be upgraded)
+data "juju_application" "resource_ref" {
+  name  = "resource_ref"
+  model = juju_model.test.name
+}
+
+# juju_application with data source reference (should be upgraded)
+data "juju_application" "data_ref" {
+  name  = "data_ref"
+  model = data.juju_model.existing.name
+}
+
+# juju_application already using model_uuid (should NOT be upgraded)
+data "juju_application" "already_correct" {
+  name       = "already_correct"
+  model_uuid = juju_model.test.uuid
+}
+
+# juju_application with variable reference (should NOT be upgraded)
+data "juju_application" "with_variable" {
+  name  = "with_variable"
+  model = var.model_name
+}

--- a/tf-upgrader/in/juju_data_machine_test.tf
+++ b/tf-upgrader/in/juju_data_machine_test.tf
@@ -1,0 +1,32 @@
+# Test file for juju_machine data source transformations
+data "juju_model" "existing" {
+  name = "existing-model"
+}
+
+resource "juju_model" "test" {
+  name = "test-model"
+}
+
+# juju_machine with resource reference (should be upgraded)
+data "juju_machine" "resource_ref" {
+  machine_id = "resource_ref"
+  model      = juju_model.test.name
+}
+
+# juju_machine with data source reference (should be upgraded)
+data "juju_machine" "data_ref" {
+  machine_id  = "data_ref"
+  model       = data.juju_model.existing.name
+}
+
+# juju_machine already using model_uuid (should NOT be upgraded)
+data "juju_machine" "already_correct" {
+  machine_id = "already_correct"
+  model_uuid = juju_model.test.uuid
+}
+
+# juju_machine with variable reference (should NOT be upgraded)
+data "juju_machine" "with_variable" {
+  machine_id = "with_variable"
+  model      = var.model_name
+}

--- a/tf-upgrader/in/juju_data_model_test.tf
+++ b/tf-upgrader/in/juju_data_model_test.tf
@@ -1,0 +1,8 @@
+# Test file for juju_model data source transformations
+resource "juju_model" "test" {
+  name = "test-model"
+}
+
+data "juju_model" "test" {
+  name = juju_model.test.name
+}

--- a/tf-upgrader/in/juju_data_secret_test.tf
+++ b/tf-upgrader/in/juju_data_secret_test.tf
@@ -1,0 +1,36 @@
+# Test file for juju_secret data source transformations
+data "juju_model" "existing" {
+  name = "existing-model"
+}
+
+resource "juju_model" "test" {
+  name = "test-model"
+}
+
+# juju_secret with resource reference (should be upgraded)
+data "juju_secret" "resource_ref" {
+  name      = "resource_ref"
+  secret_id = "x"
+  model     = juju_model.test.name
+}
+
+# juju_secret with data source reference (should be upgraded)
+data "juju_secret" "data_ref" {
+  name      = "data_ref"
+  secret_id = "x"
+  model     = data.juju_model.existing.name
+}
+
+# juju_secret already using model_uuid (should NOT be upgraded)
+data "juju_secret" "already_correct" {
+  name       = "already_correct"
+  secret_id  = "x"
+  model_uuid = juju_model.test.uuid
+}
+
+# juju_secret with variable reference (should NOT be upgraded)
+data "juju_secret" "with_variable" {
+  name      = "with_variable"
+  secret_id = "x"
+  model     = var.model_name
+}

--- a/tf-upgrader/main_test.go
+++ b/tf-upgrader/main_test.go
@@ -66,13 +66,13 @@ func TestDiscoverTerraformFiles(t *testing.T) {
 		{
 			name:          "discover files from in folder",
 			target:        "in",
-			expectedCount: 9,
+			expectedCount: 13,
 			expectError:   false,
 		},
 		{
 			name:          "discover files from in folder with relative path",
 			target:        filepath.Join(".", "in"),
-			expectedCount: 9,
+			expectedCount: 13,
 			expectError:   false,
 		},
 		{

--- a/tf-upgrader/out/juju_data_application_test.tf
+++ b/tf-upgrader/out/juju_data_application_test.tf
@@ -1,0 +1,32 @@
+# Test file for juju_application data source transformations
+data "juju_model" "existing" {
+  name = "existing-model"
+}
+
+resource "juju_model" "test" {
+  name = "test-model"
+}
+
+# juju_application with resource reference (should be upgraded)
+data "juju_application" "resource_ref" {
+  name       = "resource_ref"
+  model_uuid = juju_model.test.uuid
+}
+
+# juju_application with data source reference (should be upgraded)
+data "juju_application" "data_ref" {
+  name       = "data_ref"
+  model_uuid = data.juju_model.existing.uuid
+}
+
+# juju_application already using model_uuid (should NOT be upgraded)
+data "juju_application" "already_correct" {
+  name       = "already_correct"
+  model_uuid = juju_model.test.uuid
+}
+
+# juju_application with variable reference (should NOT be upgraded)
+data "juju_application" "with_variable" {
+  name  = "with_variable"
+  model = var.model_name
+}

--- a/tf-upgrader/out/juju_data_machine_test.tf
+++ b/tf-upgrader/out/juju_data_machine_test.tf
@@ -1,0 +1,32 @@
+# Test file for juju_machine data source transformations
+data "juju_model" "existing" {
+  name = "existing-model"
+}
+
+resource "juju_model" "test" {
+  name = "test-model"
+}
+
+# juju_machine with resource reference (should be upgraded)
+data "juju_machine" "resource_ref" {
+  machine_id = "resource_ref"
+  model_uuid = juju_model.test.uuid
+}
+
+# juju_machine with data source reference (should be upgraded)
+data "juju_machine" "data_ref" {
+  machine_id = "data_ref"
+  model_uuid = data.juju_model.existing.uuid
+}
+
+# juju_machine already using model_uuid (should NOT be upgraded)
+data "juju_machine" "already_correct" {
+  machine_id = "already_correct"
+  model_uuid = juju_model.test.uuid
+}
+
+# juju_machine with variable reference (should NOT be upgraded)
+data "juju_machine" "with_variable" {
+  machine_id = "with_variable"
+  model      = var.model_name
+}

--- a/tf-upgrader/out/juju_data_model_test.tf
+++ b/tf-upgrader/out/juju_data_model_test.tf
@@ -1,0 +1,8 @@
+# Test file for juju_model data source transformations
+resource "juju_model" "test" {
+  name = "test-model"
+}
+
+data "juju_model" "test" {
+  uuid = juju_model.test.uuid
+}

--- a/tf-upgrader/out/juju_data_secret_test.tf
+++ b/tf-upgrader/out/juju_data_secret_test.tf
@@ -1,0 +1,36 @@
+# Test file for juju_secret data source transformations
+data "juju_model" "existing" {
+  name = "existing-model"
+}
+
+resource "juju_model" "test" {
+  name = "test-model"
+}
+
+# juju_secret with resource reference (should be upgraded)
+data "juju_secret" "resource_ref" {
+  name       = "resource_ref"
+  secret_id  = "x"
+  model_uuid = juju_model.test.uuid
+}
+
+# juju_secret with data source reference (should be upgraded)
+data "juju_secret" "data_ref" {
+  name       = "data_ref"
+  secret_id  = "x"
+  model_uuid = data.juju_model.existing.uuid
+}
+
+# juju_secret already using model_uuid (should NOT be upgraded)
+data "juju_secret" "already_correct" {
+  name       = "already_correct"
+  secret_id  = "x"
+  model_uuid = juju_model.test.uuid
+}
+
+# juju_secret with variable reference (should NOT be upgraded)
+data "juju_secret" "with_variable" {
+  name      = "with_variable"
+  secret_id = "x"
+  model     = var.model_name
+}


### PR DESCRIPTION
## Description

Add support to `tf-upgrader` to also upgrade our 3 data sources.

## QA steps

`cd tf-upgrader`

Create `example.tf`:
```tf
resource "juju_model" "test" {
  name = "dev-environment"
}

data "juju_application" "database" {
  name  = "postgres"
  model = juju_model.test.name
}
```

Run `go run . example.tf` and you will see the file being updated with explanations.
