### PR TITLE
feat(import-controller): add import controller

### DIFF
--- a/docs-rtd/reference/terraform-provider/resources/controller.md
+++ b/docs-rtd/reference/terraform-provider/resources/controller.md
@@ -18,7 +18,6 @@ A resource that represents a Juju Controller.
 ### Required
 
 - `cloud` (Attributes) The cloud where the controller will operate. (see [below for nested schema](#nestedatt--cloud))
-- `cloud_credential` (Attributes, Sensitive) Cloud credentials to use for bootstrapping the controller. (see [below for nested schema](#nestedatt--cloud_credential))
 
 ### Optional
 
@@ -26,6 +25,7 @@ A resource that represents a Juju Controller.
 - `bootstrap_base` (String) The base for the bootstrap machine.
 - `bootstrap_config` (Map of String) Configuration options that apply during the bootstrap process.
 - `bootstrap_constraints` (Map of String) Constraints for the bootstrap machine.
+- `cloud_credential` (Attributes, Sensitive) Cloud credentials to use for bootstrapping the controller. (see [below for nested schema](#nestedatt--cloud_credential))
 - `controller_config` (Map of String) Configuration options for the bootstrapped controller. Note that removing a key from this map will not unset it in the controller, instead it will be left unchanged on the controller.
 - `controller_model_config` (Map of String) Configuration options to be set for the controller model.
 - `destroy_flags` (Attributes) Additional flags for destroying the controller. (see [below for nested schema](#nestedatt--destroy_flags))
@@ -49,28 +49,28 @@ A resource that represents a Juju Controller.
 
 Required:
 
-- `auth_types` (Set of String) The authentication type(s) supported by the cloud.
 - `name` (String) The name of the cloud
-- `type` (String) The type of the cloud .
 
 Optional:
 
+- `auth_types` (Set of String) The authentication type(s) supported by the cloud.
 - `ca_certificates` (Set of String) CA certificates for the cloud.
 - `config` (Map of String) Configuration options for the cloud.
 - `endpoint` (String) The API endpoint for the cloud.
 - `host_cloud_region` (String) The host cloud region for the cloud.
 - `region` (Attributes) The cloud region where the controller will operate. (see [below for nested schema](#nestedatt--cloud--region))
+- `type` (String) The type of the cloud .
 
 <a id="nestedatt--cloud--region"></a>
 ### Nested Schema for `cloud.region`
 
 Required:
 
-- `endpoint` (String) The API endpoint for the region.
 - `name` (String) The name of the region.
 
 Optional:
 
+- `endpoint` (String) The API endpoint for the region.
 - `identity_endpoint` (String) The identity endpoint for the region.
 - `storage_endpoint` (String) The storage endpoint for the region.
 

--- a/docs/resources/controller.md
+++ b/docs/resources/controller.md
@@ -18,7 +18,6 @@ A resource that represents a Juju Controller.
 ### Required
 
 - `cloud` (Attributes) The cloud where the controller will operate. (see [below for nested schema](#nestedatt--cloud))
-- `cloud_credential` (Attributes, Sensitive) Cloud credentials to use for bootstrapping the controller. (see [below for nested schema](#nestedatt--cloud_credential))
 
 ### Optional
 
@@ -26,6 +25,7 @@ A resource that represents a Juju Controller.
 - `bootstrap_base` (String) The base for the bootstrap machine.
 - `bootstrap_config` (Map of String) Configuration options that apply during the bootstrap process.
 - `bootstrap_constraints` (Map of String) Constraints for the bootstrap machine.
+- `cloud_credential` (Attributes, Sensitive) Cloud credentials to use for bootstrapping the controller. (see [below for nested schema](#nestedatt--cloud_credential))
 - `controller_config` (Map of String) Configuration options for the bootstrapped controller. Note that removing a key from this map will not unset it in the controller, instead it will be left unchanged on the controller.
 - `controller_model_config` (Map of String) Configuration options to be set for the controller model.
 - `destroy_flags` (Attributes) Additional flags for destroying the controller. (see [below for nested schema](#nestedatt--destroy_flags))
@@ -49,28 +49,28 @@ A resource that represents a Juju Controller.
 
 Required:
 
-- `auth_types` (Set of String) The authentication type(s) supported by the cloud.
 - `name` (String) The name of the cloud
-- `type` (String) The type of the cloud .
 
 Optional:
 
+- `auth_types` (Set of String) The authentication type(s) supported by the cloud.
 - `ca_certificates` (Set of String) CA certificates for the cloud.
 - `config` (Map of String) Configuration options for the cloud.
 - `endpoint` (String) The API endpoint for the cloud.
 - `host_cloud_region` (String) The host cloud region for the cloud.
 - `region` (Attributes) The cloud region where the controller will operate. (see [below for nested schema](#nestedatt--cloud--region))
+- `type` (String) The type of the cloud .
 
 <a id="nestedatt--cloud--region"></a>
 ### Nested Schema for `cloud.region`
 
 Required:
 
-- `endpoint` (String) The API endpoint for the region.
 - `name` (String) The name of the region.
 
 Optional:
 
+- `endpoint` (String) The API endpoint for the region.
 - `identity_endpoint` (String) The identity endpoint for the region.
 - `storage_endpoint` (String) The storage endpoint for the region.
 

--- a/go.sum
+++ b/go.sum
@@ -99,8 +99,6 @@ github.com/bufbuild/protocompile v0.14.1 h1:iA73zAf/fyljNjQKwYzUHD6AD4R8KMasmwa/
 github.com/bufbuild/protocompile v0.14.1/go.mod h1:ppVdAIhbr2H8asPk6k4pY7t9zB1OU5DoEw9xY/FUi1c=
 github.com/canonical/go-dqlite v1.21.0 h1:4gLDdV2GF+vg0yv9Ff+mfZZNQ1JGhnQ3GnS2GeZPHfA=
 github.com/canonical/go-dqlite v1.21.0/go.mod h1:Uvy943N8R4CFUAs59A1NVaziWY9nJ686lScY7ywurfg=
-github.com/canonical/jimm-go-sdk/v3 v3.0.6 h1:ovQAEb5R5sSl7Edn27QTi/IyCX93xd87jE9ygj14mG0=
-github.com/canonical/jimm-go-sdk/v3 v3.0.6/go.mod h1:xcJrWTpLHSw3Z16/1Zcvh31awlwIzjXdrYUYCVZhc5s=
 github.com/canonical/jimm-go-sdk/v3 v3.3.12 h1:6/HvibmscAizHoeN28WeB+Gx0OQTlHqOWKXwuZA5arI=
 github.com/canonical/jimm-go-sdk/v3 v3.3.12/go.mod h1:xcJrWTpLHSw3Z16/1Zcvh31awlwIzjXdrYUYCVZhc5s=
 github.com/canonical/lxd v0.0.0-20241209155119-76da976c6ee7 h1:D+lFLV2E9um9NcknxFVBzboPSXpxJDEXspBbHMs4KxQ=


### PR DESCRIPTION
## Description

To allow importing of controller I had to change a few things about the schema.
- importing a controller doesn't require specifying cloud and cloud credential fully. All we need is conn info to change config, and conn info + cloud name and region to destroy the controller
- i've removed some required from the schema in favor of creating specific methods to validate for Creation
- this allows to import without update-in-place, which is a requirement for the testing harness. In fact an import should be a no-hop operation, and it shouldn't require changing anything in the state.

For the config is slightly different:
- importing with some configs set will always require an update in place, because in our `Read` we set the config in state by merging the config coming from the controller and the config we have in the state (in case of import nothing)
- so importing a controller with some config in the plan will always trigger an update in-place of the configs. Although i don't think that's a problem, because updating config should be idempotent.

## QA

Bootstrap a controller.
Import it.
```terraform
resource "juju_controller" "controller_imported" {
  name        = "imported-controller"
  juju_binary = "/snap/juju/current/bin/juju"

  cloud = {
    name = "localhost"
  }
}

import {
  to = juju_controller.controller_imported
  identity = {
    name = "imported-controller"
    api_addresses = [
      "10.165.178.116:17070",
    ]
    username        = "admin"
    password        = "<redacted>"
    ca_cert         = <<-EOT
<redacted>
    EOT
    controller_uuid = "028746b6-9777-4997-8129-6d3a7354b680"
    cloud           = "localhost"
  }
}
```
change a config value.

```terraform
resource "juju_controller" "controller_imported" {
  name        = "imported-controller"
  juju_binary = "/snap/juju/current/bin/juju"

  cloud = {
    name = "localhost"
  }

  controller_config = {
    "agent-logfile-max-backups" : "3",
  }
}
```

destroy it.

```terraform
resource "juju_controller" "controller_imported" {
  name        = "imported-controller"
  juju_binary = "/snap/juju/current/bin/juju"

  cloud = {
    name = "localhost"
  }

  controller_config = {
    "agent-logfile-max-backups" : "3",
  }

  destroy_flags = {
    destroy_all_models = true
  }
}
```

`terraform apply` first. Interesting that if you forget to add the destroy flags and you add it at the end, you need to apply and then destroy, otherwise they are not in the state. We should document this behavior.

`terraform destroy`