### PR TITLE
ci(release): pins the goreleaser version to 2.14.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7.0.0
         with:
+          version: 'v2.14.3'
           args: release --clean
         env:
           # GitHub sets the GITHUB_TOKEN secret automatically.


### PR DESCRIPTION

## Description

Pins the Goreleaser version to v2.14.3 see [notice](https://github.com/opentofu/registry/issues/3974).

## Type of change

- Maintenance work (repository related, like Github actions, or revving the Go version, etc.)
