### PR TITLE
chore(update-golangci-lint): update golintci to version 2 and golang to 1.26

### DIFF
--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -77,10 +77,9 @@ jobs:
           go-version-file: "go.mod"
           cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
-          version: v1.64.5
-          args: --print-issued-lines=true
+          version: v2.8.0
 
   # This runs copyright-check against the codebase
   copyright-check:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,11 +1,29 @@
-run:
-  timeout: 5m
+version: "2"
+output:
+  formats:
+    text:
+      path: stdout
+      print-issued-lines: true
 linters:
   enable:
     - misspell
     - prealloc
     - whitespace
-output:
-  print-issued-lines: true
-  formats:
-    - format: colored-line-number
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/juju/terraform-provider-juju
 
-go 1.24.6
+go 1.25.6
 
 require (
 	github.com/bflad/tfproviderlint v0.30.0

--- a/go.sum
+++ b/go.sum
@@ -99,8 +99,6 @@ github.com/bufbuild/protocompile v0.14.1 h1:iA73zAf/fyljNjQKwYzUHD6AD4R8KMasmwa/
 github.com/bufbuild/protocompile v0.14.1/go.mod h1:ppVdAIhbr2H8asPk6k4pY7t9zB1OU5DoEw9xY/FUi1c=
 github.com/canonical/go-dqlite v1.21.0 h1:4gLDdV2GF+vg0yv9Ff+mfZZNQ1JGhnQ3GnS2GeZPHfA=
 github.com/canonical/go-dqlite v1.21.0/go.mod h1:Uvy943N8R4CFUAs59A1NVaziWY9nJ686lScY7ywurfg=
-github.com/canonical/jimm-go-sdk/v3 v3.0.6 h1:ovQAEb5R5sSl7Edn27QTi/IyCX93xd87jE9ygj14mG0=
-github.com/canonical/jimm-go-sdk/v3 v3.0.6/go.mod h1:xcJrWTpLHSw3Z16/1Zcvh31awlwIzjXdrYUYCVZhc5s=
 github.com/canonical/jimm-go-sdk/v3 v3.3.12 h1:6/HvibmscAizHoeN28WeB+Gx0OQTlHqOWKXwuZA5arI=
 github.com/canonical/jimm-go-sdk/v3 v3.3.12/go.mod h1:xcJrWTpLHSw3Z16/1Zcvh31awlwIzjXdrYUYCVZhc5s=
 github.com/canonical/lxd v0.0.0-20241209155119-76da976c6ee7 h1:D+lFLV2E9um9NcknxFVBzboPSXpxJDEXspBbHMs4KxQ=

--- a/internal/juju/applications_test.go
+++ b/internal/juju/applications_test.go
@@ -654,8 +654,7 @@ func (s *ApplicationSuite) TestUploadExistingPendingResourcesUploadSuccessful() 
 		Filename: "myimage",
 		Type:     "oci-image",
 	}
-	var pendingResources []apiapplication.PendingResourceUpload
-	pendingResources = append(pendingResources, resource)
+	pendingResources := []apiapplication.PendingResourceUpload{resource}
 	charmResources := map[string]CharmResource{
 		"custom-image": {
 			OCIImageURL:      "some-url",
@@ -682,8 +681,7 @@ func (s *ApplicationSuite) TestUploadExistingPendingResourcesUploadFailedReturnE
 		Filename: fileName,
 		Type:     "oci-image",
 	}
-	var pendingResources []apiapplication.PendingResourceUpload
-	pendingResources = append(pendingResources, resource)
+	pendingResources := []apiapplication.PendingResourceUpload{resource}
 	charmResources := map[string]CharmResource{
 		"custom-image": {
 			OCIImageURL:      "some-url",
@@ -704,13 +702,12 @@ func (s *ApplicationSuite) TestUploadExistingPendingResourcesResourceTypeUnknown
 	defer s.setupMocks(s.T()).Finish()
 	s.mockSharedClient.EXPECT().ModelType(gomock.Any()).Return(model.IAAS, nil).AnyTimes()
 	appName := "testapplication"
-	var pendingResources []apiapplication.PendingResourceUpload
 	resource := apiapplication.PendingResourceUpload{
 		Name:     "custom-image",
 		Filename: "my-image",
 		Type:     "unknown",
 	}
-	pendingResources = append(pendingResources, resource)
+	pendingResources := []apiapplication.PendingResourceUpload{resource}
 	charmResources := map[string]CharmResource{
 		"custom-image": {
 			OCIImageURL:      "some-url",

--- a/internal/juju/client.go
+++ b/internal/juju/client.go
@@ -155,10 +155,7 @@ func NewClient(ctx context.Context, config ControllerConfiguration, waitForResou
 	}
 	// Client ID and secret are only set when connecting to JAAS. Use this as a fallback
 	// value if connecting to the controller fails.
-	defaultJAASCheck := false
-	if config.ClientID != "" && config.ClientSecret != "" {
-		defaultJAASCheck = true
-	}
+	defaultJAASCheck := config.ClientID != "" && config.ClientSecret != ""
 
 	user := config.Username
 	if config.ClientID != "" && !strings.HasSuffix(config.ClientID, serviceAccountSuffix) {

--- a/internal/juju/jaas_test.go
+++ b/internal/juju/jaas_test.go
@@ -30,7 +30,7 @@ func (s *JaasSuite) setupMocks(t *testing.T) *gomock.Controller {
 
 func (s *JaasSuite) getJaasClient() jaasClient {
 	return jaasClient{
-		SharedClient: s.JujuSuite.mockSharedClient,
+		SharedClient: s.mockSharedClient,
 		getJaasApiClient: func(connection api.Connection) JaasAPIClient {
 			return s.mockJaasClient
 		},

--- a/internal/juju/offers.go
+++ b/internal/juju/offers.go
@@ -172,7 +172,7 @@ func (c offersClient) CreateOffer(input *CreateOfferInput) (*CreateOfferResponse
 		return nil, errs
 	}
 
-	modelOwner, modelName, err := c.SharedClient.ModelOwnerAndName(input.ModelUUID)
+	modelOwner, modelName, err := c.ModelOwnerAndName(input.ModelUUID)
 	if err != nil {
 		return nil, append(errs, fmt.Errorf("unable to get model name for model UUID %q: %w", input.ModelUUID, err))
 	}

--- a/internal/juju/secrets_test.go
+++ b/internal/juju/secrets_test.go
@@ -35,7 +35,7 @@ func (s *SecretSuite) setupMocks(t *testing.T) *gomock.Controller {
 
 func (s *SecretSuite) getSecretsClient() secretsClient {
 	return secretsClient{
-		SharedClient: s.JujuSuite.mockSharedClient,
+		SharedClient: s.mockSharedClient,
 		getSecretAPIClient: func(connection api.Connection) SecretAPIClient {
 			return s.mockSecretClient
 		},

--- a/internal/juju/storage.go
+++ b/internal/juju/storage.go
@@ -11,8 +11,8 @@ import (
 )
 
 var (
-	// StoragePoolNotFoundError is returned when a storage pool does not exist.
-	StoragePoolNotFoundError = errors.New("storage pool not found")
+	// ErrStoragePoolNotFound is returned when a storage pool does not exist.
+	ErrStoragePoolNotFound = errors.New("storage pool not found")
 )
 
 type storageClient struct {
@@ -112,7 +112,7 @@ func (c *storageClient) GetPool(input GetStoragePoolInput) (GetStoragePoolRespon
 		return GetStoragePoolResponse{}, err
 	}
 	if len(pools) == 0 {
-		return GetStoragePoolResponse{}, StoragePoolNotFoundError
+		return GetStoragePoolResponse{}, ErrStoragePoolNotFound
 	}
 
 	return GetStoragePoolResponse{Pool: pools[0]}, nil

--- a/internal/provider/custom_type_constraints.go
+++ b/internal/provider/custom_type_constraints.go
@@ -144,7 +144,7 @@ func (v CustomConstraintsValue) StringSemanticEquals(ctx context.Context, newVal
 	}
 
 	// Parse and normalize constraints for semantic comparison
-	leftRaw := v.StringValue.ValueString()
+	leftRaw := v.ValueString()
 	rightRaw := newValue.ValueString()
 	if leftRaw == rightRaw { // exact match
 		return true, diags

--- a/internal/provider/custom_type_csv_string.go
+++ b/internal/provider/custom_type_csv_string.go
@@ -129,7 +129,7 @@ func (v CustomCommaDelimitedStringValue) StringSemanticEquals(ctx context.Contex
 	}
 
 	// Split the two strings into tokens and compare the two slices
-	leftRaw := v.StringValue.ValueString()
+	leftRaw := v.ValueString()
 	rightRaw := newValue.ValueString()
 	if leftRaw == rightRaw { // exact match
 		return true, diags

--- a/internal/provider/modifier_units.go
+++ b/internal/provider/modifier_units.go
@@ -32,7 +32,7 @@ func (m unitCountModifier) MarkdownDescription(_ context.Context) string {
 // PlanModifyBool implements the plan modification logic.
 func (m unitCountModifier) PlanModifyInt64(ctx context.Context, req planmodifier.Int64Request, resp *planmodifier.Int64Response) {
 	// Do nothing if there is a known configuration value.
-	if !(req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown()) {
+	if !req.ConfigValue.IsNull() && !req.ConfigValue.IsUnknown() {
 		return
 	}
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -156,7 +156,7 @@ func (j jujuProviderModel) valid() bool {
 
 	return j.ControllerAddrs.ValueString() != "" &&
 		(validUserPass || validClientCredentials) &&
-		!(validUserPass && validClientCredentials)
+		(!validUserPass || !validClientCredentials)
 }
 
 // merge 2 providerModels together. The receiver data takes

--- a/internal/provider/resource_access_generic.go
+++ b/internal/provider/resource_access_generic.go
@@ -351,7 +351,7 @@ func modelToTuples(ctx context.Context, targetTag names.Tag, model objectsWithAc
 		Target:   targetTag.String(),
 		Relation: model.Access.ValueString(),
 	}
-	var tuples []juju.JaasTuple
+	tuples := make([]juju.JaasTuple, 0, 4)
 	userNameToTagf := func(s string) string { return names.NewUserTag(s).String() }
 	groupIDToTagf := func(s string) string { return jimmnames.NewGroupTag(s).String() + "#member" }
 	roleIDToTagf := func(s string) string { return jimmnames.NewRoleTag(s).String() + "#assignee" }

--- a/internal/provider/resource_access_jaas_cloud_test.go
+++ b/internal/provider/resource_access_jaas_cloud_test.go
@@ -132,9 +132,7 @@ func TestAcc_ResourceJaasAccessCloudImportState(t *testing.T) {
 						}
 						return nil
 					}
-					errs := make([]error, 1)
-					errs = append(errs, checker("users.0", "everyone@external"))
-					errs = append(errs, checker("users.#", "1"))
+					errs := []error{checker("users.0", "everyone@external"), checker("users.#", "1")}
 					return errors.Join(errs...)
 				},
 				ImportState:   true,

--- a/internal/provider/resource_access_jaas_controller_test.go
+++ b/internal/provider/resource_access_jaas_controller_test.go
@@ -126,11 +126,12 @@ func TestAcc_ResourceJaasAccessControllerImportState(t *testing.T) {
 						}
 						return nil
 					}
-					errs := make([]error, 1)
-					errs = append(errs, checker("users.0", "jimm-test@canonical.com"))
-					errs = append(errs, checker("users.#", "1"))
-					errs = append(errs, checker("service_accounts.0", strings.TrimSuffix(expectedResourceOwner(), "@serviceaccount")))
-					errs = append(errs, checker("service_accounts.#", "1"))
+					errs := []error{
+						checker("users.0", "jimm-test@canonical.com"),
+						checker("users.#", "1"),
+						checker("service_accounts.0", strings.TrimSuffix(expectedResourceOwner(), "@serviceaccount")),
+						checker("service_accounts.#", "1"),
+					}
 					return errors.Join(errs...)
 				},
 				ImportState:   true,

--- a/internal/provider/resource_application.go
+++ b/internal/provider/resource_application.go
@@ -1096,13 +1096,13 @@ func (r *applicationResource) Update(ctx context.Context, req resource.UpdateReq
 
 	if !plan.Machines.Equal(state.Machines) {
 		var planMachines, stateMachines []string
-		if !(plan.Machines.IsUnknown() || plan.Machines.IsNull()) {
+		if !plan.Machines.IsUnknown() && !plan.Machines.IsNull() {
 			resp.Diagnostics.Append(plan.Machines.ElementsAs(ctx, &planMachines, false)...)
 			if resp.Diagnostics.HasError() {
 				return
 			}
 		}
-		if !(state.Machines.IsUnknown() || plan.Machines.IsUnknown()) {
+		if !state.Machines.IsUnknown() && !plan.Machines.IsUnknown() {
 			resp.Diagnostics.Append(state.Machines.ElementsAs(ctx, &stateMachines, false)...)
 			if resp.Diagnostics.HasError() {
 				return

--- a/internal/provider/resource_integration.go
+++ b/internal/provider/resource_integration.go
@@ -502,9 +502,10 @@ func newIDForIntegrationResource(modelUUID string, apps []juju.Application) stri
 	//TODO: verify we always get only 2 endpoints and that the role value is consistent
 	keys := make([]int, len(apps))
 	for k, v := range apps {
-		if v.Role == "provider" {
+		switch v.Role {
+		case "provider":
 			keys[0] = k
-		} else if v.Role == "requirer" {
+		case "requirer":
 			keys[1] = k
 		}
 	}

--- a/internal/provider/resource_storage_pool.go
+++ b/internal/provider/resource_storage_pool.go
@@ -384,7 +384,7 @@ func (r *storagePoolResource) Delete(ctx context.Context, req resource.DeleteReq
 				ModelUUID: state.ModelUUID.ValueString(),
 				PoolName:  state.Name.ValueString(),
 			},
-			ExpectedErr:    juju.StoragePoolNotFoundError,
+			ExpectedErr:    juju.ErrStoragePoolNotFound,
 			RetryAllErrors: true,
 		},
 	); err != nil {


### PR DESCRIPTION
## Description

Updating go to version 1.26, and contextually updating golangci-lint to v2 because i couldn't find a v1 supporting go 1.26.
The new golangci-lint conf has been generated using this guide: https://golangci-lint.run/docs/product/migration-guide/
The fix here are to satisfy the linter.

