### PR TITLE
fix: allow referencing model data source in locals

### DIFF
--- a/internal/provider/data_source_model.go
+++ b/internal/provider/data_source_model.go
@@ -58,14 +58,17 @@ func (d *modelDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, 
 			"name": schema.StringAttribute{
 				Description: "The name of the model.",
 				Optional:    true,
+				Computed:    true,
 			},
 			"owner": schema.StringAttribute{
 				Description: "The owner of the model.",
 				Optional:    true,
+				Computed:    true,
 			},
 			"uuid": schema.StringAttribute{
 				Description: "The UUID of the model.",
 				Optional:    true,
+				Computed:    true,
 				Validators: []validator.String{
 					ValidatorMatchString(names.IsValidModel, "must be a valid UUID"),
 				},


### PR DESCRIPTION
## Description

This PR fixes https://github.com/juju/terraform-provider-juju/issues/1018, where a model data source that references a model by UUID cannot itself be referenced to obtain the model's name / owner. The fix is to set the fields of `name`, `owner`, and `uuid` as computed which seems to inform Terraform that these values may become known later.

## Type of change

- Change existing resource


## QA steps
The reproducer in the linked issue, specifically https://github.com/juju/terraform-provider-juju/issues/1018#issuecomment-3757564425 highlights the problem, and has been adapted to a test.
