### PR TITLE
chore(error): surface error in WaitForAppsAvailable

### DIFF
--- a/internal/juju/integrations.go
+++ b/internal/juju/integrations.go
@@ -96,7 +96,7 @@ func (c integrationsClient) CreateIntegration(input *IntegrationInput) (*CreateI
 
 	err = WaitForAppsAvailable(ctx, client, input.Apps, IntegrationApiTickWait)
 	if err != nil {
-		return nil, errors.New("the applications were not available to be integrated")
+		return nil, errors.Annotate(err, "the applications were not available to be integrated")
 	}
 
 	listViaCIDRs := splitCommaDelimitedList(input.ViaCIDRs)


### PR DESCRIPTION
## Description

In MM it was reported:
```
│ Error: Client Error
│ 
│   with module.livepatch.juju_integration.livepatch-server_dbaas-postgresql,
│   on ../../modules/livepatch-server/main.tf line 204, in resource "juju_integration" "livepatch-server_dbaas-postgresql":
│  204: resource "juju_integration" "livepatch-server_dbaas-postgresql" {
│ 
│ Unable to create integration, got error: the applications were not available to be integrated
```
After a quick look around i've noticed we mask the error.
It's just better to surface the error.
