### PR TITLE
feat: allow changing charm channel and revision together

### DIFF
--- a/internal/juju/applications.go
+++ b/internal/juju/applications.go
@@ -1533,7 +1533,8 @@ func (c applicationsClient) computeCharmID(
 		// the ID. This needs to be fixed in Juju.
 		newOrigin.ID = ""
 		newOrigin.Hash = ""
-	} else if input.Channel != "" {
+	}
+	if input.Channel != "" {
 		parsedChannel, err := charm.ParseChannel(input.Channel)
 		if err != nil {
 			return apiapplication.CharmID{}, err
@@ -1573,7 +1574,8 @@ func (c applicationsClient) computeCharmID(
 		// The idea is that deploying with ID and Hash set to "" will force Juju to find the revision set by the user.
 		oldOrigin.ID = newOrigin.ID
 		oldOrigin.Hash = newOrigin.Hash
-	} else if input.Channel != "" {
+	}
+	if input.Channel != "" {
 		oldOrigin.Track = newOrigin.Track
 		oldOrigin.Risk = newOrigin.Risk
 		oldOrigin.Branch = newOrigin.Branch

--- a/internal/provider/resource_application.go
+++ b/internal/provider/resource_application.go
@@ -977,11 +977,10 @@ func (r *applicationResource) Update(ctx context.Context, req resource.UpdateReq
 		}
 		planCharm := planCharms[0]
 		stateCharm := stateCharms[0]
-		if !planCharm.Channel.Equal(stateCharm.Channel) && !planCharm.Revision.Equal(stateCharm.Revision) {
-			resp.Diagnostics.AddWarning("Not Supported", "Changing an application's revision and channel at the same time.")
-		} else if !planCharm.Channel.Equal(stateCharm.Channel) {
+		if !planCharm.Channel.Equal(stateCharm.Channel) {
 			updateApplicationInput.Channel = planCharm.Channel.ValueString()
-		} else if !planCharm.Revision.Equal(stateCharm.Revision) {
+		}
+		if !planCharm.Revision.Equal(stateCharm.Revision) {
 			updateApplicationInput.Revision = intPtr(planCharm.Revision)
 		}
 		if !planCharm.Base.Equal(stateCharm.Base) {


### PR DESCRIPTION
## Description

Fixes: https://warthogs.atlassian.net/browse/JUJU-8530 https://github.com/juju/terraform-provider-juju/issues/498

## Type of change

- Change existing resource
- Logic changes in resources (the API interaction with Juju has been changed)
- Change in tests (one or several tests have been changed)

## QA steps

Manual QA steps should be done to test this PR.

```terraform
provider "juju" {}

resource "juju_application" "traefik" {
  name  = "cos-ingress"
  model = "my-juju-model-name"

  charm {
    name     = "traefik-k8s"
    channel  = "latest/edge" 
    revision = 177 
  }

  config = {
    juju-external-hostname = "my-website.canonical.com"
    external_hostname      = "my-website.canonical.com"
  }

  expose {}
  units = 1
  trust = true
}
```

`terraform apply -auto-approve` succeeds
`juju status` returns `177` 


```terraform
provider "juju" {}

resource "juju_application" "traefik" {
  name  = "cos-ingress"
  model = "my-juju-model-name"

  charm {
    name     = "traefik-k8s"
    channel  = "latest/stable"
    revision = 191
  }

  config = {
    juju-external-hostname = "my-website.canonical.com"
    external_hostname      = "my-website.canonical.com"
  }

  expose {}
  units = 1
  trust = true
}
```

`terraform apply -auto-approve` succeeds
 `juju status` returns `191` 