### PR TITLE
feat(juju_binary): make juju_binary a required field and add the doc to explain snap confinement

### DIFF
--- a/docs-rtd/howto/manage-controllers.md
+++ b/docs-rtd/howto/manage-controllers.md
@@ -57,6 +57,8 @@ Here we use the `localhost` cloud which is already known to the Juju CLI. Privat
 resource "juju_controller" "this" {
   name = "test-controller"
 
+  juju_binary = "/snap/juju/current/bin/juju"
+  
   cloud = {
     name       = "localhost"
     type       = "lxd"
@@ -84,9 +86,6 @@ resource "juju_controller" "this" {
     "juju-http-proxy" = "http://my-proxy.internal"
   }
 
-  # Optional: use a Juju binary from a specific location.
-  # The default is /usr/bin/juju.
-  juju_binary = "/snap/juju/current/bin/juju"
 }
 ```
 

--- a/docs-rtd/reference/terraform-provider/resources/controller.md
+++ b/docs-rtd/reference/terraform-provider/resources/controller.md
@@ -19,6 +19,7 @@ A resource that represents a Juju Controller.
 
 - `cloud` (Attributes) The cloud where the controller will operate. (see [below for nested schema](#nestedatt--cloud))
 - `cloud_credential` (Attributes, Sensitive) Cloud credentials to use for bootstrapping the controller. (see [below for nested schema](#nestedatt--cloud_credential))
+- `juju_binary` (String) The path to the juju CLI binary. If you have installed Juju as a snap, use the path `/snap/juju/current/bin/juju` to avoid snap confinement issues.
 
 ### Optional
 
@@ -29,7 +30,6 @@ A resource that represents a Juju Controller.
 - `controller_config` (Map of String) Configuration options for the bootstrapped controller. Note that removing a key from this map will not unset it in the controller, instead it will be left unchanged on the controller.
 - `controller_model_config` (Map of String) Configuration options to be set for the controller model.
 - `destroy_flags` (Attributes) Additional flags for destroying the controller. Changing any of these values will require applying before they can be taken into account during destroy. (see [below for nested schema](#nestedatt--destroy_flags))
-- `juju_binary` (String) The path to the juju CLI binary.
 - `model_constraints` (Map of String) Constraints for all workload machines in models.
 - `model_default` (Map of String) Configuration options to be set for all models.
 - `name` (String) The name to be assigned to the controller. Changing this value will require the controller to be destroyed and recreated by terraform.

--- a/docs/resources/controller.md
+++ b/docs/resources/controller.md
@@ -19,6 +19,7 @@ A resource that represents a Juju Controller.
 
 - `cloud` (Attributes) The cloud where the controller will operate. (see [below for nested schema](#nestedatt--cloud))
 - `cloud_credential` (Attributes, Sensitive) Cloud credentials to use for bootstrapping the controller. (see [below for nested schema](#nestedatt--cloud_credential))
+- `juju_binary` (String) The path to the juju CLI binary. If you have installed Juju as a snap, use the path `/snap/juju/current/bin/juju` to avoid snap confinement issues.
 
 ### Optional
 
@@ -29,7 +30,6 @@ A resource that represents a Juju Controller.
 - `controller_config` (Map of String) Configuration options for the bootstrapped controller. Note that removing a key from this map will not unset it in the controller, instead it will be left unchanged on the controller.
 - `controller_model_config` (Map of String) Configuration options to be set for the controller model.
 - `destroy_flags` (Attributes) Additional flags for destroying the controller. Changing any of these values will require applying before they can be taken into account during destroy. (see [below for nested schema](#nestedatt--destroy_flags))
-- `juju_binary` (String) The path to the juju CLI binary.
 - `model_constraints` (Map of String) Constraints for all workload machines in models.
 - `model_default` (Map of String) Configuration options to be set for all models.
 - `name` (String) The name to be assigned to the controller. Changing this value will require the controller to be destroyed and recreated by terraform.

--- a/internal/provider/resource_controller.go
+++ b/internal/provider/resource_controller.go
@@ -19,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -383,13 +382,11 @@ func (r *controllerResource) Schema(_ context.Context, _ resource.SchemaRequest,
 				},
 			},
 			"juju_binary": schema.StringAttribute{
-				Description: "The path to the juju CLI binary.",
-				Optional:    true,
-				Computed:    true,
+				Description: "The path to the juju CLI binary. If you have installed Juju as a snap, use the path `/snap/juju/current/bin/juju` to avoid snap confinement issues.",
+				Required:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
-				Default: stringdefault.StaticString("/usr/bin/juju"),
 			},
 			"model_constraints": schema.MapAttribute{
 				Description: "Constraints for all workload machines in models.",


### PR DESCRIPTION
## Description

We thought about auto-detecting the juju_binary in the PATH, but it's just best to require the field. Mainly because to avoid snap confinement issues the full path has to be specified. I've documented directly in the field, so we make sure people don't make mistakes.


