### PR TITLE
feat: add validator for offer_url to reject controller source

### DIFF
--- a/internal/provider/resource_integration.go
+++ b/internal/provider/resource_integration.go
@@ -199,6 +199,7 @@ func (r *integrationResource) Schema(_ context.Context, _ resource.SchemaRequest
 								stringvalidator.ConflictsWith(path.Expressions{
 									path.MatchRelative().AtParent().AtName("name"),
 								}...),
+								NewValidatorOfferURL(),
 							},
 						},
 					},

--- a/internal/provider/validator_offer_url.go
+++ b/internal/provider/validator_offer_url.go
@@ -1,0 +1,62 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the Apache License, Version 2.0, see LICENCE file for details.
+
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/juju/juju/core/crossmodel"
+)
+
+var _ validator.String = validatorOfferURL{}
+
+type validatorOfferURL struct{}
+
+// NewValidatorOfferURL returns a validator which ensures that the offer URL is valid
+// and does not contain a source controller field.
+func NewValidatorOfferURL() validator.String {
+	return validatorOfferURL{}
+}
+
+// Description returns a description of the validator's behavior.
+func (v validatorOfferURL) Description(ctx context.Context) string {
+	return v.MarkdownDescription(ctx)
+}
+
+// MarkdownDescription returns a markdown formatted description of the validator's behavior.
+func (v validatorOfferURL) MarkdownDescription(context.Context) string {
+	return "offer URL must be a valid offer URL string and must not include a source controller"
+}
+
+// ValidateString performs the validation for offer URL values.
+func (v validatorOfferURL) ValidateString(ctx context.Context, request validator.StringRequest, response *validator.StringResponse) {
+	if request.ConfigValue.IsNull() || request.ConfigValue.IsUnknown() {
+		return
+	}
+
+	value := request.ConfigValue.ValueString()
+
+	// Parse the offer URL using Juju's parser
+	parsedURL, err := crossmodel.ParseOfferURL(value)
+	if err != nil {
+		response.Diagnostics.Append(validatordiag.InvalidAttributeValueDiagnostic(
+			request.Path,
+			"offer URL must be a valid offer string",
+			value,
+		))
+		return
+	}
+
+	// Check if the source controller field is set
+	if parsedURL.Source != "" {
+		response.Diagnostics.Append(validatordiag.InvalidAttributeValueDiagnostic(
+			request.Path,
+			"offer URL must not include a source controller. "+
+				"Remove the controller prefix from the offer URL (e.g., use 'admin/model.offer' instead of 'controller:admin/model.offer')",
+			value,
+		))
+	}
+}

--- a/internal/provider/validator_offer_url_test.go
+++ b/internal/provider/validator_offer_url_test.go
@@ -1,0 +1,86 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the Apache License, Version 2.0, see LICENCE file for details.
+
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidatorOfferURL(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		name        string
+		value       types.String
+		expectError bool
+	}
+
+	tests := []testCase{
+		{
+			name:        "valid offer URL without controller",
+			value:       types.StringValue("admin/model.offer"),
+			expectError: false,
+		},
+		{
+			name:        "valid offer URL with non-admin user",
+			value:       types.StringValue("user/modelname.offername"),
+			expectError: false,
+		},
+		{
+			name:        "invalid offer URL with controller source",
+			value:       types.StringValue("controller:admin/model.offer"),
+			expectError: true,
+		},
+		{
+			name:        "invalid offer URL with complex controller source",
+			value:       types.StringValue("microcloud-core:admin/cos.prometheus-receive-remote-write"),
+			expectError: true,
+		},
+		{
+			name:        "invalid malformed offer URL",
+			value:       types.StringValue("invalid-url"),
+			expectError: true,
+		},
+		{
+			name:        "null value",
+			value:       types.StringNull(),
+			expectError: false,
+		},
+		{
+			name:        "unknown value",
+			value:       types.StringUnknown(),
+			expectError: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			request := validator.StringRequest{
+				Path:           path.Root("test"),
+				PathExpression: path.MatchRoot("test"),
+				ConfigValue:    tc.value,
+			}
+			response := validator.StringResponse{}
+
+			NewValidatorOfferURL().ValidateString(context.Background(), request, &response)
+
+			valueStr := "<null or unknown>"
+			if !tc.value.IsNull() && !tc.value.IsUnknown() {
+				valueStr = tc.value.ValueString()
+			}
+
+			if tc.expectError {
+				assert.True(t, response.Diagnostics.HasError(), "Expected error for value %s, but got none", valueStr)
+			} else {
+				assert.False(t, response.Diagnostics.HasError(), "Expected no error for value %s, but got: %v", valueStr, response.Diagnostics)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description 
When users specify an offer URL with a controller prefix (e.g., `controller:admin/model.offer`), the provider strips the prefix internally but Terraform compares against the original value, causing "Provider produced inconsistent result after apply" errors and resource tainting.

**Changes:**

- **`validator_offer_url.go`**: New validator that parses offer URLs using `crossmodel.ParseOfferURL()` and rejects any with a non-empty `Source` field
- **`validator_offer_url_test.go`**: Unit tests covering valid URLs, invalid URLs with controller prefixes, malformed URLs, and null/unknown values
- **`resource_integration.go`**: Added `ValidatorOfferURL()` to the `offer_url` field validators

**Example:**

Users attempting to use:
```terraform
application {
  offer_url = "microcloud-core:admin/cos.prometheus-receive-remote-write"
  endpoint  = "receive-remote-write"
}
```

Will now receive a validation error at plan time:
```
offer URL must not include a source controller (cross-controller relations are not supported).
Remove the controller prefix from the offer URL (e.g., use 'admin/model.offer' instead of 'controller:admin/model.offer')
```

The correct configuration is:
```terraform
application {
  offer_url = "admin/cos.prometheus-receive-remote-write"
  endpoint  = "receive-remote-write"
}
```

Fixes: #969

## Type of change

- Change existing resource
