### PR TITLE
fix: resource application test

### DIFF
--- a/internal/provider/resource_application.go
+++ b/internal/provider/resource_application.go
@@ -1570,13 +1570,13 @@ func assertEqualsMachines(machinesToCompare []string) func(outputFromAPI *juju.R
 	}
 }
 
-func assertEqualsUnitCount(unitsToCompare int) func(outputFromAPI *juju.ReadApplicationResponse) error {
+func assertEqualsUnitCount(desiredUnits int) func(outputFromAPI *juju.ReadApplicationResponse) error {
 	return func(outputFromAPI *juju.ReadApplicationResponse) error {
-		if outputFromAPI.Units != unitsToCompare {
+		if outputFromAPI.Units != desiredUnits {
 			return juju.NewRetryReadError("plan units differ from application units")
 		}
 
-		if unitsToCompare == 0 && len(outputFromAPI.Machines) > 0 {
+		if desiredUnits == 0 && len(outputFromAPI.Machines) > 0 {
 			return juju.NewRetryReadError("expected no machines for zero-unit application")
 		}
 

--- a/internal/provider/resource_application_unit_test.go
+++ b/internal/provider/resource_application_unit_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	jujuerrors "github.com/juju/errors"
+	"github.com/stretchr/testify/require"
 
 	"github.com/juju/terraform-provider-juju/internal/juju"
 )
@@ -58,18 +59,12 @@ func TestAssertEqualsUnitCount(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			err := assertEqualsUnitCount(tc.units)(tc.response)
 			if tc.expectError {
-				if err == nil {
-					t.Fatalf("expected error, got nil")
-				}
-				if !jujuerrors.Is(err, juju.RetryReadError) {
-					t.Fatalf("expected RetryReadError, got %v", err)
-				}
+				require.Error(t, err)
+				require.True(t, jujuerrors.Is(err, juju.RetryReadError), "expected RetryReadError, got %v", err)
 				return
 			}
 
-			if err != nil {
-				t.Fatalf("expected no error, got %v", err)
-			}
+			require.NoError(t, err)
 		})
 	}
 }


### PR DESCRIPTION
## Description

This PR fixes a flaky `juju_application` import verification failure seen in the scale-to-zero/subordinate flow.

The application resource could fail on import with missing machine attributes.  

The provider could persist stale machine state during update, then import/read would return empty machines, causing pre/post import state mismatch. I investigated this between Juju 3 and 4 using the 4.0 branch, and was surprised when Juju wasn't the issue here per se, in that it did eventually converge to 0 machines. 

Which to my surprise it appeared Juju 4 was running a little slower (this may be wrong, but it appears this way). Ultimately, the issue was indeed that the convergence of units and machines wasn't waited for (and explicitly in the case of 0 units).

The fix was to add an assert to the units for the expected amount, as well as ensuring that if there are no units, then there should be no machines (which is inline with our subordinates as we set it to units = 1).

I've added a little unit test for the assert just to give me greater confidence. 
I did originally also add an explicit scale to 0 acc test, but felt it was a bit redundant. Happy to readd it though.

There is a little bit of a negative to this in that  application updates may wait slightly longer for convergence, but state should now be consistent and import less flaky.

## Additional notes
Funny thing I found, @alesstimec left a TODO on this for @SimoneDutto 🤣 

In the little unit test, I just used default go - we use testify elsewhere, am I ok to switch this to testify?