### PR TITLE
docs: add metadata

### DIFF
--- a/docs-rtd/contributing.md
+++ b/docs-rtd/contributing.md
@@ -1,4 +1,7 @@
 ---
+myst:
+  html_meta:
+    description: "Learn how to contribute to the Terraform Provider for Juju with code, documentation, testing, and understand submission guidelines and licensing."
 orphan: true
 ---
 

--- a/docs-rtd/howto/create-deployment-dependencies.md
+++ b/docs-rtd/howto/create-deployment-dependencies.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Learn how to create deployment dependencies in the Terraform Provider for Juju using null_resource and juju wait-for commands."
+---
+
 (create-deployment-dependencies)=
 # Create deployment dependencies
 

--- a/docs-rtd/howto/index.md
+++ b/docs-rtd/howto/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Step-by-step guides for managing Terraform Provider for Juju: setup, authentication, deployment, and infrastructure operations."
+---
+
 (howtos)=
 # How-to guides
 

--- a/docs-rtd/howto/manage-applications.md
+++ b/docs-rtd/howto/manage-applications.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Learn how to deploy, configure, scale, and trust Juju applications using Terraform with detailed configuration examples."
+---
+
 (manage-applications)=
 # Manage applications
 

--- a/docs-rtd/howto/manage-charm-resources.md
+++ b/docs-rtd/howto/manage-charm-resources.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Learn how to specify and manage charm resources when deploying or updating applications with Terraform Provider for Juju."
+---
+
 (manage-charm-resources)=
 # Manage charm resources
 

--- a/docs-rtd/howto/manage-charms.md
+++ b/docs-rtd/howto/manage-charms.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Learn how to deploy Charmhub charms with specific channels and revisions, including automatic revision computation examples."
+---
+
 (manage-charms)=
 # Manage charms
 

--- a/docs-rtd/howto/manage-clouds.md
+++ b/docs-rtd/howto/manage-clouds.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Learn how to add machine and Kubernetes clouds to Juju controllers and manage cloud access permissions with JAAS."
+---
+
 (manage-clouds)=
 # Manage clouds
 

--- a/docs-rtd/howto/manage-controllers.md
+++ b/docs-rtd/howto/manage-controllers.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Learn how to reference and connect to Juju and JIMM controllers using static credentials, environment variables, or the Juju CLI."
+---
+
 (manage-controllers)=
 # Manage controllers
 

--- a/docs-rtd/howto/manage-credentials.md
+++ b/docs-rtd/howto/manage-credentials.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Learn how to define, add, update, and remove cloud credentials in the Terraform Provider for Juju for secure authentication."
+---
+
 (manage-credentials)=
 # Manage credentials
 

--- a/docs-rtd/howto/manage-groups.md
+++ b/docs-rtd/howto/manage-groups.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Learn how to add, reference, and manage JAAS groups and group membership for users, service accounts, and nested groups."
+---
+
 (manage-groups)=
 # Manage groups
 

--- a/docs-rtd/howto/manage-machines.md
+++ b/docs-rtd/howto/manage-machines.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Learn how to add, reference, configure constraints, and remove machines in Juju models using the Terraform Provider for Juju."
+---
+
 (manage-machines)=
 # Manage machines
 

--- a/docs-rtd/howto/manage-models.md
+++ b/docs-rtd/howto/manage-models.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Learn how to reference, add, configure, and manage Juju models with constraints and configuration keys using Terraform."
+---
+
 (manage-models)=
 # Manage models
 

--- a/docs-rtd/howto/manage-offers.md
+++ b/docs-rtd/howto/manage-offers.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Learn how to create, reference, and integrate with Juju application offers for same-controller and cross-controller relations."
+---
+
 (manage-offers)=
 # Manage offers
 

--- a/docs-rtd/howto/manage-provider/upgrade-provider-to-v1.md
+++ b/docs-rtd/howto/manage-provider/upgrade-provider-to-v1.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Complete guide for upgrading the Terraform Provider for Juju from v0.x to v1.0.0 with breaking changes and migration steps."
+---
+
 (upgrade-to-terraform-provider-juju-v-1)=
 # Upgrade the provider to v1
 

--- a/docs-rtd/howto/manage-relations.md
+++ b/docs-rtd/howto/manage-relations.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Learn how to add and remove same-model and cross-model relations between Juju applications using Terraform integration resources."
+---
+
 (manage-relations)=
 # Manage relations
 

--- a/docs-rtd/howto/manage-roles.md
+++ b/docs-rtd/howto/manage-roles.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Learn how to add, reference, and manage JAAS roles and role access permissions for users, service accounts, and groups."
+---
+
 (manage-roles)=
 # Manage roles
 

--- a/docs-rtd/howto/manage-secrets.md
+++ b/docs-rtd/howto/manage-secrets.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Learn how to add, reference, update, and manage access to user secrets in Juju models using the Terraform Provider for Juju."
+---
+
 (manage-secrets)=
 # Manage secrets
 

--- a/docs-rtd/howto/manage-service-accounts.md
+++ b/docs-rtd/howto/manage-service-accounts.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Learn how to manage service account access to controllers, clouds, models, offers, roles, and groups in JAAS."
+---
+
 (manage-service-accounts)=
 # Manage service accounts
 

--- a/docs-rtd/howto/manage-ssh-keys.md
+++ b/docs-rtd/howto/manage-ssh-keys.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Learn how to add SSH keys to Juju models using Terraform, including examples for GitHub and Launchpad key integration."
+---
+
 (manage-ssh-keys)=
 # Manage SSH keys
 

--- a/docs-rtd/howto/manage-the-terraform-provider-for-juju.md
+++ b/docs-rtd/howto/manage-the-terraform-provider-for-juju.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Learn how to install, configure, and upgrade the Terraform Provider for Juju with detailed setup instructions and version migration guides."
+---
+
 (manage-the-terraform-provider-for-juju)=
 # Manage the Terraform Provider for Juju
 

--- a/docs-rtd/howto/manage-units.md
+++ b/docs-rtd/howto/manage-units.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Learn how to control the number of units for Juju applications using the Terraform Provider for Juju to scale your deployments."
+---
+
 (manage-units)=
 # Manage units
 

--- a/docs-rtd/howto/manage-users.md
+++ b/docs-rtd/howto/manage-users.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Learn how to add, manage access, update passwords, and remove users in Juju controllers using Terraform Provider."
+---
+
 (manage-users)=
 # Manage users
 

--- a/docs-rtd/howto/use-the-juju-cli.md
+++ b/docs-rtd/howto/use-the-juju-cli.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Learn how to use the Juju CLI within Terraform plans using provisioners for Juju and JAAS controllers."
+---
+
 (use-the-juju-cli-in-terraform)=
 # Use the Juju CLI in Terraform
 

--- a/docs-rtd/index.md
+++ b/docs-rtd/index.md
@@ -1,4 +1,7 @@
 ---
+myst:
+  html_meta:
+    description: "Terraform Provider for Juju extends Terraform with Juju functionality to deploy, configure, and manage infrastructure and applications on any cloud."
 relatedlinks: "[Charmcraft](https://documentation.ubuntu.com/charmcraft/), [Charmlibs](https://canonical-charmlibs.readthedocs-hosted.com/), [Concierge](https://github.com/canonical/concierge), [JAAS](https://documentation.ubuntu.com/jaas/), [Jubilant](https://documentation.ubuntu.com/jubilant/), [Juju](https://documentation.ubuntu.com/juju/), [Ops](https://documentation.ubuntu.com/ops/), [Pebble](https://documentation.ubuntu.com/pebble/)"
 ---
 

--- a/docs-rtd/tutorial.md
+++ b/docs-rtd/tutorial.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Learn how to deploy Mattermost and PostgreSQL on Kubernetes using the Terraform Provider for Juju in this hands-on introductory tutorial."
+---
+
 # Tutorial
 
 <!--


### PR DESCRIPTION
One of our roadmap commitments this cycle is to get our docs in a better shape for SEO. Part of this is adding metadata to all of our docs. This PR adds them to all the non-autogenerated files. 

Note 1: I used this AI prompt that we have in the documentation team for this purpose: https://github.com/canonical/AI-resources-for-docs/blob/main/docs/prompts/add-metadata-descriptions.md The results are not amazing but, imo, good enough.

Note 2: We probably don't need to worry about the autogenerated ones, as all the other docs link to them systematically as is.
