### PR TITLE
refactor(application): avoid using patterns in status call

### DIFF
--- a/.github/workflows/k8s_tunnel.yml
+++ b/.github/workflows/k8s_tunnel.yml
@@ -178,7 +178,7 @@ jobs:
 
           resource \"juju_application\" \"testapp\" {
             name = \"juju-qa-test\"
-            model = juju_model.testmodel.name
+            model_uuid = juju_model.testmodel.uuid
 
             charm {
               name = \"juju-qa-test\"


### PR DESCRIPTION
## Description

Juju 4 does not implement patterns in status calls. To avoid that we fetch full model status instead.

## Type of change

- Logic changes in resources (the API interaction with Juju has been changed)
