### PR TITLE
feat(tf-upgrader): upgrade required_providers from 0.x to 1.0.0

### DIFF
--- a/tf-upgrader/README.md
+++ b/tf-upgrader/README.md
@@ -24,6 +24,8 @@ It also transforms Juju provider data sources from name to uuid references:
 
 It also upgrades output blocks that reference `juju_model.*.name` to use `juju_model.*.uuid`.
 
+It also upgrades the `required_providers` block from specifying version `0.x` to `>= 1.0.0`.
+
 ## Usage
 
 Upgrade a single file:

--- a/tf-upgrader/in/terraform_block.tf
+++ b/tf-upgrader/in/terraform_block.tf
@@ -1,0 +1,38 @@
+terraform {
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = ">= 0.15.0"
+    }
+    github = {
+      source  = "hashicorp/github"
+      version = "6.6.0"
+    }
+  }
+
+  required_version = ">= 1.5.0"
+}
+
+terraform {
+  required_providers {
+    github = {
+      source  = "hashicorp/github"
+      version = "6.6.0"
+    }
+    juju = {
+      source  = "juju/juju"
+      version = ">= 0.15.0"
+    }
+  }
+  required_version = ">= 1.5.0"
+}
+
+terraform {
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = ">= 0.15.0"
+    }
+  }
+  required_version = ">= 1.5.0"
+}

--- a/tf-upgrader/main_test.go
+++ b/tf-upgrader/main_test.go
@@ -66,13 +66,13 @@ func TestDiscoverTerraformFiles(t *testing.T) {
 		{
 			name:          "discover files from in folder",
 			target:        "in",
-			expectedCount: 13,
+			expectedCount: 14,
 			expectError:   false,
 		},
 		{
 			name:          "discover files from in folder with relative path",
 			target:        filepath.Join(".", "in"),
-			expectedCount: 13,
+			expectedCount: 14,
 			expectError:   false,
 		},
 		{

--- a/tf-upgrader/out/terraform_block.tf
+++ b/tf-upgrader/out/terraform_block.tf
@@ -1,0 +1,38 @@
+terraform {
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = ">=1.0.0"
+    }
+    github = {
+      source  = "hashicorp/github"
+      version = "6.6.0"
+    }
+  }
+
+  required_version = ">= 1.5.0"
+}
+
+terraform {
+  required_providers {
+    github = {
+      source  = "hashicorp/github"
+      version = "6.6.0"
+    }
+    juju = {
+      source  = "juju/juju"
+      version = ">=1.0.0"
+    }
+  }
+  required_version = ">= 1.5.0"
+}
+
+terraform {
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = ">=1.0.0"
+    }
+  }
+  required_version = ">= 1.5.0"
+}


### PR DESCRIPTION
## Description

Support upgrading `required_providers` for the tf-upgrader.

From: 
```terraform
terraform {
  required_providers {
     juju = {
       source = "juju/juju" 
      version = ">= 0.15.0"
     }
  }
}
```

to

```terraform
terraform {
  required_providers {
     juju = {
       source = "juju/juju" 
      version = ">=1.0.0"
     }
  }
}
```