### PR TITLE
fix: integration test on juju 2.9

### DIFF
--- a/.github/workflows/test_integration.yml
+++ b/.github/workflows/test_integration.yml
@@ -88,7 +88,7 @@ jobs:
           channel: ${{ matrix.action-operator.cloud-channel }}
           juju-channel: ${{ matrix.action-operator.juju }}
           lxd-channel: ${{ matrix.action-operator.lxd-channel }}
-      - name: Setup operator environment (set status)              # set the workflow status if command failed
+      - name: Setup operator environment (set status)
         if: always()
         run: |
           if ${{ steps.setup-op-0.outcome == 'success' || steps.setup-op-1.outcome == 'success' || steps.setup-op-2.outcome=='success' }}; then


### PR DESCRIPTION
## Description

Retry Juju controller setup step a few times, since it fails intermittently on Juju 2.9 due to mongod failing to start up.

## Type of change

- Maintenance work (repository related, like Github actions, or revving the Go version, etc.)

## Environment

- Juju controller version: 

- Terraform version: 

## Additional notes
 
`mongod` fails to start up logging this:
```
Unable to start up mongod due to missing featureCompatibilityVersion document,
16:48
```
This happens because there already are database files at the path mongo is set to write them. Since all of this happens in an lxc container that Juju has just created as part of bootstrap, it can only happen because Juju retries mongo startup.  

I haven't been able to determine the root cause of why Juju would even attempt to retry, but it's intermittent enough that it has to be timing-related. Since we're likely to be the only ones frequently bootstrapping 2.9 controllers, I'm assuming the retry workaround will be sufficient.