### PR TITLE
fix: replace juju prefix version match with parsing

### DIFF
--- a/docs-rtd/reference/terraform-provider/resources/controller.md
+++ b/docs-rtd/reference/terraform-provider/resources/controller.md
@@ -28,7 +28,7 @@ A resource that represents a Juju Controller.
 - `bootstrap_constraints` (Map of String) Constraints for the bootstrap machine.
 - `controller_config` (Map of String) Configuration options for the bootstrapped controller. Note that removing a key from this map will not unset it in the controller, instead it will be left unchanged on the controller.
 - `controller_model_config` (Map of String) Configuration options to be set for the controller model.
-- `destroy_flags` (Attributes) Additional flags for destroying the controller. (see [below for nested schema](#nestedatt--destroy_flags))
+- `destroy_flags` (Attributes) Additional flags for destroying the controller. Changing any of these values will require applying before they can be taken into account during destroy. (see [below for nested schema](#nestedatt--destroy_flags))
 - `juju_binary` (String) The path to the juju CLI binary.
 - `model_constraints` (Map of String) Constraints for all workload machines in models.
 - `model_default` (Map of String) Configuration options to be set for all models.

--- a/docs/resources/controller.md
+++ b/docs/resources/controller.md
@@ -28,7 +28,7 @@ A resource that represents a Juju Controller.
 - `bootstrap_constraints` (Map of String) Constraints for the bootstrap machine.
 - `controller_config` (Map of String) Configuration options for the bootstrapped controller. Note that removing a key from this map will not unset it in the controller, instead it will be left unchanged on the controller.
 - `controller_model_config` (Map of String) Configuration options to be set for the controller model.
-- `destroy_flags` (Attributes) Additional flags for destroying the controller. (see [below for nested schema](#nestedatt--destroy_flags))
+- `destroy_flags` (Attributes) Additional flags for destroying the controller. Changing any of these values will require applying before they can be taken into account during destroy. (see [below for nested schema](#nestedatt--destroy_flags))
 - `juju_binary` (String) The path to the juju CLI binary.
 - `model_constraints` (Map of String) Constraints for all workload machines in models.
 - `model_default` (Map of String) Configuration options to be set for all models.

--- a/internal/provider/resource_controller.go
+++ b/internal/provider/resource_controller.go
@@ -404,8 +404,10 @@ func (r *controllerResource) Schema(_ context.Context, _ resource.SchemaRequest,
 
 			// The flags below are only used when destroying the controller.
 			"destroy_flags": schema.SingleNestedAttribute{
-				Description: "Additional flags for destroying the controller.",
-				Optional:    true,
+				Description: "Additional flags for destroying the controller." +
+					" Changing any of these values will require applying before they can be" +
+					" taken into account during destroy.",
+				Optional: true,
 				PlanModifiers: []planmodifier.Object{
 					objectplanmodifier.UseStateForUnknown(),
 				},


### PR DESCRIPTION
## Description

The comparison between the Juju CLI version and the Juju agent version was previously a prefix check. Replace it with properly parsing both versions.

Following up on https://github.com/juju/terraform-provider-juju/pull/1035.

## Type of change

- Change existing resource
- Logic changes in resources (the API interaction with Juju has been changed)
- Change in tests (one or several tests have been changed)

