### PR TITLE
fix: ensure resources are refreshed when charm is refreshed

### DIFF
--- a/docs-rtd/howto/manage-applications.md
+++ b/docs-rtd/howto/manage-applications.md
@@ -209,6 +209,7 @@ resource "juju_application" "application_three" {
 ## Upgrade an application
 
 To upgrade an application, update its charm.
+When the charm is updated, its resources will also be updated unless pinned.
 
 > See more: {ref}`update-a-charm`
 

--- a/docs-rtd/howto/manage-charms.md
+++ b/docs-rtd/howto/manage-charms.md
@@ -65,6 +65,8 @@ resource "juju_application" "this" {
 
 The Terraform provider does not support refreshing the charm when the revision is not specified. When unset, the revision number is determined during application creation. If you wish to keep the revision unset, you can refresh the application manually using the `juju` CLI. However, note that setting both `channel` and `revision` makes for a more reproducible deployment.
 
+When the charm is changed, its resources will also be updated unless pinned.
+
 > See more: [`juju_application` > `charm` > nested schema ](../reference/terraform-provider/resources/application)
 
 ## Remove a charm

--- a/internal/juju/applications.go
+++ b/internal/juju/applications.go
@@ -1581,8 +1581,11 @@ func (c applicationsClient) UpdateCharmAndResources(
 		charmID.Origin = origin
 	}
 
+	// Fetch latest resources and update them if the charm is being refreshed
+	// or if there are resources to update.
+	// Pinned resources will be kept as is.
 	var resourceIds map[string]string
-	if len(input.Resources) != 0 {
+	if updateCharm || len(input.Resources) > 0 {
 		resourceIds, err = c.updateResources(input.AppName, input.Resources, charmsAPIClient, charmID, resourcesAPIClient)
 		if err != nil {
 			return err

--- a/internal/provider/resource_application.go
+++ b/internal/provider/resource_application.go
@@ -1178,7 +1178,7 @@ func (r *applicationResource) Update(ctx context.Context, req resource.UpdateReq
 				// initialize the resources
 				updateApplicationInput.Resources = make(juju.CharmResources)
 			}
-			// Set resource revision to zero gets the latest resource revision from CharmHub
+			// Set resource revision to -1 gets the latest resource revision from CharmHub
 			updateApplicationInput.Resources[k] = juju.CharmResource{
 				RevisionNumber: "-1",
 			}


### PR DESCRIPTION
## Description

This PR fixes a regression introduced in https://github.com/juju/terraform-provider-juju/pull/709 that changed existing behaviour. Specifically, when a charm's revision was changed, the provider would also update the charm resources. After the linked change, this behavior was removed. This has proven to be challenging for users as seen in https://github.com/juju/terraform-provider-juju/issues/961 because of the unannounced change and because determining valid charm resources for a specific charm revision is not always a trivial task.

The fix is only a 1 liner to revert to the previous behavior and I've introduced a specific test for this.

Fixes https://github.com/juju/terraform-provider-juju/issues/961 and [JUJU-8820](https://warthogs.atlassian.net/browse/JUJU-8820)

## Type of change

- Logic changes in resources (the API interaction with Juju has been changed)

## QA steps

The test steps are sufficient, commenting out the 1 line fix, the test fails.

[JUJU-8776]: https://warthogs.atlassian.net/browse/JUJU-8820

[JUJU-8820]: https://warthogs.atlassian.net/browse/JUJU-8820?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ