### PR TITLE
fix: cross-controller integration import

### DIFF
--- a/internal/juju/client.go
+++ b/internal/juju/client.go
@@ -256,6 +256,13 @@ func (sc *sharedClient) AddOfferingController(name string, conf ControllerConfig
 	return nil
 }
 
+// IsOfferingController returns true if the given controller name is of one of the
+// added offering controllers.
+func (sc *sharedClient) IsOfferingController(name string) bool {
+	_, ok := sc.offeringControllerConfigs[name]
+	return ok
+}
+
 // GetConnection returns a juju connection for use creating juju
 // api clients. A model UUID can optionally be provided to connect
 // to a specific model.

--- a/internal/juju/interfaces.go
+++ b/internal/juju/interfaces.go
@@ -29,6 +29,7 @@ type SharedClient interface {
 	GetConnection(modelUUID *string) (api.Connection, error)
 	GetOfferingControllerConn(name string) (api.Connection, error)
 	AddOfferingController(name string, conf ControllerConfiguration) error
+	IsOfferingController(name string) bool
 	ModelType(modelUUID string) (model.ModelType, error)
 	ModelOwnerAndName(modelUUID string) (string, string, error)
 	ModelStatus(modelUUID string, conn api.Connection) (*params.FullStatus, error)

--- a/internal/juju/mock_test.go
+++ b/internal/juju/mock_test.go
@@ -288,6 +288,44 @@ func (c *MockSharedClientGetOfferingControllerConnCall) DoAndReturn(f func(strin
 	return c
 }
 
+// IsOfferingController mocks base method.
+func (m *MockSharedClient) IsOfferingController(name string) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsOfferingController", name)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsOfferingController indicates an expected call of IsOfferingController.
+func (mr *MockSharedClientMockRecorder) IsOfferingController(name any) *MockSharedClientIsOfferingControllerCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsOfferingController", reflect.TypeOf((*MockSharedClient)(nil).IsOfferingController), name)
+	return &MockSharedClientIsOfferingControllerCall{Call: call}
+}
+
+// MockSharedClientIsOfferingControllerCall wrap *gomock.Call
+type MockSharedClientIsOfferingControllerCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockSharedClientIsOfferingControllerCall) Return(arg0 bool) *MockSharedClientIsOfferingControllerCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockSharedClientIsOfferingControllerCall) Do(f func(string) bool) *MockSharedClientIsOfferingControllerCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockSharedClientIsOfferingControllerCall) DoAndReturn(f func(string) bool) *MockSharedClientIsOfferingControllerCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // JujuLogger mocks base method.
 func (m *MockSharedClient) JujuLogger() *jujuLoggerShim {
 	m.ctrl.T.Helper()

--- a/internal/provider/resource_cross_controller_test.go
+++ b/internal/provider/resource_cross_controller_test.go
@@ -34,6 +34,14 @@ func TestAcc_ResourceIntegration_CrossControllers_Basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccResourceIntegrationCrossController(consumerModel, getOfferingControllerDataFromEnv(t)),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair("juju_model.consumer", "uuid", "juju_integration.a", "model_uuid"),
+				),
+			},
+			{
+				ImportStateVerify: true,
+				ImportState:       true,
+				ResourceName:      "juju_integration.a",
 			},
 		},
 	})


### PR DESCRIPTION
## Description

Fix cross-controller integration import support, allowing the import to be matched up to the integration resource.

This is done by taking the controller name parsed out of the offer string and looking for it in the `offering_controller` map in the provider block.

Previous to this change, the provider would import and then destroy/create the integration since it couldn't match it up:
```
Terraform will perform the following actions:

  # juju_integration.sink-source must be replaced
  # (imported from "...:dummy-sink:source:dummy-source:sink")
  # Warning: this will destroy the imported resource
-/+ resource "juju_integration" "sink-source" {
      ~ id         = "...:dummy-sink:source:dummy-source:sink" -> (known after apply)
        model_uuid = "..."

      - application { # forces replacement
          - endpoint  = "sink" -> null
          - offer_url = "admin/offering-model.dummy-source" -> null
        }
        application { # forces replacement
            endpoint = "source"
            name     = "dummy-sink"
        }
      + application { # forces replacement
          + endpoint            = "sink"
          + name                = (known after apply)
          + offer_url           = "admin/offering-model.dummy-source"
          + offering_controller = "offering-controller"
        }
    }

Plan: 1 to import, 1 to add, 0 to change, 1 to destroy.
```

Fixes: [JUJU-8805](https://warthogs.atlassian.net/browse/JUJU-8805)

## Type of change

- Change existing resource
- Change in tests (one or several tests have been changed)
- Bug fix (non-breaking change which fixes an issue)

## QA steps

1. Set up offerer
```sh
juju bootstrap lxd offering-controller
juju add-model offering-model
juju deploy juju-qa-dummy-source
juju offer dummy-source:sink
```

2. Set up consumer
```sh
juju bootstrap lxd consuming-controller
juju add-model consuming-model
juju deploy juju-qa-dummy-sink
juju consume offering-controller:admin/offering-model.dummy-source
juju relate dummy-source:sink dummy-sink:source
```

3. Generate env file
```sh
make generate-env-file-with-offering-controller offering-controller
```

4. Fill in `offering_controllers` from `test.env` and run this plan
```tf
terraform {
  required_providers {
    juju = {
      source = "juju/juju"
    }
  }
}

provider "juju" {
   offering_controllers = {
     "offering-controller" = {
       # from the freshly generated test.env file's OFFERING_CONTROLLER_...
       controller_addresses = "..."
       username             = "..."
       password             = "..."
       ca_certificate       = "..."
     }
   }
}

data "juju_model" "machine_model" {
  name  = "test"
  owner = "admin"
}

data "juju_application" "name" {
  model_uuid = data.juju_model.machine_model.uuid
  name       = "dummy-sink"
}

resource "juju_integration" "sink-source" {

  application {
    offering_controller = "offering-controller"
    offer_url = "admin/offering-model.dummy-source"
    endpoint  = "sink"
  }

  application {
    name     = data.juju_application.name.name
    endpoint = "source"
  }

  model_uuid = data.juju_model.machine_model.uuid
}

import {
  to = juju_integration.sink-source
  id = "${data.juju_model.machine_model.uuid}:dummy-sink:source:dummy-source:sink"
}
```

5. Plan will only report importing an existing integration. It will look like this
```tf
Terraform will perform the following actions:

  # juju_integration.sink-source will be imported
    resource "juju_integration" "sink-source" {
        id         = "...:dummy-sink:source:dummy-source:sink"
        model_uuid = "..."

        application {
            endpoint            = "sink"
            offer_url           = "admin/offering-model.dummy-source"
            offering_controller = "offering-controller"
        }
        application {
            endpoint = "source"
            name     = "dummy-sink"
        }
    }

Plan: 1 to import, 0 to add, 0 to change, 0 to destroy.
```

[JUJU-8805]: https://warthogs.atlassian.net/browse/JUJU-8805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ