### PR TITLE
feat: pass process env vars to juju cmd runner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ GOOS=$(shell go env GOOS)
 GOARCH=$(shell go env GOARCH)
 GOPATH=$(shell go env GOPATH)
 PARALLEL_TEST_COUNT ?= 3
-EDGE_VERSION ?= 1.3.0
+EDGE_VERSION ?= 1.3.1
 REGISTRY_DIR=~/.terraform.d/plugins/registry.terraform.io/juju/juju/${EDGE_VERSION}/${GOOS}_${GOARCH}
 
 .PHONY: install

--- a/internal/juju/controllers.go
+++ b/internal/juju/controllers.go
@@ -126,6 +126,8 @@ func (r *commandRunner) Run(ctx context.Context, args ...string) error {
 	cmd.Stderr = logFile
 
 	// Build environment vars
+	// Set env vars from the current process to ensure things like proxy settings are preserved, then add JUJU_DATA.
+	cmd.Env = os.Environ()
 	cmd.Env = append(cmd.Env, fmt.Sprintf("JUJU_DATA=%s", r.workingDir))
 
 	if err := cmd.Run(); err != nil {


### PR DESCRIPTION
## Description

Pass the current process' environment variables to the Juju command runner. This should resolve scenarios involving proxies, the user must set the appropriate http proxy vars when running `terraform apply` and they will be passed onto the Juju CLI.

~~I am targetting branch v1.3 for a planned patch release.~~

Edit: A workaround is to create a script like the following and point the `juju_binary` field at the script:
```bash
#!/bin/bash
export https_proxy="http://myproxy.com:8080" 
export http_proxy="http://myproxy.com:8080"
exec /snap/juju/current/bin/juju "$@"
```

## Type of change

- Logic changes in resources (the API interaction with Juju has been changed)

## QA steps

Manual QA steps should be done to test this PR.

1. Create a file e.g. `fake-juju.sh` and add the contents,
```bash
#!/bin/bash
printenv
```
2. Use the following Terraform plan,
```tf
terraform {
  required_providers {
    juju = {
      source  = "juju/juju" 
      version = "1.3.2"
    }
  }
}

provider "juju" {
  controller_mode = true
}

resource "juju_controller" "controller" {
  name          = "foo"

  juju_binary   = "<path>/fake-juju.sh"

  cloud = {
    name   = "localhost"
	  auth_types = ["certificate"]
	  type = "lxd"
  }

  cloud_credential = {
    name = "test-credential"
    auth_type = "certificate"
    
    attributes = {
        server-cert = "foo"
      }
  }  
}
```
3. Run `MYVAR=custom-val terraform apply` which will fail with,
```
Unable to bootstrap controller "foo", got error: failed to read controller details from client store: controller foo not found
```
4. Inspect the bootstrap log at `/tmp/juju-bootstrap-log-<random>.txt` which will contain `MYVAR=custom-val`