### PR TITLE
feat(import-controller): add import for controllers

### DIFF
--- a/.github/workflows/k8s_tunnel.yml
+++ b/.github/workflows/k8s_tunnel.yml
@@ -48,7 +48,7 @@ jobs:
         cloud:
           - "microk8s"
         terraform:
-          - "1.11.*"
+          - "1.12.*"
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test_integration.yml
+++ b/.github/workflows/test_integration.yml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        terraform: ["1.11.*"]
+        terraform: ["1.12.*"]
         action-operator:
           - { lxd-channel: "5.21/stable", cloud: "lxd", cloud-channel: "6", juju: "2.9" }
           - { lxd-channel: "5.21/stable", cloud: "lxd", cloud-channel: "6", juju: "3" }
@@ -163,7 +163,7 @@ jobs:
         cloud:
           - "lxd"
         terraform:
-          - "1.11.*"
+          - "1.12.*"
         juju:
           - "2.9/stable"
           - "3/stable"

--- a/.github/workflows/test_integration_cross_controller.yml
+++ b/.github/workflows/test_integration_cross_controller.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        terraform: ["1.11.*"]
+        terraform: ["1.12.*"]
         action-operator:
           - { lxd-channel: "5.21/stable", cloud: "lxd", cloud-channel: "6", juju: "2.9" }
           - { lxd-channel: "5.21/stable", cloud: "lxd", cloud-channel: "6", juju: "3" }

--- a/.github/workflows/test_integration_cross_controller_jaas.yml
+++ b/.github/workflows/test_integration_cross_controller_jaas.yml
@@ -35,7 +35,7 @@ jobs:
           cache: true
       - uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: "1.11.*"
+          terraform_version: "1.12.*"
           terraform_wrapper: false
 
       - name: Set up Docker Compose

--- a/.github/workflows/test_integration_jaas.yaml
+++ b/.github/workflows/test_integration_jaas.yaml
@@ -49,7 +49,7 @@ jobs:
           cache: true
       - uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: "1.11.*"
+          terraform_version: "1.12.*"
           terraform_wrapper: false
       - name: Set up Docker Compose
         uses: docker/setup-compose-action@v1

--- a/docs-rtd/reference/terraform-provider/resources/controller.md
+++ b/docs-rtd/reference/terraform-provider/resources/controller.md
@@ -66,11 +66,11 @@ Optional:
 
 Required:
 
-- `endpoint` (String) The API endpoint for the region.
 - `name` (String) The name of the region.
 
 Optional:
 
+- `endpoint` (String) The API endpoint for the region.
 - `identity_endpoint` (String) The identity endpoint for the region.
 - `storage_endpoint` (String) The storage endpoint for the region.
 

--- a/docs/resources/controller.md
+++ b/docs/resources/controller.md
@@ -66,11 +66,11 @@ Optional:
 
 Required:
 
-- `endpoint` (String) The API endpoint for the region.
 - `name` (String) The name of the region.
 
 Optional:
 
+- `endpoint` (String) The API endpoint for the region.
 - `identity_endpoint` (String) The identity endpoint for the region.
 - `storage_endpoint` (String) The storage endpoint for the region.
 

--- a/go.sum
+++ b/go.sum
@@ -99,8 +99,6 @@ github.com/bufbuild/protocompile v0.14.1 h1:iA73zAf/fyljNjQKwYzUHD6AD4R8KMasmwa/
 github.com/bufbuild/protocompile v0.14.1/go.mod h1:ppVdAIhbr2H8asPk6k4pY7t9zB1OU5DoEw9xY/FUi1c=
 github.com/canonical/go-dqlite v1.21.0 h1:4gLDdV2GF+vg0yv9Ff+mfZZNQ1JGhnQ3GnS2GeZPHfA=
 github.com/canonical/go-dqlite v1.21.0/go.mod h1:Uvy943N8R4CFUAs59A1NVaziWY9nJ686lScY7ywurfg=
-github.com/canonical/jimm-go-sdk/v3 v3.0.6 h1:ovQAEb5R5sSl7Edn27QTi/IyCX93xd87jE9ygj14mG0=
-github.com/canonical/jimm-go-sdk/v3 v3.0.6/go.mod h1:xcJrWTpLHSw3Z16/1Zcvh31awlwIzjXdrYUYCVZhc5s=
 github.com/canonical/jimm-go-sdk/v3 v3.3.12 h1:6/HvibmscAizHoeN28WeB+Gx0OQTlHqOWKXwuZA5arI=
 github.com/canonical/jimm-go-sdk/v3 v3.3.12/go.mod h1:xcJrWTpLHSw3Z16/1Zcvh31awlwIzjXdrYUYCVZhc5s=
 github.com/canonical/lxd v0.0.0-20241209155119-76da976c6ee7 h1:D+lFLV2E9um9NcknxFVBzboPSXpxJDEXspBbHMs4KxQ=


### PR DESCRIPTION
## Description

Importing a controller in this way is a different approach to https://github.com/juju/terraform-provider-juju/pull/1040. Basically we keep the same identity schema, but we also fetch the cloud and cloud credential definition during import.

This allows to keep the validation for required field the same between import and creation of controllers.

The tricky part is that to avoid require-replacing things during tests, due to microk8s and localhost having implicit configuration for clouds and cloud credentials, I had to add `lifecycle` directives in tests plan.

The code here is a little more complex, but it adds the value of actually checking the controller we are importing by comparing what's in the controller and what's in the plan. In the other pr, while it's simpler, the controller was imported without checking cloud and cloud credentials.

### NOTE

Identity Schema is available from 1.12.0
https://github.com/hashicorp/terraform/blob/v1.12/CHANGELOG.md#1120-may-14-2025

## QA

```terraform
provider "juju" {
  controller_mode = true
}

locals {
  lxd_creds = yamldecode(file("~/lxd-credentials.yaml"))
}

resource "juju_controller" "controller_imported" {
  name        = "imported-controller"
  juju_binary = "/snap/juju/current/bin/juju"

  cloud = {
    name       = "localhost"
    auth_types = ["certificate"]
    type       = "lxd"
    endpoint   = local.lxd_creds.endpoint

    region = {
      name = "localhost"
    }
  }

  cloud_credential = {
    name      = "localhost"
    auth_type = "certificate"

    attributes = {
      server-cert = local.lxd_creds.server-cert
    }
  }

  lifecycle {
    ignore_changes = [
      cloud_credential.attributes["client-cert"],
      cloud_credential.attributes["client-key"],
    ]
  }

}

import {
  to = juju_controller.controller_imported
  identity = {
    name = "imported-controller"
    api_addresses = [
      "10.165.178.123:17070",
    ]
    username        = "admin"
    password        = "0f81b8da67378ec9044ad1d49bb7e17e"
    ca_cert         = <<-EOT
    EOT
    controller_uuid = "78355a44-3bfd-4920-8d93-d0ac751eb881"
    credential_name = "localhost"
  }
}
```