### PR TITLE
docs(export-model): add documentation to export a model

### DIFF
--- a/docs-rtd/howto/manage-models.md
+++ b/docs-rtd/howto/manage-models.md
@@ -262,11 +262,9 @@ To destroy a model, remove its resource definition from your Terraform plan.
 
 ## Export a model
 
-To export the Terraform configuration from a model, you can leverage `terraform query`.
+To export the Terraform configuration from a model, you can use `terraform query`.
 
 > See also: [terraform query](https://developer.hashicorp.com/terraform/language/v1.14.x/import/bulk?page=import&page=bulk)
-
-To do this:
 
 ### Ensure the provider is connected to the model's host controller
 
@@ -295,7 +293,7 @@ provider "juju" {
 
 ### Define what you want to query for
 
-Then, you define the resources you want to export from a model using the `list` resources in the query file.
+Define the resources you want to export from a model using the `list` resources in the query file.
 
 > The query file must have the `.tfquery.hcl` extension.
 
@@ -417,13 +415,11 @@ list "juju_storage_pool" "all_storage_pools" {
 
 ### Query and generate the configuration file
 
-Run:
+To generate the config with the specified list resources into the `test.tf` file, run:
 
 `TF_VAR_model_uuid="<model-uuid>" terraform query --generate-config-out=test.tf`
 
-This command will generate the Terraform configuration in the `test.tf` file, along with the import blocks.
-
-For example:
+An example of the generated config:
 
 ```terraform
 resource "juju_application" "all_apps_0" {


### PR DESCRIPTION
## Description

Add doc for the export feature.

## QA

Create a model with something to export.

```
#!/bin/bash
set -euo pipefail

MODEL_NAME="${1:-test4}"
SSH_KEY_FILE="/tmp/tf-list-query-test-key"

juju add-model "${MODEL_NAME}"

MODEL_UUID=$(juju show-model "${MODEL_NAME}" --format json | jq -r --arg m "${MODEL_NAME}" '.[$m]["model-uuid"]')
echo "${MODEL_UUID}"

juju deploy juju-qa-dummy-source dummy-source --model "${MODEL_NAME}"
juju deploy juju-qa-dummy-sink dummy-sink --model "${MODEL_NAME}"
juju integrate --model "${MODEL_NAME}" dummy-source dummy-sink
juju offer "${MODEL_NAME}.dummy-source:sink"
juju add-machine --model "${MODEL_NAME}"

if [[ ! -f "${SSH_KEY_FILE}" ]]; then
    ssh-keygen -t rsa -b 2048 -f "${SSH_KEY_FILE}" -N "" -C "test@tf-list-query"
fi
juju add-ssh-key --model "${MODEL_NAME}" "$(cat "${SSH_KEY_FILE}.pub")"
```

Follow the `how-to`, and you should have your generated plan and doing terraform apply.