### PR TITLE
docs: document the setting of units for subordinates between 0.19 and…

### DIFF
--- a/docs-rtd/reference/terraform-provider/resources/application.md
+++ b/docs-rtd/reference/terraform-provider/resources/application.md
@@ -217,3 +217,9 @@ Import is supported using the following syntax:
 # Applications can be imported using the format: `model_uuid:application_name`, for example:
 $ terraform import juju_application.wordpress abe22490-a845-4a4d-ba52-7ec80a60aff5:wordpress
 ```
+
+
+## Note on Subordinate Applications and Units
+For subordinate applications (such as those that attach to a principal charm). Starting with version 0.19.0, remove the units field from your subordinate application.
+
+The provider will show units = 1 in state for subordinates if the units field is omitted, this is expected and for backwards compatibility.

--- a/docs/resources/application.md
+++ b/docs/resources/application.md
@@ -218,6 +218,8 @@ Import is supported using the following syntax:
 $ terraform import juju_application.wordpress abe22490-a845-4a4d-ba52-7ec80a60aff5:wordpress
 ```
 
-## Note on Subordinate Applications and Units
 
-For subordinate applications (such as those that attach to a principal charm), Juju always reports `units = 0` because subordinates do not have standalone units. In provider versions before 0.19.0, you could explicitly set `units = 0` for subordinates. Starting with version 0.19.0 (when the `machines` feature was introduced for the application resource), the provider will show `units = 1` in state for subordinates if the `units` field is omitted, for backward compatibility. If you explicitly set `units = 0` for a subordinate, the provider will respect this and show `units = 0` in state. If you upgrade from an older version and encounter state mismatches or errors, remove the `units` field from subordinate application configurations and let the provider handle it automatically. This avoids confusion and ensures state matches Juju's actual value.
+## Note on Subordinate Applications and Units
+For subordinate applications (such as those that attach to a principal charm). Starting with version 0.19.0, remove the units field from your subordinate application.
+
+The provider will show units = 1 in state for subordinates if the units field is omitted, this is expected and for backwards compatibility.

--- a/templates/resources/application.md.tmpl
+++ b/templates/resources/application.md.tmpl
@@ -25,3 +25,9 @@ Import is supported using the following syntax:
 
 {{codefile "shell" "examples/resources/juju_application/import.sh"}}
 {{- end }}
+
+
+## Note on Subordinate Applications and Units
+For subordinate applications (such as those that attach to a principal charm). Starting with version 0.19.0, remove the units field from your subordinate application.
+
+The provider will show units = 1 in state for subordinates if the units field is omitted, this is expected and for backwards compatibility.


### PR DESCRIPTION
… greater versions

## Description

Documents that the units field needs to be removed when users upgrade from 0.19+ and have subordinate charms.

I think, if we wish to fix this, we could add an UpgradeState version for the application resource, checking if the charm is not Principal and setting the units to 0. I'm not sure I see the value in actually fixing this given simply removing units field works and the fix would only work from the next release. Leaving at least 0.19 -> 1.0.0 requiring the removal of the units field fix and 0.19 -> <whenever it is released> being automatically solved in the UpgradeState.

Fixes: #1003 

