### PR TITLE
feat: implement controller config read/update

### DIFF
--- a/internal/provider/config_utils.go
+++ b/internal/provider/config_utils.go
@@ -132,7 +132,10 @@ func computeConfigDiff(ctx context.Context, configState types.Map, configPlan ty
 	}
 	newConfigMapNotNil := map[string]string{}
 	for k, v := range planConfig {
-		if v != nil {
+		if v == nil {
+			continue
+		}
+		if stateConfig[k] == nil || *stateConfig[k] != *v {
 			newConfigMapNotNil[k] = *v
 		}
 	}

--- a/internal/provider/config_utils_test.go
+++ b/internal/provider/config_utils_test.go
@@ -91,7 +91,6 @@ func TestComputeConfigDiff(t *testing.T) {
 	expectedNewConfig := map[string]string{
 		"key2": "newValue2",
 		"key4": "value4",
-		"key5": "value5",
 	}
 	assert.Equal(t, expectedNewConfig, newConfig, fmt.Sprintf("newConfig mismatch: got %+v, want %+v", newConfig, expectedNewConfig))
 

--- a/internal/provider/mock_test.go
+++ b/internal/provider/mock_test.go
@@ -81,11 +81,11 @@ func (c *MockJujuCommandBootstrapCall) DoAndReturn(f func(context.Context, juju.
 }
 
 // Config mocks base method.
-func (m *MockJujuCommand) Config(ctx context.Context, connInfo *juju.ControllerConnectionInformation) (map[string]string, map[string]string, error) {
+func (m *MockJujuCommand) Config(ctx context.Context, connInfo *juju.ControllerConnectionInformation) (map[string]any, map[string]any, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Config", ctx, connInfo)
-	ret0, _ := ret[0].(map[string]string)
-	ret1, _ := ret[1].(map[string]string)
+	ret0, _ := ret[0].(map[string]any)
+	ret1, _ := ret[1].(map[string]any)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }
@@ -103,19 +103,19 @@ type MockJujuCommandConfigCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockJujuCommandConfigCall) Return(arg0, arg1 map[string]string, arg2 error) *MockJujuCommandConfigCall {
+func (c *MockJujuCommandConfigCall) Return(arg0, arg1 map[string]any, arg2 error) *MockJujuCommandConfigCall {
 	c.Call = c.Call.Return(arg0, arg1, arg2)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockJujuCommandConfigCall) Do(f func(context.Context, *juju.ControllerConnectionInformation) (map[string]string, map[string]string, error)) *MockJujuCommandConfigCall {
+func (c *MockJujuCommandConfigCall) Do(f func(context.Context, *juju.ControllerConnectionInformation) (map[string]any, map[string]any, error)) *MockJujuCommandConfigCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockJujuCommandConfigCall) DoAndReturn(f func(context.Context, *juju.ControllerConnectionInformation) (map[string]string, map[string]string, error)) *MockJujuCommandConfigCall {
+func (c *MockJujuCommandConfigCall) DoAndReturn(f func(context.Context, *juju.ControllerConnectionInformation) (map[string]any, map[string]any, error)) *MockJujuCommandConfigCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -159,17 +159,17 @@ func (c *MockJujuCommandDestroyCall) DoAndReturn(f func(context.Context, *juju.C
 }
 
 // UpdateConfig mocks base method.
-func (m *MockJujuCommand) UpdateConfig(ctx context.Context, connInfo *juju.ControllerConnectionInformation, controllerConfig, controllerModelConfig map[string]string) error {
+func (m *MockJujuCommand) UpdateConfig(ctx context.Context, connInfo *juju.ControllerConnectionInformation, controllerConfig, controllerModelConfig map[string]string, unsetControllerModelConfig []string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateConfig", ctx, connInfo, controllerConfig, controllerModelConfig)
+	ret := m.ctrl.Call(m, "UpdateConfig", ctx, connInfo, controllerConfig, controllerModelConfig, unsetControllerModelConfig)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateConfig indicates an expected call of UpdateConfig.
-func (mr *MockJujuCommandMockRecorder) UpdateConfig(ctx, connInfo, controllerConfig, controllerModelConfig any) *MockJujuCommandUpdateConfigCall {
+func (mr *MockJujuCommandMockRecorder) UpdateConfig(ctx, connInfo, controllerConfig, controllerModelConfig, unsetControllerModelConfig any) *MockJujuCommandUpdateConfigCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateConfig", reflect.TypeOf((*MockJujuCommand)(nil).UpdateConfig), ctx, connInfo, controllerConfig, controllerModelConfig)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateConfig", reflect.TypeOf((*MockJujuCommand)(nil).UpdateConfig), ctx, connInfo, controllerConfig, controllerModelConfig, unsetControllerModelConfig)
 	return &MockJujuCommandUpdateConfigCall{Call: call}
 }
 
@@ -185,13 +185,13 @@ func (c *MockJujuCommandUpdateConfigCall) Return(arg0 error) *MockJujuCommandUpd
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockJujuCommandUpdateConfigCall) Do(f func(context.Context, *juju.ControllerConnectionInformation, map[string]string, map[string]string) error) *MockJujuCommandUpdateConfigCall {
+func (c *MockJujuCommandUpdateConfigCall) Do(f func(context.Context, *juju.ControllerConnectionInformation, map[string]string, map[string]string, []string) error) *MockJujuCommandUpdateConfigCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockJujuCommandUpdateConfigCall) DoAndReturn(f func(context.Context, *juju.ControllerConnectionInformation, map[string]string, map[string]string) error) *MockJujuCommandUpdateConfigCall {
+func (c *MockJujuCommandUpdateConfigCall) DoAndReturn(f func(context.Context, *juju.ControllerConnectionInformation, map[string]string, map[string]string, []string) error) *MockJujuCommandUpdateConfigCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/provider/resource_controller_test.go
+++ b/internal/provider/resource_controller_test.go
@@ -88,11 +88,11 @@ func TestAcc_ResourceController(t *testing.T) {
 			Username:  "admin",
 			Password:  "password",
 		},
-	).Return(map[string]string{
+	).Return(map[string]any{
 		"agent-logfile-max-backups": "3",
 		"audit-log-capture-args":    "true",
 		"autocert-dns-name":         "test-external-name",
-	}, map[string]string{
+	}, map[string]any{
 		"enable-os-refresh-update": "false",
 		"http-proxy":               "fake-proxy",
 	}, nil).AnyTimes()


### PR DESCRIPTION
## Description

This PR implements reading and updating controller configuration.

In many ways this task was made easy by the fact that controller config is similar to model config which we already support. Note that there are 2 sets of controller related configurations values that can be changed - controller-configuration and controller-model-configuration - `juju controller-config` and `juju model-config -m controller`, respectively.

I'll explain how the type coercion works between the map[string]string that the provider accepts and the types that the Juju controller's config values expects since it's useful to have it written down. This works the same way for both sets of controller config as well as model config in general.
- We convert `map[string]string` -> `map[string]any`.
- The Juju controller attempts to coerce the value to the expected type based on the key. E.g. `ssh-server-port` is an integer.
- When the provider does a `Read()` and converts Juju's config map from `map[string]any` -> `map[string]string` we use `fmt.Sprint(value)` so certain values like booleans are always represented as "true"/"false".

What works:
- Setting strings, booleans and integers work.

What doesn't work:
- Setting a field with type `list` fails because we are sending a string instead of a JSON list. Fortunately out of all the config values there are only 2 that are lists (these are controller config values, there are no model config values that are lists).
  - features:  A list of runtime changeable features to be updated
  - audit-log-exclude-methods: The list of Facade.Method names that aren't interesting for audit logging purposes.
- Setting a boolean with a value of "1" or "0" sets the value successfully, but Terraform's `Read()` sees the new value as "true"/"false", so the plan author must correct this.

Finally, if you set an invalid value, like "foo" for a boolean/integer you get an appropriate error back:
```
│ Error: Controller Update Error
│ 
│   with juju_controller.test_controller,
│   on main.tf line 72, in resource "juju_controller" "test_controller":
│   72: resource "juju_controller" "test_controller" {
│ 
│ Unable to update controller "test-controller" configuration: failed to update controller model config:
│ test-mode: expected bool, got string("foo")
```

Just a note that I haven't updated the provider's mock tests since those still pass and we don't yet have the scaffolding to bootstrap a controller from the provider.

Fixes: [JUJU-8930](https://warthogs.atlassian.net/browse/JUJU-8930) and [JUJU-8931](https://warthogs.atlassian.net/browse/JUJU-8931)

## Type of change

- Change existing resource
- Logic changes in resources (the API interaction with Juju has been changed)

## QA steps

Manual QA steps should be done to test this PR. Obtain your LXD credentials by running,
`juju show-credentials --client localhost localhost --show-secrets`.

With this I was able to bootstrap a controller and update its config after bootstrap.

```tf
terraform {
  required_version = ">= 1.6.6"
  required_providers {
    juju = {
      source = "registry.terraform.io/juju/juju" # (uses local provider repository)
      # source  = "juju/juju"
      version = "~> 0.21.0"
    }
  }
}

provider "juju" {
  controller_mode = true
}

variable "lxd_client_cert" {
  type      = string
  sensitive = true
  default = <<EOT
<cert>
EOT
}

variable "lxd_client_key" {
  type      = string
  sensitive = true
  default = <<EOT
<key>
EOT
}

variable "lxd_server_cert" {
  type      = string
  sensitive = true
  default = <<EOT
<cert>
EOT
}

resource "juju_controller" "test_controller" {
  name = "test-controller"

  cloud = {
    name       = "localhost"
    type       = "lxd"
    auth_types = ["certificate"]
  }

  cloud_credential = {
    name      = "localhost"
    auth_type = "certificate"
    attributes = {
      "client-cert" = var.lxd_client_cert
      "client-key"  = var.lxd_client_key
      "server-cert" = var.lxd_server_cert
    }
  }

  controller_config = {
    "audit-log-max-backups" = "10"
  }

  controller_model_config = {
    "test-mode" = "true"
  }

  juju_binary = "/snap/juju/current/bin/juju"
}
```

Just a heads up, I ran the provider in debug mode and my plan was not accepting that there is a "juju_controller" resource until I applied this diff,
```diff
--- i/internal/provider/provider.go
+++ w/internal/provider/provider.go
@@ -542,12 +542,8 @@ func getJujuProviderModel(ctx context.Context, req provider.ConfigureRequest) (j
 // The resource type name is determined by the Resource implementing
 // the Metadata method. All resources must have unique names.
 func (p *jujuProvider) Resources(_ context.Context) []func() resource.Resource {
-       if p.controllerMode {
-               return []func() resource.Resource{
-                       func() resource.Resource { return NewControllerResource(p.newJujuCommand) },
-               }
-       }
        return []func() resource.Resource{
+               func() resource.Resource { return NewControllerResource(p.newJujuCommand) },
```

[JUJU-8930]: https://warthogs.atlassian.net/browse/JUJU-8930?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ