### PR TITLE
docs(juju_secret): fixes a model name reference in documentation

### DIFF
--- a/docs-rtd/howto/manage-secrets.md
+++ b/docs-rtd/howto/manage-secrets.md
@@ -31,7 +31,7 @@ To add a (user) secret on the controller specified in the juju provider definiti
 
 ```terraform
 resource "juju_secret" "my-secret" {
-  model = juju_model.development.name
+  model_uuid = juju_model.development.uuid
   name  = "my_secret_name"
   value = {
     key1 = "value1"


### PR DESCRIPTION
## Description

Fixes a 1.0.0 model name reference in `juju_secret` documentation.

Fixes: #997 

## Type of change

- Other (please describe): documentation fix
