### PR TITLE
chore: merge v1.3 branch into main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 1.3.1
+
+NOTES:
+
+* **This release requires Juju controller version 2.9.49 or higher Juju.**
+* **If using JAAS, this release requires Juju controller version 3.6.5 or higher.**
+* This release uses Juju client api code from the Juju 3.6.11 release.
+
+BUG FIXES
+
+* Respect proxy environment variables by @SimoneDutto in [#1103](https://github.com/juju/terraform-provider-juju/pull/1103)
+
 
 ## 1.3.0
 


### PR DESCRIPTION
## Description

This PR merges the v1.3 branch back into main so that main contains the latest tagged release and changelog.

Because we landed the proxy fix in main, then cherry-picked the merge-commit into the v1.3 branch afterwards (in order to avoid releasing the enable-ha action), we have the same code with new commit hashes. To avoid this in the future, we can target the desired branch from the start based on when we want to release the change.
