### PR TITLE
fix(endpointbindings): fix EndpointBindings* tests

### DIFF
--- a/internal/provider/resource_application_test.go
+++ b/internal/provider/resource_application_test.go
@@ -2351,9 +2351,7 @@ func testCheckEndpointsAreSetToCorrectSpace(ctx context.Context, modelUUID, appN
 		for i := 0; i < 50; i++ {
 			status, err := clientAPIClient.Status(
 				context.Background(),
-				&apiclient.StatusArgs{
-					Patterns: []string{appName},
-				})
+				&apiclient.StatusArgs{})
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
## Description

Fix EndpointBindings* tests by dropping `Patters` which is not supported in Juju 4.
