### PR TITLE
fix: ensure resources are refreshed when charm is refreshed

### DIFF
--- a/docs-rtd/howto/manage-applications.md
+++ b/docs-rtd/howto/manage-applications.md
@@ -209,6 +209,7 @@ resource "juju_application" "application_three" {
 ## Upgrade an application
 
 To upgrade an application, update its charm.
+When the charm is updated, its resources will also be updated unless pinned.
 
 > See more: {ref}`update-a-charm`
 

--- a/docs-rtd/howto/manage-charms.md
+++ b/docs-rtd/howto/manage-charms.md
@@ -65,6 +65,8 @@ resource "juju_application" "this" {
 
 The Terraform provider does not support refreshing the charm when the revision is not specified. When unset, the revision number is determined during application creation. If you wish to keep the revision unset, you can refresh the application manually using the `juju` CLI. However, note that setting both `channel` and `revision` makes for a more reproducible deployment.
 
+When the charm is changed, its resources will also be updated unless pinned.
+
 > See more: [`juju_application` > `charm` > nested schema ](../reference/terraform-provider/resources/application)
 
 ## Remove a charm

--- a/internal/juju/applications.go
+++ b/internal/juju/applications.go
@@ -1456,8 +1456,11 @@ func (c applicationsClient) UpdateCharmAndResources(
 		charmID.Origin = origin
 	}
 
+	// Fetch latest resources and update them if the charm is being refreshed
+	// or if there are resources to update.
+	// Pinned resources will be kept as is.
 	var resourceIds map[string]string
-	if len(input.Resources) != 0 {
+	if updateCharm || len(input.Resources) > 0 {
 		resourceIds, err = c.updateResources(input.AppName, input.Resources, charmsAPIClient, charmID, resourcesAPIClient)
 		if err != nil {
 			return err


### PR DESCRIPTION
## Description

This PR is a duplicate of https://github.com/juju/terraform-provider-juju/pull/981 and back-ports the fix to v0.
