### PR TITLE
fix: fixes state inconsistency when constraints come from model defaults

### DIFF
--- a/internal/provider/resource_machine.go
+++ b/internal/provider/resource_machine.go
@@ -156,8 +156,13 @@ func (r *machineResource) Schema(ctx context.Context, req resource.SchemaRequest
 					"and provider's defaults. Changing this value will cause the application to be destroyed and" +
 					" recreated by terraform.",
 				Optional: true,
+				Computed: true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplaceIf(constraintsRequiresReplacefunc, "", ""),
+					// UseStateForUnknown because if any constraints are set at the model level, they'll be
+					// returned in the API response and we want to avoid unnecessary diffs if the user didn't
+					// explicitly set constraints per machine.
+					stringplanmodifier.UseStateForUnknown(),
 				},
 				Validators: []validator.String{
 					stringvalidator.ConflictsWith(path.Expressions{
@@ -372,6 +377,7 @@ func (r *machineResource) Create(ctx context.Context, req resource.CreateRequest
 
 	plan.Base = types.StringValue(readResponse.Base)
 	plan.Hostname = types.StringValue(readResponse.Hostname)
+	plan.Constraints = NewCustomConstraintsValue(readResponse.Constraints)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
@@ -485,9 +491,10 @@ func (r *machineResource) Read(ctx context.Context, req resource.ReadRequest, re
 	//    It could happen that the hostname is set to an empty string during import, but unlikely because
 	//    that means you've created a machine and then imported it immediately afterwards.
 	data.Hostname = types.StringValue(response.Hostname)
-	if response.Constraints != "" {
-		data.Constraints = NewCustomConstraintsValue(response.Constraints)
-	}
+	// Always set constraints from Juju, as they're optional + computed for the scenario where the model sets the
+	// constraints. We're also using UseStateForUnknown plan modifier, so if the user doesn't set constraints and
+	// the API returns them from the model, we won't get unnecessary diffs.
+	data.Constraints = NewCustomConstraintsValue(response.Constraints)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 

--- a/internal/provider/resource_machine_test.go
+++ b/internal/provider/resource_machine_test.go
@@ -165,7 +165,7 @@ func TestAcc_ResourceMachine_ConstraintsSetOnModelAreHonoured(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair("juju_model.this", "uuid", resourceName, "model_uuid"),
 					resource.TestCheckResourceAttrSet(resourceName, "machine_id"),
-					resource.TestCheckResourceAttr(resourceName, "constraints", "arch=arm64 mem=1024M"),
+					resource.TestCheckResourceAttr(resourceName, "constraints", "mem=1024M"),
 				),
 			},
 			// Plan again to ensure model inherited constraints do not cause drift (i.e., architecture).
@@ -211,7 +211,7 @@ func TestAcc_ResourceMachine_ConstraintsSetOnModelUseStateForUnknown(t *testing.
 				Config: testAccResourceMachineWithModelConstraintsAndAnnotation(modelName, "value-one"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "annotations.test", "value-one"),
-					resource.TestCheckResourceAttr(resourceName, "constraints", "arch=arm64 mem=1024M"),
+					resource.TestCheckResourceAttr(resourceName, "constraints", "mem=1024M"),
 				),
 			},
 			{
@@ -226,7 +226,7 @@ func TestAcc_ResourceMachine_ConstraintsSetOnModelUseStateForUnknown(t *testing.
 				},
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "annotations.test", "value-two"),
-					resource.TestCheckResourceAttr(resourceName, "constraints", "arch=arm64 mem=1024M"),
+					resource.TestCheckResourceAttr(resourceName, "constraints", "mem=1024M"),
 				),
 			},
 		},
@@ -325,7 +325,7 @@ func testAccResourceMachineWithModelConstraints(modelName string) string {
 	return fmt.Sprintf(`
 resource "juju_model" "this" {
 	name = %q
-	constraints = "arch=arm64 mem=1024M"
+	constraints = "mem=1024M"
 }
 
 resource "juju_machine" "this" {
@@ -340,7 +340,7 @@ func testAccResourceMachineWithModelConstraintsAndAnnotation(modelName, annotati
 	return fmt.Sprintf(`
 resource "juju_model" "this" {
 	name = %q
-	constraints = "arch=arm64 mem=1024M"
+	constraints = "mem=1024M"
 }
 
 resource "juju_machine" "this" {

--- a/internal/provider/resource_machine_test.go
+++ b/internal/provider/resource_machine_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 
 	internaltesting "github.com/juju/terraform-provider-juju/internal/testing"
 )
@@ -141,6 +142,97 @@ func TestAcc_ResourceMachine_WithPlacement(t *testing.T) {
 	})
 }
 
+func TestAcc_ResourceMachine_ConstraintsSetOnModelAreHonoured(t *testing.T) {
+	if testingCloud != LXDCloudTesting {
+		t.Skip(t.Name() + " only runs with LXD")
+	}
+	agentVersion := os.Getenv(TestJujuAgentVersion)
+	if agentVersion == "" {
+		t.Errorf("%s is not set", TestJujuAgentVersion)
+	} else if internaltesting.CompareVersions(agentVersion, "3.0.0") < 0 {
+		t.Skipf("%s is not set or is below 3.0.0", TestJujuAgentVersion)
+	}
+
+	modelName := acctest.RandomWithPrefix("tf-test-machine")
+	resourceName := "juju_machine.this"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: frameworkProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceMachineWithModelConstraints(modelName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair("juju_model.this", "uuid", resourceName, "model_uuid"),
+					resource.TestCheckResourceAttrSet(resourceName, "machine_id"),
+					resource.TestCheckResourceAttr(resourceName, "constraints", "arch=arm64 mem=1024M"),
+				),
+			},
+			// Plan again to ensure model inherited constraints do not cause drift (i.e., architecture).
+			{
+				Config:   testAccResourceMachineWithModelConstraints(modelName),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+// Concrete scenario for UseStateForUnknown on machine.constraints:
+//  1. First apply creates a machine without explicit machine constraints.
+//     Juju reports model-inherited constraints (e.g. "arch=arm64 mem=1024M"),
+//     and that value is stored in Terraform state.
+//  2. Second apply changes only annotations (an unrelated in-place update).
+//  3. During planning, constraints may be unknown because it is computed and
+//     omitted in config. UseStateForUnknown keeps the prior known state value
+//     in the plan instead of letting constraints temporarily become unknown.
+//  4. Apply/refresh finishes with an empty post-refresh plan.
+//
+// In short: unrelated updates do not cause computed constraints to churn from
+// known -> unknown -> known.
+func TestAcc_ResourceMachine_ConstraintsSetOnModelUseStateForUnknown(t *testing.T) {
+	if testingCloud != LXDCloudTesting {
+		t.Skip(t.Name() + " only runs with LXD")
+	}
+	agentVersion := os.Getenv(TestJujuAgentVersion)
+	if agentVersion == "" {
+		t.Errorf("%s is not set", TestJujuAgentVersion)
+	} else if internaltesting.CompareVersions(agentVersion, "3.0.0") < 0 {
+		t.Skipf("%s is not set or is below 3.0.0", TestJujuAgentVersion)
+	}
+
+	modelName := acctest.RandomWithPrefix("tf-test-machine")
+	resourceName := "juju_machine.this"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: frameworkProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceMachineWithModelConstraintsAndAnnotation(modelName, "value-one"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "annotations.test", "value-one"),
+					resource.TestCheckResourceAttr(resourceName, "constraints", "arch=arm64 mem=1024M"),
+				),
+			},
+			{
+				Config: testAccResourceMachineWithModelConstraintsAndAnnotation(modelName, "value-two"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "annotations.test", "value-two"),
+					resource.TestCheckResourceAttr(resourceName, "constraints", "arch=arm64 mem=1024M"),
+				),
+			},
+		},
+	})
+}
+
 func testAccResourceMachineBasicMinimal(modelName string) string {
 	return fmt.Sprintf(`
 resource "juju_model" "this" {
@@ -227,6 +319,39 @@ resource "juju_machine" "this" {
 	base = "ubuntu@22.04"
 }
 `, modelName)
+}
+
+func testAccResourceMachineWithModelConstraints(modelName string) string {
+	return fmt.Sprintf(`
+resource "juju_model" "this" {
+	name = %q
+	constraints = "arch=arm64 mem=1024M"
+}
+
+resource "juju_machine" "this" {
+	name = "this_machine"
+	model_uuid = juju_model.this.uuid
+	base = "ubuntu@22.04"
+}
+`, modelName)
+}
+
+func testAccResourceMachineWithModelConstraintsAndAnnotation(modelName, annotationValue string) string {
+	return fmt.Sprintf(`
+resource "juju_model" "this" {
+	name = %q
+	constraints = "arch=arm64 mem=1024M"
+}
+
+resource "juju_machine" "this" {
+	name = "this_machine"
+	model_uuid = juju_model.this.uuid
+	base = "ubuntu@22.04"
+	annotations = {
+		test = %q
+	}
+}
+`, modelName, annotationValue)
 }
 
 func testAccResourceMachineWithConstraints(modelName, constraints string) string {


### PR DESCRIPTION

## Description

Fixes `juju_machine.constraints` state inconsistency when constraints come from model defaults rather than being set directly on the machine.

Changes:
- Made machine constraints optional + computed.
- Set machine constraints from Juju in create/read for the inherited-defaults flow.
- Added test coverage for model-inherited constraints and no-drift re-plan.

A little driveby:
- Added UseStateForUnknown() on machine constraints to reduce plan noise from temporary unknowns.


Now it prevents null/unknown vs returned value mismatches and stabilises follow-up reapplies for this path.

Fixes: #1119 

## Type of change
- Change existing resource

## Environment

- Juju controller version: 3.6.14

- Terraform version: 1.12

## QA steps

Run this plan **twice**.
```tf
terraform {
  required_providers {
    juju = {
      source  = "juju/juju"
      version = "1.3.0"
    }
  }
}

resource "juju_model" "test" {
  name = "test"
  constraints = "arch=arm64 mem=1G"
}

resource "juju_machine" "landscape_server" {
  model_uuid  = juju_model.test.uuid
  name        = "landscape-server-0"
  base        = "ubuntu@24.04"
}
```

## Additional notes
When fixing this I realised there's one more minor issue, if you add some constraints to model defaults, and others to machine I.e., architecture to the model and cores to the machine, we will have drift because it is going to report both the architecture **and** cores constraint despite only being planned for cores. 

I'll fix this in a follow up.
