### PR TITLE
test(generate-env-file): add script to generate env file from switched controller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ modules-dev/
 .envrc
 vendor/
 __debug_bin
+test.env

--- a/Makefile
+++ b/Makefile
@@ -105,3 +105,8 @@ install-dependencies: install-snap-dependencies
 ## install-dependencies: Install all the dependencies
 
 check: juju-unit-test
+
+generate-env-file:
+## populate-env: Populate the test.env file with current juju controller details.
+	@echo "Populating the test.env file with current juju controller details"
+	@./tools/generate_env_file.sh

--- a/tools/generate_env_file.sh
+++ b/tools/generate_env_file.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -e
+
+# generate_env_file.sh
+# This script extracts the current Juju controller's environment variables
+# and writes them to a test.env file. It retrieves the controller's API endpoints,
+# username, password, CA certificate, cloud name, cloud type, and user system
+# architecture, and writes them in KEY="value" format.
+#
+# This enables the developer to quickly set up environment variables for
+# testing the terraform provider without needing to manually configure them.
+
+ENV_FILE="./test.env"
+
+# Get current controller information
+CONTROLLER=$(juju whoami | yq -r '.Controller')
+JUJU_CONTROLLER_ADDRESSES=$(juju show-controller | yq -r ".${CONTROLLER}.details.api-endpoints | join(\",\")")
+JUJU_USERNAME=$(cat ~/.local/share/juju/accounts.yaml | yq -r ".controllers.${CONTROLLER}.user")
+JUJU_PASSWORD=$(cat ~/.local/share/juju/accounts.yaml | yq -r ".controllers.${CONTROLLER}.password")
+JUJU_CA_CERT=$(juju show-controller "${CONTROLLER}" | yq -r ".${CONTROLLER}.details.\"ca-cert\"" | awk '{printf "%s\\n", $0}' | sed 's/\\n$//')
+
+# Get cloud information
+CLOUD_NAME=$(juju show-controller "${CONTROLLER}" | yq -r ".${CONTROLLER}.details.cloud")
+CLOUD_TYPE=$(juju show-cloud "$CLOUD_NAME" --format json | jq -r --arg cloud "$CLOUD_NAME" '.[] | select(.name == $cloud and .defined == "public") | .type')
+
+# Map kubernetes/k8s to microk8s for testing
+if [ "$CLOUD_TYPE" = "kubernetes" ] || [ "$CLOUD_TYPE" = "k8s" ]; then
+    CLOUD_TYPE="microk8s"
+fi
+
+
+# Write environment variables to test.env file
+cat > "$ENV_FILE" << EOF
+TF_ACC="1"
+JUJU_CONTROLLER_ADDRESSES="$JUJU_CONTROLLER_ADDRESSES"
+CONTROLLER="$CONTROLLER"
+JUJU_USERNAME="$JUJU_USERNAME"
+JUJU_PASSWORD="$JUJU_PASSWORD"
+JUJU_CA_CERT="$JUJU_CA_CERT"
+TEST_CLOUD="$CLOUD_TYPE"
+EOF
+
+echo "Environment variables written to $ENV_FILE"


### PR DESCRIPTION
# Description

This enables configuring test runners with the current switched controller by running `make generate-env-file` and configuring the test runner accordingly.

> ATM it doesn't work with JAAS.

# QA

add this to your `settings.json` in vscode:

`"go.testEnvFile": "${workspaceFolder}/test.env",`

juju switch <lxd_controller>
`make generate-env-file`
Check the content of test.env.

Run `TestAcc_ResourceModel_Minimal` and it should work.

juju switch <microk8s_controller>
`make generate-env-file`
Check the content of test.env

Run `TestAcc_ResourceModel_Minimal` and it should work.

Now to show that the test runner is picking changes from `test.env`, change the IP address in `test.env` to a random ip address and the test runner should timeout.
