### PR TITLE
feat: destroy controller

### DIFF
--- a/docs-rtd/reference/terraform-provider/resources/controller.md
+++ b/docs-rtd/reference/terraform-provider/resources/controller.md
@@ -28,6 +28,7 @@ A resource that represents a Juju Controller.
 - `bootstrap_constraints` (Map of String) Constraints for the bootstrap machine.
 - `controller_config` (Map of String) Configuration options for the bootstrapped controller. Note that removing a key from this map will not unset it in the controller, instead it will be left unchanged on the controller.
 - `controller_model_config` (Map of String) Configuration options to be set for the controller model.
+- `destroy_flags` (Attributes) Additional flags for destroying the controller. (see [below for nested schema](#nestedatt--destroy_flags))
 - `juju_binary` (String) The path to the juju CLI binary.
 - `model_constraints` (Map of String) Constraints for all workload machines in models.
 - `model_default` (Map of String) Configuration options to be set for all models.
@@ -38,6 +39,7 @@ A resource that represents a Juju Controller.
 
 - `api_addresses` (List of String) API addresses of the controller.
 - `ca_cert` (String) CA certificate for the controller.
+- `controller_uuid` (String) The UUID of the controller.
 - `id` (String) The ID of this resource.
 - `password` (String, Sensitive) Admin password for the controller.
 - `username` (String) Admin username for the controller.
@@ -82,6 +84,18 @@ Required:
 - `attributes` (Map of String) Authentication attributes (key-value pairs specific to the auth type).
 - `auth_type` (String) The authentication type (e.g., 'userpass', 'oauth2', 'access-key').
 - `name` (String) The name of the credential.
+
+
+<a id="nestedatt--destroy_flags"></a>
+### Nested Schema for `destroy_flags`
+
+Optional:
+
+- `destroy_all_models` (Boolean) Destroy all models in the controller.
+- `destroy_storage` (Boolean) Destroy all storage instances managed by the controller.
+- `force` (Boolean) Force destroy models ignoring any errors.
+- `model_timeout` (Number) Timeout for each step of force model destruction.
+- `release_storage` (Boolean) Release all storage instances from management of the controller, without destroying them.
 
 
 <a id="nestedatt--storage_pool"></a>

--- a/docs/resources/controller.md
+++ b/docs/resources/controller.md
@@ -28,6 +28,7 @@ A resource that represents a Juju Controller.
 - `bootstrap_constraints` (Map of String) Constraints for the bootstrap machine.
 - `controller_config` (Map of String) Configuration options for the bootstrapped controller. Note that removing a key from this map will not unset it in the controller, instead it will be left unchanged on the controller.
 - `controller_model_config` (Map of String) Configuration options to be set for the controller model.
+- `destroy_flags` (Attributes) Additional flags for destroying the controller. (see [below for nested schema](#nestedatt--destroy_flags))
 - `juju_binary` (String) The path to the juju CLI binary.
 - `model_constraints` (Map of String) Constraints for all workload machines in models.
 - `model_default` (Map of String) Configuration options to be set for all models.
@@ -38,6 +39,7 @@ A resource that represents a Juju Controller.
 
 - `api_addresses` (List of String) API addresses of the controller.
 - `ca_cert` (String) CA certificate for the controller.
+- `controller_uuid` (String) The UUID of the controller.
 - `id` (String) The ID of this resource.
 - `password` (String, Sensitive) Admin password for the controller.
 - `username` (String) Admin username for the controller.
@@ -82,6 +84,18 @@ Required:
 - `attributes` (Map of String) Authentication attributes (key-value pairs specific to the auth type).
 - `auth_type` (String) The authentication type (e.g., 'userpass', 'oauth2', 'access-key').
 - `name` (String) The name of the credential.
+
+
+<a id="nestedatt--destroy_flags"></a>
+### Nested Schema for `destroy_flags`
+
+Optional:
+
+- `destroy_all_models` (Boolean) Destroy all models in the controller.
+- `destroy_storage` (Boolean) Destroy all storage instances managed by the controller.
+- `force` (Boolean) Force destroy models ignoring any errors.
+- `model_timeout` (Number) Timeout for each step of force model destruction.
+- `release_storage` (Boolean) Release all storage instances from management of the controller, without destroying them.
 
 
 <a id="nestedatt--storage_pool"></a>

--- a/internal/juju/mock_test.go
+++ b/internal/juju/mock_test.go
@@ -2843,6 +2843,45 @@ func (c *MockCommandRunnerRunCall) DoAndReturn(f func(context.Context, ...string
 	return c
 }
 
+// Version mocks base method.
+func (m *MockCommandRunner) Version(ctx context.Context) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Version", ctx)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Version indicates an expected call of Version.
+func (mr *MockCommandRunnerMockRecorder) Version(ctx any) *MockCommandRunnerVersionCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Version", reflect.TypeOf((*MockCommandRunner)(nil).Version), ctx)
+	return &MockCommandRunnerVersionCall{Call: call}
+}
+
+// MockCommandRunnerVersionCall wrap *gomock.Call
+type MockCommandRunnerVersionCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockCommandRunnerVersionCall) Return(arg0 string, arg1 error) *MockCommandRunnerVersionCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockCommandRunnerVersionCall) Do(f func(context.Context) (string, error)) *MockCommandRunnerVersionCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockCommandRunnerVersionCall) DoAndReturn(f func(context.Context) (string, error)) *MockCommandRunnerVersionCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // WorkingDir mocks base method.
 func (m *MockCommandRunner) WorkingDir() string {
 	m.ctrl.T.Helper()

--- a/internal/provider/mock_test.go
+++ b/internal/provider/mock_test.go
@@ -121,17 +121,17 @@ func (c *MockJujuCommandConfigCall) DoAndReturn(f func(context.Context, *juju.Co
 }
 
 // Destroy mocks base method.
-func (m *MockJujuCommand) Destroy(ctx context.Context, connInfo *juju.ControllerConnectionInformation) error {
+func (m *MockJujuCommand) Destroy(ctx context.Context, args juju.DestroyArguments) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Destroy", ctx, connInfo)
+	ret := m.ctrl.Call(m, "Destroy", ctx, args)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Destroy indicates an expected call of Destroy.
-func (mr *MockJujuCommandMockRecorder) Destroy(ctx, connInfo any) *MockJujuCommandDestroyCall {
+func (mr *MockJujuCommandMockRecorder) Destroy(ctx, args any) *MockJujuCommandDestroyCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Destroy", reflect.TypeOf((*MockJujuCommand)(nil).Destroy), ctx, connInfo)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Destroy", reflect.TypeOf((*MockJujuCommand)(nil).Destroy), ctx, args)
 	return &MockJujuCommandDestroyCall{Call: call}
 }
 
@@ -147,13 +147,13 @@ func (c *MockJujuCommandDestroyCall) Return(arg0 error) *MockJujuCommandDestroyC
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockJujuCommandDestroyCall) Do(f func(context.Context, *juju.ControllerConnectionInformation) error) *MockJujuCommandDestroyCall {
+func (c *MockJujuCommandDestroyCall) Do(f func(context.Context, juju.DestroyArguments) error) *MockJujuCommandDestroyCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockJujuCommandDestroyCall) DoAndReturn(f func(context.Context, *juju.ControllerConnectionInformation) error) *MockJujuCommandDestroyCall {
+func (c *MockJujuCommandDestroyCall) DoAndReturn(f func(context.Context, juju.DestroyArguments) error) *MockJujuCommandDestroyCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }


### PR DESCRIPTION
## Description

Add wrapper for Juju CLI `destroy-controller` command.
Add implementation of `Delete` for the `juju_controller` resource that calls the former command.

## Type of change

- Change existing resource
- Logic changes in resources (the API interaction with Juju has been changed)
- Change in tests (one or several tests have been changed)

