### PR TITLE
test(application-k8s): in juju 4 the juju-external-hostname implicit config for charms doesn't exist

### DIFF
--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -127,6 +127,18 @@ func SkipAgainstJuju4(t *testing.T) {
 	}
 }
 
+// jujuExternalHostname returns the juju-external-hostname config line for use
+// in Terraform HCL templates. In Juju < 4.0 this config is an implicit config and
+// it's required to expose an application.
+// In Juju 4.0+ it must be omitted, so an empty string is returned instead.
+func jujuExternalHostname() string {
+	agentVersion := os.Getenv(TestJujuAgentVersion)
+	if agentVersion != "" && internaltesting.CompareVersions(agentVersion, "4.0.0") >= 0 {
+		return ""
+	}
+	return `juju-external-hostname="myhostname"`
+}
+
 func TestProviderConfigure(t *testing.T) {
 	testAccPreCheck(t)
 	jujuProvider := NewJujuProvider("dev", ProviderConfiguration{WaitForResources: true})

--- a/internal/provider/resource_application_test.go
+++ b/internal/provider/resource_application_test.go
@@ -1712,10 +1712,10 @@ func testAccResourceApplicationBasic(modelName, appName string) string {
 		  trust = true
 		  expose{}
 		  config = {
-			juju-external-hostname="myhostname"
+			%s
 		  }
 		}
-		`, modelName, appName)
+		`, modelName, appName, jujuExternalHostname())
 	}
 }
 
@@ -1754,10 +1754,10 @@ func testAccResourceApplicationScaleUp(modelName, appName, numberOfUnits string)
 		  expose{}
 		  units = %q
 		  config = {
-			juju-external-hostname="myhostname"
+			%s
 		  }
 		}
-		`, modelName, appName, numberOfUnits)
+		`, modelName, appName, numberOfUnits, jujuExternalHostname())
 	}
 }
 
@@ -1867,10 +1867,10 @@ resource "juju_application" "this" {
     "%s" = "%s"
   }
   config = {
-    juju-external-hostname="myhostname"
+    %s
   }
 }
-`, modelName, channel, resourceName, customResource)
+`, modelName, channel, resourceName, customResource, jujuExternalHostname())
 }
 
 func testAccResourceApplicationWithChannelAndRevision(modelName, channel string, revision int) string {
@@ -1907,10 +1907,10 @@ resource "juju_application" "this" {
   trust = true
   expose{}
   config = {
-    juju-external-hostname="myhostname"
+    %s
   }
 }
-`, modelName, channel)
+`, modelName, channel, jujuExternalHostname())
 }
 
 func testAccResourceApplicationUpdates(modelName string, units int, expose bool, hostname string) string {
@@ -1958,10 +1958,10 @@ func testAccResourceApplicationUpdates(modelName string, units int, expose bool,
 		  %s
 		  config = {
 		  	# hostname = "%s"
-			juju-external-hostname="myhostname"
+			%s
 		  }
 		}
-		`, modelName, units, exposeStr, hostname)
+		`, modelName, units, exposeStr, hostname, jujuExternalHostname())
 	}
 }
 
@@ -1977,9 +1977,6 @@ func testAccResourceApplicationRefreshCharmUpdatesResources(modelName string, re
 		  charm {
 			name     = "coredns"
 			revision = %d
-		  }
-		  config = {
-			juju-external-hostname="myhostname"
 		  }
 		}
 		`, modelName, revision)
@@ -2119,10 +2116,10 @@ resource "juju_application" "this" {
   expose{}
   constraints = "%s"
   config = {
-    juju-external-hostname="myhostname"
+    %s
   }
 }
-`, modelName, constraints)
+`, modelName, constraints, jujuExternalHostname())
 	}
 }
 


### PR DESCRIPTION
## Description

in juju 4 this implicit config has been removed, but it's still needed in juju 3 to expose an application. So i conditionally set it.

See: https://github.com/juju/juju/issues/21945

# QA

No 4 test should fail with:
```
Unable to create application, got error: preparing CAAS application args:
        validating create application args: validating application config: unknown
        option "juju-external-hostname"
```