### PR TITLE
feat(data-offer): add `offering_controller` to juju offer data source

### DIFF
--- a/.github/workflows/test_integration_cross_controller.yml
+++ b/.github/workflows/test_integration_cross_controller.yml
@@ -95,5 +95,5 @@ jobs:
           TEST_CLOUD: ${{ matrix.action-operator.cloud }}
           CROSS_CONTROLLERS_TESTS: "1"
         run: |
-          go test -parallel 3 -timeout 90m -v -cover -run "^TestAcc_ResourceIntegration_CrossControllers" ./internal/provider/
+          go test -parallel 3 -timeout 90m -v -cover -run "^TestAcc_(ResourceIntegration|DataOffer)_CrossControllers" ./internal/provider/
         timeout-minutes: 90

--- a/docs-rtd/reference/terraform-provider/data-sources/offer.md
+++ b/docs-rtd/reference/terraform-provider/data-sources/offer.md
@@ -25,6 +25,10 @@ data "juju_offer" "this" {
 
 - `url` (String) The offer URL.
 
+### Optional
+
+- `offering_controller` (String) The name of the controller offering the offer.
+
 ### Read-Only
 
 - `application_name` (String) The name of the application.

--- a/docs/data-sources/offer.md
+++ b/docs/data-sources/offer.md
@@ -25,6 +25,10 @@ data "juju_offer" "this" {
 
 - `url` (String) The offer URL.
 
+### Optional
+
+- `offering_controller` (String) The name of the controller offering the offer.
+
 ### Read-Only
 
 - `application_name` (String) The name of the application.

--- a/internal/juju/offers.go
+++ b/internal/juju/offers.go
@@ -55,7 +55,8 @@ type CreateOfferResponse struct {
 
 // ReadOfferInput represents input for reading an offer.
 type ReadOfferInput struct {
-	OfferURL string
+	OfferURL           string
+	OfferingController string
 	// GetModelUUID, if set, will populate the ModelUUID field in the response.
 	// Only set this if you know the user has at least read access to
 	// the model. E.g. if you are creating the offer you can be sure
@@ -196,12 +197,17 @@ func (c offersClient) CreateOffer(input *CreateOfferInput) (*CreateOfferResponse
 
 // ReadOffer reads offer managed by the offer resource.
 func (c offersClient) ReadOffer(input *ReadOfferInput) (*ReadOfferResponse, error) {
-	conn, err := c.GetConnection(nil)
+	var conn api.Connection
+	var err error
+	if input.OfferingController != "" {
+		conn, err = c.GetOfferingControllerConn(input.OfferingController)
+	} else {
+		conn, err = c.GetConnection(nil)
+	}
 	if err != nil {
 		return nil, err
 	}
 	defer func() { _ = conn.Close() }()
-
 	client := applicationoffers.NewClient(conn)
 	result, err := client.ApplicationOffer(input.OfferURL)
 	if err != nil {

--- a/internal/provider/data_source_offer_cross_controller_test.go
+++ b/internal/provider/data_source_offer_cross_controller_test.go
@@ -1,0 +1,61 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the Apache License, Version 2.0, see LICENCE file for details.
+
+package provider
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	internaltesting "github.com/juju/terraform-provider-juju/internal/testing"
+)
+
+// These tests require a Juju controller and an existing offering Juju controller with a model, an
+// application and an offer. Check `project-docs/CROSS_CONTROLLER_TESTS.md` for more details
+// on how to set up the environment.
+
+func TestAcc_DataOffer_CrossControllers_Basic(t *testing.T) {
+	OnlyCrossController(t)
+	consumerModel := acctest.RandomWithPrefix("tf-integration-consumer-cross-controller")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: frameworkProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataOfferCrossController(consumerModel, getOfferingControllerDataFromEnv(t)),
+			},
+		},
+	})
+}
+
+func testAccDataOfferCrossController(ConsumerModel string, offeringController offeringControllerData) string {
+	return internaltesting.GetStringFromTemplateWithData("testAccResourceIntegrationCrossController",
+		`
+provider "juju" {
+  offering_controllers = {
+    {{.ControllerName}} = {
+		controller_addresses = "{{.ControllerAddr}}"
+		username = "{{.ControllerUser}}"
+		password = "{{.ControllerPass}}"
+		ca_certificate = <<EOF
+{{.ControllerCert}}
+EOF
+	}
+  }
+}
+  
+data "juju_offer" "this" {
+	offering_controller = "{{.ControllerName}}"
+	url = "admin/offering-model.dummy-source" # offer url from offering controller
+} 
+`, internaltesting.TemplateData{
+			"ConsumerModel":  ConsumerModel,
+			"ControllerName": offeringController.ControllerName,
+			"ControllerAddr": offeringController.ControllerAddr,
+			"ControllerUser": offeringController.ControllerUser,
+			"ControllerPass": offeringController.ControllerPass,
+			"ControllerCert": offeringController.ControllerCert,
+		})
+}


### PR DESCRIPTION
## Description

Straight forward add support for data juju offer to reference an external controller.

Fixes: 

## QA

```terraform
terraform {
  required_providers {
    juju = {
      source = "juju/juju"
    }
  }
}

locals {
  offering_controller_name = "offering-controller"
}

provider "juju" {
  offering_controllers = {
    (local.offering_controller_name) = {
      controller_addresses = "10.165.178.240:17070"
      username             = "admin"
      password             = "85fc48b400ff09dd16075aa1f6ba2625"
      ca_certificate       = file("ca.crt")
    }
  }
}


data "juju_offer" "this" {
  offering_controller = local.offering_controller_name
  url                 = "admin/offering-model.dummy-source" # offer url from offering controller
}


resource "null_resource" "stdout" {
  triggers = {
    always_run = "${timestamp()}"
  }

  provisioner "local-exec" {
    command = "echo ${jsonencode(data.juju_offer.this)} | jq ."
  }
}
```