### PR TITLE
docs: fix dependency issue

### DIFF
--- a/docs-rtd/requirements.txt
+++ b/docs-rtd/requirements.txt
@@ -2,7 +2,7 @@
 canonical-sphinx>=0.5.1
 
 # Extensions previously auto-loaded by canonical-sphinx
-myst-parser
+myst-parser~=4.0
 sphinx-autobuild
 sphinx-design
 sphinx-notfound-page


### PR DESCRIPTION
One of our Sphinx dependencies has had a major release that our starter pack doesn't support yet, so we need to pin the dependency version to the last one that worked. This PR does that.

