### PR TITLE
feat: update tf-upgrader to handle model data source

### DIFF
--- a/juju-tf-upgrader/in/juju_access_model_test.tf
+++ b/juju-tf-upgrader/in/juju_access_model_test.tf
@@ -1,8 +1,4 @@
 # Test file for juju_access_model resource transformations
-data "juju_model" "existing" {
-  name = "existing-model"
-}
-
 resource "juju_model" "test" {
   name = "test-model"
 }

--- a/juju-tf-upgrader/in/juju_access_secret_test.tf
+++ b/juju-tf-upgrader/in/juju_access_secret_test.tf
@@ -1,8 +1,4 @@
 # Test file for juju_access_secret resource transformations
-data "juju_model" "existing" {
-  name = "existing-model"
-}
-
 resource "juju_model" "test" {
   name = "test-model"
 }

--- a/juju-tf-upgrader/in/juju_application_test.tf
+++ b/juju-tf-upgrader/in/juju_application_test.tf
@@ -1,8 +1,4 @@
 # Test file for juju_application resource transformations
-data "juju_model" "production" {
-  name = "production-env"
-}
-
 resource "juju_model" "development" {
   name = "dev-environment"
 }

--- a/juju-tf-upgrader/in/juju_data_application_test.tf
+++ b/juju-tf-upgrader/in/juju_data_application_test.tf
@@ -1,8 +1,4 @@
 # Test file for juju_application data source transformations
-data "juju_model" "existing" {
-  name = "existing-model"
-}
-
 resource "juju_model" "test" {
   name = "test-model"
 }

--- a/juju-tf-upgrader/in/juju_data_machine_test.tf
+++ b/juju-tf-upgrader/in/juju_data_machine_test.tf
@@ -1,8 +1,4 @@
 # Test file for juju_machine data source transformations
-data "juju_model" "existing" {
-  name = "existing-model"
-}
-
 resource "juju_model" "test" {
   name = "test-model"
 }

--- a/juju-tf-upgrader/in/juju_data_secret_test.tf
+++ b/juju-tf-upgrader/in/juju_data_secret_test.tf
@@ -1,8 +1,4 @@
 # Test file for juju_secret data source transformations
-data "juju_model" "existing" {
-  name = "existing-model"
-}
-
 resource "juju_model" "test" {
   name = "test-model"
 }

--- a/juju-tf-upgrader/in/juju_machine_test.tf
+++ b/juju-tf-upgrader/in/juju_machine_test.tf
@@ -1,8 +1,4 @@
 # Test file for juju_machine resource transformations
-data "juju_model" "existing" {
-  name = "existing-model"
-}
-
 resource "juju_model" "test" {
   name = "test-model"
 }

--- a/juju-tf-upgrader/in/juju_offer_test.tf
+++ b/juju-tf-upgrader/in/juju_offer_test.tf
@@ -1,8 +1,4 @@
 # Test file for juju_offer resource transformations
-data "juju_model" "existing" {
-  name = "existing-model"
-}
-
 resource "juju_model" "test" {
   name = "test-model"
 }

--- a/juju-tf-upgrader/in/juju_secret_test.tf
+++ b/juju-tf-upgrader/in/juju_secret_test.tf
@@ -1,8 +1,4 @@
 # Test file for juju_secret resource transformations
-data "juju_model" "existing" {
-  name = "existing-model"
-}
-
 resource "juju_model" "test" {
   name = "test-model"
 }

--- a/juju-tf-upgrader/in/juju_ssh_key_test.tf
+++ b/juju-tf-upgrader/in/juju_ssh_key_test.tf
@@ -1,8 +1,4 @@
 # Test file for juju_ssh_key resource transformations
-data "juju_model" "existing" {
-  name = "existing-model"
-}
-
 resource "juju_model" "test" {
   name = "test-model"
 }

--- a/juju-tf-upgrader/in/outputs_variables_test.tf
+++ b/juju-tf-upgrader/in/outputs_variables_test.tf
@@ -1,8 +1,4 @@
 # Test file for output and variable transformations
-data "juju_model" "production" {
-  name = "production-env"
-}
-
 resource "juju_model" "development" {
   name = "dev-environment"
 }

--- a/juju-tf-upgrader/out/juju_access_model_test.tf
+++ b/juju-tf-upgrader/out/juju_access_model_test.tf
@@ -1,8 +1,4 @@
 # Test file for juju_access_model resource transformations
-data "juju_model" "existing" {
-  name = "existing-model"
-}
-
 resource "juju_model" "test" {
   name = "test-model"
 }

--- a/juju-tf-upgrader/out/juju_access_secret_test.tf
+++ b/juju-tf-upgrader/out/juju_access_secret_test.tf
@@ -1,8 +1,4 @@
 # Test file for juju_access_secret resource transformations
-data "juju_model" "existing" {
-  name = "existing-model"
-}
-
 resource "juju_model" "test" {
   name = "test-model"
 }

--- a/juju-tf-upgrader/out/juju_application_test.tf
+++ b/juju-tf-upgrader/out/juju_application_test.tf
@@ -1,8 +1,4 @@
 # Test file for juju_application resource transformations
-data "juju_model" "production" {
-  name = "production-env"
-}
-
 resource "juju_model" "development" {
   name = "dev-environment"
 }

--- a/juju-tf-upgrader/out/juju_data_application_test.tf
+++ b/juju-tf-upgrader/out/juju_data_application_test.tf
@@ -1,8 +1,4 @@
 # Test file for juju_application data source transformations
-data "juju_model" "existing" {
-  name = "existing-model"
-}
-
 resource "juju_model" "test" {
   name = "test-model"
 }

--- a/juju-tf-upgrader/out/juju_data_machine_test.tf
+++ b/juju-tf-upgrader/out/juju_data_machine_test.tf
@@ -1,8 +1,4 @@
 # Test file for juju_machine data source transformations
-data "juju_model" "existing" {
-  name = "existing-model"
-}
-
 resource "juju_model" "test" {
   name = "test-model"
 }

--- a/juju-tf-upgrader/out/juju_data_model_test.tf
+++ b/juju-tf-upgrader/out/juju_data_model_test.tf
@@ -4,5 +4,6 @@ resource "juju_model" "test" {
 }
 
 data "juju_model" "test" {
-  uuid = juju_model.test.uuid
+  name  = juju_model.test.name
+  owner = "### FILL IN OWNER"
 }

--- a/juju-tf-upgrader/out/juju_data_secret_test.tf
+++ b/juju-tf-upgrader/out/juju_data_secret_test.tf
@@ -1,8 +1,4 @@
 # Test file for juju_secret data source transformations
-data "juju_model" "existing" {
-  name = "existing-model"
-}
-
 resource "juju_model" "test" {
   name = "test-model"
 }

--- a/juju-tf-upgrader/out/juju_machine_test.tf
+++ b/juju-tf-upgrader/out/juju_machine_test.tf
@@ -1,8 +1,4 @@
 # Test file for juju_machine resource transformations
-data "juju_model" "existing" {
-  name = "existing-model"
-}
-
 resource "juju_model" "test" {
   name = "test-model"
 }

--- a/juju-tf-upgrader/out/juju_offer_test.tf
+++ b/juju-tf-upgrader/out/juju_offer_test.tf
@@ -1,8 +1,4 @@
 # Test file for juju_offer resource transformations
-data "juju_model" "existing" {
-  name = "existing-model"
-}
-
 resource "juju_model" "test" {
   name = "test-model"
 }

--- a/juju-tf-upgrader/out/juju_secret_test.tf
+++ b/juju-tf-upgrader/out/juju_secret_test.tf
@@ -1,8 +1,4 @@
 # Test file for juju_secret resource transformations
-data "juju_model" "existing" {
-  name = "existing-model"
-}
-
 resource "juju_model" "test" {
   name = "test-model"
 }

--- a/juju-tf-upgrader/out/juju_ssh_key_test.tf
+++ b/juju-tf-upgrader/out/juju_ssh_key_test.tf
@@ -1,8 +1,4 @@
 # Test file for juju_ssh_key resource transformations
-data "juju_model" "existing" {
-  name = "existing-model"
-}
-
 resource "juju_model" "test" {
   name = "test-model"
 }

--- a/juju-tf-upgrader/out/outputs_variables_test.tf
+++ b/juju-tf-upgrader/out/outputs_variables_test.tf
@@ -1,8 +1,4 @@
 # Test file for output and variable transformations
-data "juju_model" "production" {
-  name = "production-env"
-}
-
 resource "juju_model" "development" {
   name = "dev-environment"
 }


### PR DESCRIPTION
## Description

This PR is a follow-up to https://github.com/juju/terraform-provider-juju/pull/948 which modified the model data source in to add an `owner` field. Now the TF upgrader handles this by adding the field with a dummy value of "### FILL IN OWNER" and issues a warning.

Also, many of the tests were testing the model data source, this seemed unnecessary so I've removed them in favor of testing it once.