### PR TITLE
test: fix check for testing against Juju 4

### DIFF
--- a/internal/provider/resource_controller_test.go
+++ b/internal/provider/resource_controller_test.go
@@ -32,6 +32,7 @@ import (
 	controllerapi "github.com/juju/juju/api/controller/controller"
 	"github.com/juju/names/v6"
 	"github.com/juju/terraform-provider-juju/internal/juju"
+	internaltesting "github.com/juju/terraform-provider-juju/internal/testing"
 	"github.com/juju/version/v2"
 )
 
@@ -412,12 +413,10 @@ func TestAcc_ResourceControllerWithJujuBinary(t *testing.T) {
 					if testingCloud != LXDCloudTesting {
 						return true, nil
 					}
-					version, err := TestClient.Applications.GetControllerVersion(t.Context())
-					if err != nil {
-						t.Fatalf("failed to get controller version: %v", err)
-						return true, nil
-					}
-					if version.Major > 3 {
+					agentVersion := os.Getenv(TestJujuAgentVersion)
+					if agentVersion == "" {
+						t.Fatal("Juju agent version not set")
+					} else if internaltesting.CompareVersions(agentVersion, "4.0.0") >= 0 {
 						return true, nil
 					}
 					return false, nil


### PR DESCRIPTION
## Description

Adjust the check for Juju 4 in the controller bootstrap test to use the `JUJU_AGENT_VERSION` env var rather than using the `TestClient`. 

The `TestClient` is nil when running this test individually since there is no controller to connect to. When running all the tests, the test client is setup but is pointing to the controller under test, not the controller we have just bootstrapped.