### PR TITLE
feat: fix defaults being sent down from juju when nothing is specifie…

### DIFF
--- a/internal/provider/custom_type_constraints.go
+++ b/internal/provider/custom_type_constraints.go
@@ -81,11 +81,27 @@ func (t CustomConstraintsType) ValueType(ctx context.Context) attr.Value {
 
 var _ basetypes.StringValuable = CustomConstraintsValue{}
 
+// NewNullCustomConstraintsValue creates a null CustomConstraintsValue.
+func NewNullCustomConstraintsValue() CustomConstraintsValue {
+	return CustomConstraintsValue{
+		StringValue: basetypes.NewStringNull(),
+	}
+}
+
 // NewCustomConstraintsValue creates a new CustomConstraintsValue from a string.
 func NewCustomConstraintsValue(in string) CustomConstraintsValue {
 	return CustomConstraintsValue{
 		StringValue: basetypes.StringValue(types.StringValue(in)),
 	}
+}
+
+// NewNormalizedCustomConstraintsValue creates a CustomConstraintsValue and
+// normalizes an empty string to null.
+func NewNormalizedCustomConstraintsValue(in string) CustomConstraintsValue {
+	if in == "" {
+		return NewNullCustomConstraintsValue()
+	}
+	return NewCustomConstraintsValue(in)
 }
 
 // CustomConstraintsValue is a custom value type that represents a string

--- a/internal/provider/custom_type_constraints_test.go
+++ b/internal/provider/custom_type_constraints_test.go
@@ -10,6 +10,19 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestNewNormalizedCustomConstraintsValue(t *testing.T) {
+	t.Run("empty string becomes null", func(t *testing.T) {
+		value := NewNormalizedCustomConstraintsValue("")
+		assert.True(t, value.IsNull())
+	})
+
+	t.Run("non-empty string stays non-null", func(t *testing.T) {
+		value := NewNormalizedCustomConstraintsValue("mem=512M")
+		assert.False(t, value.IsNull())
+		assert.Equal(t, "mem=512M", value.ValueString())
+	})
+}
+
 func TestCustomConstraintsValue_StringSemanticEquals(t *testing.T) {
 	ctx := t.Context()
 

--- a/internal/provider/resource_machine.go
+++ b/internal/provider/resource_machine.go
@@ -172,6 +172,7 @@ func (r *machineResource) Schema(ctx context.Context, req resource.SchemaRequest
 					"and provider's defaults. Changing this value will cause the application to be destroyed and" +
 					" recreated by terraform.",
 				Optional: true,
+				Computed: true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplaceIf(constraintsRequiresReplacefunc, "", ""),
 				},
@@ -388,6 +389,9 @@ func (r *machineResource) Create(ctx context.Context, req resource.CreateRequest
 
 	plan.Base = types.StringValue(readResponse.Base)
 	plan.Hostname = types.StringValue(readResponse.Hostname)
+	if plan.Constraints.IsUnknown() {
+		plan.Constraints = NewCustomConstraintsValue(readResponse.Constraints)
+	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 

--- a/internal/provider/resource_machine.go
+++ b/internal/provider/resource_machine.go
@@ -390,7 +390,7 @@ func (r *machineResource) Create(ctx context.Context, req resource.CreateRequest
 	plan.Base = types.StringValue(readResponse.Base)
 	plan.Hostname = types.StringValue(readResponse.Hostname)
 	if plan.Constraints.IsUnknown() {
-		plan.Constraints = NewCustomConstraintsValue(readResponse.Constraints)
+		plan.Constraints = NewNormalizedCustomConstraintsValue(readResponse.Constraints)
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
@@ -459,7 +459,7 @@ func readMachine(ctx context.Context, client *juju.Client, modelUUID, machineID 
 		machineResourceModel: machineResourceModel{
 			Annotations: annotationsValue,
 			Base:        types.StringValue(response.Base),
-			Constraints: NewCustomConstraintsValue(response.Constraints),
+			Constraints: NewNormalizedCustomConstraintsValue(response.Constraints),
 			Hostname:    types.StringValue(response.Hostname),
 			MachineID:   types.StringValue(response.ID),
 		},
@@ -518,9 +518,7 @@ func (r *machineResource) Read(ctx context.Context, req resource.ReadRequest, re
 	//    It could happen that the hostname is set to an empty string during import, but unlikely because
 	//    that means you've created a machine and then imported it immediately afterwards.
 	data.Hostname = machine.Hostname
-	if machine.Constraints.ValueString() != "" {
-		data.Constraints = machine.Constraints
-	}
+	data.Constraints = machine.Constraints
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 
 	id := newMachineID(modelUUID, machineID, machineName)

--- a/internal/provider/resource_machine.go
+++ b/internal/provider/resource_machine.go
@@ -389,9 +389,7 @@ func (r *machineResource) Create(ctx context.Context, req resource.CreateRequest
 
 	plan.Base = types.StringValue(readResponse.Base)
 	plan.Hostname = types.StringValue(readResponse.Hostname)
-	if plan.Constraints.IsUnknown() {
-		plan.Constraints = NewNormalizedCustomConstraintsValue(readResponse.Constraints)
-	}
+	plan.Constraints = NewNormalizedCustomConstraintsValue(readResponse.Constraints)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 

--- a/internal/provider/resource_machine_test.go
+++ b/internal/provider/resource_machine_test.go
@@ -378,6 +378,8 @@ func TestAcc_ResourceMachine_InheritsModelConstraintsWithoutDrift(t *testing.T) 
 					resource.TestCheckResourceAttrSet(resourceName, "constraints"),
 				),
 			},
+			// We plan again to ensure that upon planning with the constraint being user set,
+			// we see no drift and that the value is compared to exactly what the user set previously.
 			{
 				Config:   testAccResourceMachineWithModelConstraints(modelName, "mem=512M"),
 				PlanOnly: true,

--- a/internal/provider/resource_machine_test.go
+++ b/internal/provider/resource_machine_test.go
@@ -360,6 +360,32 @@ func TestAcc_ResourceMachine_ConstraintsNormalization(t *testing.T) {
 	})
 }
 
+func TestAcc_ResourceMachine_InheritsModelConstraintsWithoutDrift(t *testing.T) {
+	if testingCloud != LXDCloudTesting {
+		t.Skip(t.Name() + " only runs with LXD")
+	}
+	modelName := acctest.RandomWithPrefix("tf-test-machine-model-constraints")
+	resourceName := "juju_machine.this"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: frameworkProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceMachineWithModelConstraints(modelName, "mem=512M"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair("juju_model.this", "uuid", resourceName, "model_uuid"),
+					resource.TestCheckResourceAttr(resourceName, "name", "this_machine"),
+					resource.TestCheckResourceAttrSet(resourceName, "constraints"),
+				),
+			},
+			{
+				Config:   testAccResourceMachineWithModelConstraints(modelName, "mem=512M"),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 func testAccResourceMachineAddMachine(modelName string, IP string, pubKeyPath string, privKeyPath string) string {
 	return fmt.Sprintf(`
 resource "juju_model" "this_model" {
@@ -375,6 +401,21 @@ resource "juju_machine" "this_machine" {
     private_key_file = %q
 }
 `, modelName, IP, pubKeyPath, privKeyPath)
+}
+
+func testAccResourceMachineWithModelConstraints(modelName, constraints string) string {
+	return fmt.Sprintf(`
+resource "juju_model" "this" {
+	name = %q
+	constraints = %q
+}
+
+resource "juju_machine" "this" {
+	name = "this_machine"
+	model_uuid = juju_model.this.uuid
+	base = "ubuntu@22.04"
+}
+`, modelName, constraints)
 }
 
 func testAccResourceMachineWithPlacement(modelName string) string {

--- a/internal/provider/resource_machine_test.go
+++ b/internal/provider/resource_machine_test.go
@@ -360,7 +360,10 @@ func TestAcc_ResourceMachine_ConstraintsNormalization(t *testing.T) {
 	})
 }
 
-func TestAcc_ResourceMachine_InheritsModelConstraintsWithoutDrift(t *testing.T) {
+// TestAcc_ResourceMachine_InheritsModelConstraints proves that now constraints are computed,
+// we don't see "produced an unexpected new value: .constraints: was null," error when inheriting
+// the cosntraints for the machine from the model.
+func TestAcc_ResourceMachine_InheritsModelConstraints(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}
@@ -377,12 +380,6 @@ func TestAcc_ResourceMachine_InheritsModelConstraintsWithoutDrift(t *testing.T) 
 					resource.TestCheckResourceAttr(resourceName, "name", "this_machine"),
 					resource.TestCheckResourceAttrSet(resourceName, "constraints"),
 				),
-			},
-			// We plan again to ensure that upon planning with the constraint being user set,
-			// we see no drift and that the value is compared to exactly what the user set previously.
-			{
-				Config:   testAccResourceMachineWithModelConstraints(modelName, "mem=512M"),
-				PlanOnly: true,
 			},
 		},
 	})


### PR DESCRIPTION
…d for constraints

## Description

Fixes juju_machine.constraints state inconsistency when constraints come from model defaults rather than being set directly on the machine.

Opened a new PR and closed #1124 

After discussions, we're just simply making it computed and using Juju for the unknown now. If agreed, this will become our usual approach to handling defaults.

There is a bit of discomfort with this approach though, when creating the model with a constraint of "1G" for memory, and then subsequently reading the machine to see what its memory constraint is set to, Juju normalises it into "1024M". As such TF is signalling an update like so:

```tf
Terraform will perform the following actions:

  # juju_model.test will be updated in-place
  ~ resource "juju_model" "test" {
      ~ constraints = "arch=arm64 mem=1024M" -> "arch=arm64 mem=1G"
        id          = "bdee015e-e082-4ff5-8af5-cb05a50282eb"
        name        = "test"
        # (3 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

There's another little nuance, if you change the models constraints, and apply the plan again, you will see:
```tf
Terraform will perform the following actions:

  # juju_model.test will be updated in-place
  ~ resource "juju_model" "test" {
      ~ constraints = "arch=arm64 mem=1024M" -> "arch=arm64 mem=512M"
        id          = "bdee015e-e082-4ff5-8af5-cb05a50282eb"
        name        = "test"
        # (3 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```
Which it obviously isn't changing the memory on the machine - so perhaps this is misleading.

It is functionally harmless and merely noise, my question is, is it worth adding noise reduction logic for scenarios like this? 

Lastly, we normalise empty machine constraint values to null in state, instead of storing them as an empty string, and applies that consistently across create, read, and import. This avoids mismatches where the same unset value could appear differently between lifecycle paths, which in turn removes false drift/import verification noise.

Fixes: #1119 

## Type of change

- Change existing resource

## Environment

- Juju controller version: 3.6.X

- Terraform version: 1.14

## QA steps

Run this plan twice.
```tf
terraform {
  required_providers {
    juju = {
      source  = "juju/juju"
      version = "1.3.0"
    }
  }
}

resource "juju_model" "test" {
  name = "test"
  constraints = "arch=arm64 mem=1G"
}

resource "juju_machine" "landscape_server" {
  model_uuid  = juju_model.test.uuid
  name        = "landscape-server-0"
  base        = "ubuntu@24.04"
}
```
