### PR TITLE
feat(tf-upgrader): handle deprecated fields by issuing warning or replacing the field

### DIFF
--- a/tf-upgrader/README.md
+++ b/tf-upgrader/README.md
@@ -26,6 +26,12 @@ It also upgrades output blocks that reference `juju_model.*.name` to use `juju_m
 
 It also upgrades the `required_providers` block from specifying version `0.x` to `>= 1.0.0`.
 
+It also handles deprecated fields in resource configurations:
+
+- **`placement`**: Shows a warning for `juju_application` resources using the deprecated `placement` field, recommending migration to the `machines` field
+- **`principal`**: Automatically removes the unused `principal` field from `juju_application` resources  
+- **`series`**: Automatically upgrades the deprecated `series` field to `base` for both `juju_application` and `juju_machine` resources
+
 ## Usage
 
 Upgrade a single file:
@@ -77,6 +83,8 @@ output "model_name" {
 - Resources without model references
 
 The tool will show warnings for variables that contain "model" in their name, as these may need manual review.
+
+The tool will also show warnings for deprecated fields that require manual intervention, such as the `placement` field which should be migrated to use the `machines` field according to the documentation.
 
 ## Testing
 

--- a/tf-upgrader/in/multiple_deprecated_test.tf
+++ b/tf-upgrader/in/multiple_deprecated_test.tf
@@ -1,0 +1,15 @@
+resource "juju_application" "wordpress" {
+  model = juju_model.my_model.name
+  name  = "wordpress"
+  charm {
+    name = "wordpress"
+  }
+  placement = "0"
+  principal = true
+  series    = "jammy"
+  units     = 1
+}
+
+resource "juju_model" "my_model" {
+  name = "wordpress-model"
+}

--- a/tf-upgrader/in/principal_removal_test.tf
+++ b/tf-upgrader/in/principal_removal_test.tf
@@ -1,0 +1,13 @@
+resource "juju_application" "wordpress" {
+  model = juju_model.my_model.name
+  name  = "wordpress"
+  charm {
+    name = "wordpress"
+  }
+  principal = true
+  units     = 1
+}
+
+resource "juju_model" "my_model" {
+  name = "wordpress-model"
+}

--- a/tf-upgrader/in/series_to_base_app_test.tf
+++ b/tf-upgrader/in/series_to_base_app_test.tf
@@ -1,0 +1,13 @@
+resource "juju_application" "wordpress" {
+  model = juju_model.my_model.name
+  name  = "wordpress"
+  charm {
+    name = "wordpress"
+  }
+  series = "jammy"
+  units  = 1
+}
+
+resource "juju_model" "my_model" {
+  name = "wordpress-model"
+}

--- a/tf-upgrader/in/series_to_base_machine_test.tf
+++ b/tf-upgrader/in/series_to_base_machine_test.tf
@@ -1,0 +1,8 @@
+resource "juju_machine" "machine1" {
+  model  = juju_model.my_model.name
+  series = "jammy"
+}
+
+resource "juju_model" "my_model" {
+  name = "machine-model"
+}

--- a/tf-upgrader/main_test.go
+++ b/tf-upgrader/main_test.go
@@ -66,13 +66,13 @@ func TestDiscoverTerraformFiles(t *testing.T) {
 		{
 			name:          "discover files from in folder",
 			target:        "in",
-			expectedCount: 14,
+			expectedCount: 18,
 			expectError:   false,
 		},
 		{
 			name:          "discover files from in folder with relative path",
 			target:        filepath.Join(".", "in"),
-			expectedCount: 14,
+			expectedCount: 18,
 			expectError:   false,
 		},
 		{

--- a/tf-upgrader/out/multiple_deprecated_test.tf
+++ b/tf-upgrader/out/multiple_deprecated_test.tf
@@ -1,0 +1,14 @@
+resource "juju_application" "wordpress" {
+  name = "wordpress"
+  charm {
+    name = "wordpress"
+  }
+  placement  = "0"
+  units      = 1
+  model_uuid = juju_model.my_model.uuid
+  base       = "jammy"
+}
+
+resource "juju_model" "my_model" {
+  name = "wordpress-model"
+}

--- a/tf-upgrader/out/principal_removal_test.tf
+++ b/tf-upgrader/out/principal_removal_test.tf
@@ -1,0 +1,12 @@
+resource "juju_application" "wordpress" {
+  name = "wordpress"
+  charm {
+    name = "wordpress"
+  }
+  units      = 1
+  model_uuid = juju_model.my_model.uuid
+}
+
+resource "juju_model" "my_model" {
+  name = "wordpress-model"
+}

--- a/tf-upgrader/out/series_to_base_app_test.tf
+++ b/tf-upgrader/out/series_to_base_app_test.tf
@@ -1,0 +1,13 @@
+resource "juju_application" "wordpress" {
+  name = "wordpress"
+  charm {
+    name = "wordpress"
+  }
+  units      = 1
+  model_uuid = juju_model.my_model.uuid
+  base       = "jammy"
+}
+
+resource "juju_model" "my_model" {
+  name = "wordpress-model"
+}

--- a/tf-upgrader/out/series_to_base_machine_test.tf
+++ b/tf-upgrader/out/series_to_base_machine_test.tf
@@ -1,0 +1,8 @@
+resource "juju_machine" "machine1" {
+  model_uuid = juju_model.my_model.uuid
+  base       = "jammy"
+}
+
+resource "juju_model" "my_model" {
+  name = "machine-model"
+}


### PR DESCRIPTION
## Description

Handle deprecated fields.

I've decided not to handle `machines` automatically because it can require creating new machine resources, and in general is not an obvious upgrade path.
