### PR TITLE
docs: add ssh-key examples for github and launchpad

### DIFF
--- a/docs-rtd/howto/manage-ssh-keys.md
+++ b/docs-rtd/howto/manage-ssh-keys.md
@@ -31,7 +31,7 @@ terraform {
 }
 
 provider "github" {
-  owner = "SimoneDutto"
+  owner = "<name>"
 }
 
 provider "juju" {}
@@ -79,7 +79,7 @@ resource "juju_model" "test" {
 }
 
 data "http" "launchpad_keys" {
-  url = "https://launchpad.net/~simonedutto/+sshkeys"
+  url = "https://launchpad.net/~<username>/+sshkeys"
 }
 
 # Split the keys into a list by line


### PR DESCRIPTION
## Description

(Uses and) Fixes: https://github.com/juju/terraform-provider-juju/issues/838 

## Type of change

Documentation.

## QA steps

In `terraform-provider-juju/docs-rtd` run `make run` to preview the relevant doc.
