### PR TITLE
fix(jaas-export-models): fix GetUser() to return the client-id when connected to JAAS

### DIFF
--- a/internal/juju/client.go
+++ b/internal/juju/client.go
@@ -266,6 +266,9 @@ func (sc *sharedClient) IsOfferingController(name string) bool {
 
 // GetUser returns the username of the user connecting to the Juju controller.
 func (sc *sharedClient) GetUser() string {
+	if sc.isJAAS {
+		return sc.controllerConfig.ClientID
+	}
 	return sc.controllerConfig.Username
 }
 


### PR DESCRIPTION
## Description

The listmodels test was failing against jaas. Now it doesn't fail anymore.
