### PR TITLE
feat(tf-upgrader): support upgrade model -> model_uuid even when variables are used

### DIFF
--- a/juju-tf-upgrader/in/juju_access_model_test.tf
+++ b/juju-tf-upgrader/in/juju_access_model_test.tf
@@ -28,7 +28,7 @@ resource "juju_access_model" "already_correct" {
   users      = ["admin"]
 }
 
-# juju_access_model with variable reference (should NOT be upgraded)
+# juju_access_model with variable reference (should be upgraded)
 resource "juju_access_model" "with_variable" {
   access = "read"
   model  = var.model_name

--- a/juju-tf-upgrader/in/juju_access_secret_test.tf
+++ b/juju-tf-upgrader/in/juju_access_secret_test.tf
@@ -31,7 +31,7 @@ resource "juju_access_secret" "already_correct" {
   users      = ["admin"]
 }
 
-# juju_access_secret with variable reference (should NOT be upgraded)
+# juju_access_secret with variable reference (should be upgraded)
 resource "juju_access_secret" "with_variable" {
   access    = "read"
   model     = var.model_name

--- a/juju-tf-upgrader/in/juju_application_test.tf
+++ b/juju-tf-upgrader/in/juju_application_test.tf
@@ -35,7 +35,7 @@ resource "juju_application" "already_correct" {
   model_uuid = juju_model.development.uuid
 }
 
-# juju_application with variable reference (should NOT be upgraded)
+# juju_application with variable reference (should be upgraded)
 resource "juju_application" "with_variable" {
   name = "mysql"
   charm {

--- a/juju-tf-upgrader/in/juju_data_application_test.tf
+++ b/juju-tf-upgrader/in/juju_data_application_test.tf
@@ -25,7 +25,7 @@ data "juju_application" "already_correct" {
   model_uuid = juju_model.test.uuid
 }
 
-# juju_application with variable reference (should NOT be upgraded)
+# juju_application with variable reference (should be upgraded)
 data "juju_application" "with_variable" {
   name  = "with_variable"
   model = var.model_name

--- a/juju-tf-upgrader/in/juju_data_machine_test.tf
+++ b/juju-tf-upgrader/in/juju_data_machine_test.tf
@@ -25,7 +25,7 @@ data "juju_machine" "already_correct" {
   model_uuid = juju_model.test.uuid
 }
 
-# juju_machine with variable reference (should NOT be upgraded)
+# juju_machine with variable reference (should be upgraded)
 data "juju_machine" "with_variable" {
   machine_id = "with_variable"
   model      = var.model_name

--- a/juju-tf-upgrader/in/juju_data_secret_test.tf
+++ b/juju-tf-upgrader/in/juju_data_secret_test.tf
@@ -28,7 +28,7 @@ data "juju_secret" "already_correct" {
   model_uuid = juju_model.test.uuid
 }
 
-# juju_secret with variable reference (should NOT be upgraded)
+# juju_secret with variable reference (should be upgraded)
 data "juju_secret" "with_variable" {
   name      = "with_variable"
   secret_id = "x"

--- a/juju-tf-upgrader/in/juju_integration_test.tf
+++ b/juju-tf-upgrader/in/juju_integration_test.tf
@@ -42,7 +42,7 @@ resource "juju_integration" "already_upgraded" {
   }
 }
 
-# juju_integration that should NOT be upgraded (model references variable)
+# juju_integration that should be upgraded (model references variable)
 resource "juju_integration" "variable_ref" {
   model = var.model_name
 

--- a/juju-tf-upgrader/in/juju_machine_test.tf
+++ b/juju-tf-upgrader/in/juju_machine_test.tf
@@ -31,7 +31,7 @@ resource "juju_machine" "already_correct" {
   constraints = "tags=correct-tag"
 }
 
-# juju_machine with variable reference (should NOT be upgraded)
+# juju_machine with variable reference (should be upgraded)
 resource "juju_machine" "with_variable" {
   model       = var.model_name
   base        = "ubuntu@22.04"

--- a/juju-tf-upgrader/in/juju_offer_test.tf
+++ b/juju-tf-upgrader/in/juju_offer_test.tf
@@ -28,7 +28,7 @@ resource "juju_offer" "already_correct" {
   endpoints        = ["endpoint"]
 }
 
-# juju_offer with variable reference (should NOT be upgraded)
+# juju_offer with variable reference (should be upgraded)
 resource "juju_offer" "with_variable" {
   model            = var.model_name
   application_name = "var-app"

--- a/juju-tf-upgrader/in/juju_secret_test.tf
+++ b/juju-tf-upgrader/in/juju_secret_test.tf
@@ -37,7 +37,7 @@ resource "juju_secret" "already_correct" {
   }
 }
 
-# juju_secret with variable reference (should NOT be upgraded)
+# juju_secret with variable reference (should be upgraded)
 resource "juju_secret" "with_variable" {
   model = var.model_name
   name  = "var_secret"

--- a/juju-tf-upgrader/in/juju_ssh_key_test.tf
+++ b/juju-tf-upgrader/in/juju_ssh_key_test.tf
@@ -25,7 +25,7 @@ resource "juju_ssh_key" "already_correct" {
   payload    = "ssh-rsa AAAAB3NzaC1yc2E..."
 }
 
-# juju_ssh_key with variable reference (should NOT be upgraded)
+# juju_ssh_key with variable reference (should be upgraded)
 resource "juju_ssh_key" "with_variable" {
   model   = var.model_name
   payload = "ssh-rsa AAAAB3NzaC1yc2E..."

--- a/juju-tf-upgrader/out/juju_access_model_test.tf
+++ b/juju-tf-upgrader/out/juju_access_model_test.tf
@@ -28,9 +28,9 @@ resource "juju_access_model" "already_correct" {
   users      = ["admin"]
 }
 
-# juju_access_model with variable reference (should NOT be upgraded)
+# juju_access_model with variable reference (should be upgraded)
 resource "juju_access_model" "with_variable" {
-  access = "read"
-  model  = var.model_name
-  users  = ["user1"]
+  access     = "read"
+  users      = ["user1"]
+  model_uuid = var.model_name
 }

--- a/juju-tf-upgrader/out/juju_access_secret_test.tf
+++ b/juju-tf-upgrader/out/juju_access_secret_test.tf
@@ -31,10 +31,10 @@ resource "juju_access_secret" "already_correct" {
   users      = ["admin"]
 }
 
-# juju_access_secret with variable reference (should NOT be upgraded)
+# juju_access_secret with variable reference (should be upgraded)
 resource "juju_access_secret" "with_variable" {
-  access    = "read"
-  model     = var.model_name
-  secret_id = "secret:jkl012"
-  users     = ["user1"]
+  access     = "read"
+  secret_id  = "secret:jkl012"
+  users      = ["user1"]
+  model_uuid = var.model_name
 }

--- a/juju-tf-upgrader/out/juju_application_test.tf
+++ b/juju-tf-upgrader/out/juju_application_test.tf
@@ -35,11 +35,11 @@ resource "juju_application" "already_correct" {
   model_uuid = juju_model.development.uuid
 }
 
-# juju_application with variable reference (should NOT be upgraded)
+# juju_application with variable reference (should be upgraded)
 resource "juju_application" "with_variable" {
   name = "mysql"
   charm {
     name = "mysql"
   }
-  model = var.model_name
+  model_uuid = var.model_name
 }

--- a/juju-tf-upgrader/out/juju_data_application_test.tf
+++ b/juju-tf-upgrader/out/juju_data_application_test.tf
@@ -25,8 +25,8 @@ data "juju_application" "already_correct" {
   model_uuid = juju_model.test.uuid
 }
 
-# juju_application with variable reference (should NOT be upgraded)
+# juju_application with variable reference (should be upgraded)
 data "juju_application" "with_variable" {
-  name  = "with_variable"
-  model = var.model_name
+  name       = "with_variable"
+  model_uuid = var.model_name
 }

--- a/juju-tf-upgrader/out/juju_data_machine_test.tf
+++ b/juju-tf-upgrader/out/juju_data_machine_test.tf
@@ -25,8 +25,8 @@ data "juju_machine" "already_correct" {
   model_uuid = juju_model.test.uuid
 }
 
-# juju_machine with variable reference (should NOT be upgraded)
+# juju_machine with variable reference (should be upgraded)
 data "juju_machine" "with_variable" {
   machine_id = "with_variable"
-  model      = var.model_name
+  model_uuid = var.model_name
 }

--- a/juju-tf-upgrader/out/juju_data_secret_test.tf
+++ b/juju-tf-upgrader/out/juju_data_secret_test.tf
@@ -28,9 +28,9 @@ data "juju_secret" "already_correct" {
   model_uuid = juju_model.test.uuid
 }
 
-# juju_secret with variable reference (should NOT be upgraded)
+# juju_secret with variable reference (should be upgraded)
 data "juju_secret" "with_variable" {
-  name      = "with_variable"
-  secret_id = "x"
-  model     = var.model_name
+  name       = "with_variable"
+  secret_id  = "x"
+  model_uuid = var.model_name
 }

--- a/juju-tf-upgrader/out/juju_integration_test.tf
+++ b/juju-tf-upgrader/out/juju_integration_test.tf
@@ -42,9 +42,8 @@ resource "juju_integration" "already_upgraded" {
   }
 }
 
-# juju_integration that should NOT be upgraded (model references variable)
+# juju_integration that should be upgraded (model references variable)
 resource "juju_integration" "variable_ref" {
-  model = var.model_name
 
   application {
     name = "app1"
@@ -53,4 +52,5 @@ resource "juju_integration" "variable_ref" {
   application {
     name = "app2"
   }
+  model_uuid = var.model_name
 }

--- a/juju-tf-upgrader/out/juju_machine_test.tf
+++ b/juju-tf-upgrader/out/juju_machine_test.tf
@@ -31,10 +31,10 @@ resource "juju_machine" "already_correct" {
   constraints = "tags=correct-tag"
 }
 
-# juju_machine with variable reference (should NOT be upgraded)
+# juju_machine with variable reference (should be upgraded)
 resource "juju_machine" "with_variable" {
-  model       = var.model_name
   base        = "ubuntu@22.04"
   name        = "var_machine"
   constraints = "cores=2"
+  model_uuid  = var.model_name
 }

--- a/juju-tf-upgrader/out/juju_offer_test.tf
+++ b/juju-tf-upgrader/out/juju_offer_test.tf
@@ -28,9 +28,9 @@ resource "juju_offer" "already_correct" {
   endpoints        = ["endpoint"]
 }
 
-# juju_offer with variable reference (should NOT be upgraded)
+# juju_offer with variable reference (should be upgraded)
 resource "juju_offer" "with_variable" {
-  model            = var.model_name
   application_name = "var-app"
   endpoints        = ["db"]
+  model_uuid       = var.model_name
 }

--- a/juju-tf-upgrader/out/juju_secret_test.tf
+++ b/juju-tf-upgrader/out/juju_secret_test.tf
@@ -37,11 +37,11 @@ resource "juju_secret" "already_correct" {
   }
 }
 
-# juju_secret with variable reference (should NOT be upgraded)
+# juju_secret with variable reference (should be upgraded)
 resource "juju_secret" "with_variable" {
-  model = var.model_name
-  name  = "var_secret"
+  name = "var_secret"
   value = {
     token = "xyz789"
   }
+  model_uuid = var.model_name
 }

--- a/juju-tf-upgrader/out/juju_ssh_key_test.tf
+++ b/juju-tf-upgrader/out/juju_ssh_key_test.tf
@@ -25,8 +25,8 @@ resource "juju_ssh_key" "already_correct" {
   payload    = "ssh-rsa AAAAB3NzaC1yc2E..."
 }
 
-# juju_ssh_key with variable reference (should NOT be upgraded)
+# juju_ssh_key with variable reference (should be upgraded)
 resource "juju_ssh_key" "with_variable" {
-  model   = var.model_name
-  payload = "ssh-rsa AAAAB3NzaC1yc2E..."
+  payload    = "ssh-rsa AAAAB3NzaC1yc2E..."
+  model_uuid = var.model_name
 }


### PR DESCRIPTION
## Description

By QAing the tool on big modules and plans, I've realised most of our users use `var.model` instead of importing the model with a data source.
In this PR we add support for that in the `tf-upgrader`.