### PR TITLE
docs: update landing pages

### DIFF
--- a/docs-rtd/AGENTS.documentation-landing-pages.md
+++ b/docs-rtd/AGENTS.documentation-landing-pages.md
@@ -1,0 +1,178 @@
+---
+customInstructions:
+  role: >-
+    Documentation standards for Terraform Provider for Juju homepage and landing pages. When asked to
+    update landing pages, FIRST assess the current state against these standards, identify gaps, and
+    create a todo list grouped by format and content issues. ALWAYS present assessment to user before
+    making changes.
+applyTo:
+  - pattern: "**/index.md"
+    reason: Homepage and landing pages follow specific structure and content patterns
+  - pattern: "**/tutorial/index.md"
+    reason: Tutorial landing page should group and explain content flow
+  - pattern: "**/howto/index.md"
+    reason: How-to landing page should organize by lifecycle/workflow
+  - pattern: "**/reference/index.md"
+    reason: Reference landing page should organize by dependency flow and provider patterns
+  - pattern: "**/explanation/index.md"
+    reason: Explanation landing page should group related conceptual topics
+---
+
+# Landing Pages Documentation Standards for Terraform Provider for Juju
+
+## Homepage Intro Paragraphs
+
+**Standard structure**: Four brief paragraphs covering:
+
+1. **What the product is** - Succinct, memorable definition
+2. **What the product does** - Core capabilities in plain language  
+3. **What problem the product solves** - The need it meets
+4. **Who the product is for** - Target audience
+
+**Template example**:
+```markdown
+Something that says what the product is, succinctly and memorably consectetur adipiscing elit, sed do eiusmod tempor.
+
+A description of what the product does. Urna cursus eget nunc scelerisque viverra mauris in. Nibh mauris cursus mattis molestie a iaculis at vestibulum rhoncus est pellentesque elit.
+
+An account of what need the product meets. Dui ut ornare lectus sit amet lam.
+
+Something that describes whom the product is useful for. Nunc non blandit massa enim nec dui nunc mattis enim.
+```
+
+**Key principles**:
+- Keep each paragraph brief (1-2 sentences maximum)
+- Avoid technical jargon in favor of clear benefits
+- Make the first sentence memorable and quotable
+- End with a clear call to value for the target audience
+
+## Organizing Principle: Provider Workflow and Resource Categories
+
+**Core principle**: Organize content following the Terraform provider workflow and the logical grouping of Juju resources being managed through Terraform.
+
+### Terraform Provider Dependency Flow
+
+The Terraform Provider for Juju lets you manage Juju resources using Terraform. The dependency flow is:
+
+**Provider Configuration** → **Authentication** → **Juju Resources via Terraform**
+
+1. **Provider Configuration** (setup layer)
+   - Installing the provider
+   - Configuring provider connection to Juju controller
+   - Provider versioning and compatibility
+
+2. **Authentication** (access layer)
+   - Static credentials
+   - Client credentials (JAAS)
+   - Environment variables
+   - CLI-based authentication
+
+3. **Juju Resources** (resource layer)
+   - Terraform resources (create/manage Juju entities)
+   - Terraform data sources (read Juju entities)
+   - Organized by Juju resource type (controllers, models, applications, etc.)
+
+### Applying This to Landing Pages
+
+**Reference landing page** (`docs-rtd/reference/index.md`):
+Organize sections to reflect Terraform provider patterns:
+
+```markdown
+## Provider Configuration
+(How to set up and authenticate the provider)
+- Provider setup, authentication methods, version compatibility
+
+## Terraform Resources
+(Juju entities you can create and manage via Terraform)
+- Grouped by entity type: Controllers, Credentials, Models, Applications, etc.
+- Each resource links to full reference documentation
+
+## Terraform Data Sources
+(Juju entities you can read/reference via Terraform)
+- Grouped by entity type
+- Explains relationship to corresponding resources
+
+## Provider Actions
+(Special operations beyond standard CRUD)
+- Enable HA, custom operations
+```
+
+**Explanation landing page** (`docs-rtd/explanation/index.md`):
+Organize by conceptual foundation:
+
+```markdown
+## Provider fundamentals
+(How the provider works)
+- Provider architecture, authentication flow, state management
+
+## Resource lifecycle
+(Understanding how Terraform manages Juju resources)
+- Import patterns, update behavior, deletion handling
+
+## Integration patterns
+(Best practices for using the provider)
+- Multi-controller setups, JAAS integration, version management
+```
+
+**How-to landing page** (`docs-rtd/howto/index.md`):
+Organize by operational tasks:
+
+```markdown
+## Set up the provider
+(Initial configuration)
+- Install provider, configure authentication, verify connectivity
+
+## Manage controllers and clouds
+(Control plane operations)
+- Bootstrap controllers, add clouds, manage credentials
+
+## Deploy and manage applications
+(Application lifecycle)
+- Deploy applications, configure, relate, scale
+
+## Advanced operations
+(Complex workflows)
+- Import existing infrastructure, migrate between controllers, upgrade patterns
+```
+
+**Tutorial** (`docs-rtd/tutorial.md`):
+Single comprehensive tutorial following workflow:
+- Set up provider → Deploy first application → Scale → Clean up
+
+### Why This Organization Works for Terraform Provider
+
+- **Matches Terraform users' mental model**: "Configure provider → Authenticate → Manage resources"
+- **Reflects Terraform patterns**: Resources, data sources, and provider configuration are familiar Terraform concepts
+- **Shows Juju through Terraform lens**: Resources organized by Juju entity type, but accessed via Terraform workflow
+- **Scales with provider growth**: New resources fit into existing resource categories
+
+## Quality Checklist for Terraform Provider Landing Pages
+
+**Homepage format**:
+- [ ] "In this documentation" section with bullet points organized by workflow
+- [ ] "How this documentation is organised" section with Diátaxis explanation (text format only - no quadrant grid)
+- [ ] "Project and community" section with subsections (Get involved, Releases, Governance)
+- [ ] NO horizontal lines (`---`) used for section separators
+
+**Reference**:
+- [ ] Provider configuration section covers all authentication methods
+- [ ] Resources and data sources clearly distinguished
+- [ ] Resources grouped by logical Juju entity categories
+- [ ] Links to auto-generated Terraform registry documentation where appropriate
+
+**Explanation**:
+- [ ] Provider architecture explained for Terraform users
+- [ ] Import/lifecycle patterns documented
+- [ ] Differences from Juju CLI usage clarified
+
+**How-to**:
+- [ ] Setup guides assume Terraform knowledge, explain Juju specifics
+- [ ] Entity-focused organization (manage-controllers, manage-models, etc.)
+- [ ] Examples show Terraform HCL, not CLI commands
+- [ ] Bridge sections link between related entity types
+
+**Tutorial**:
+- [ ] Assumes Terraform familiarity, teaches Juju concepts
+- [ ] Uses realistic example application deployment
+- [ ] Shows complete workflow from setup to cleanup
+- [ ] Points to how-to guides for deeper coverage of each step

--- a/docs-rtd/AGENTS.documentation-landing-pages.md
+++ b/docs-rtd/AGENTS.documentation-landing-pages.md
@@ -25,11 +25,12 @@ applyTo:
 **Standard structure**: Four brief paragraphs covering:
 
 1. **What the product is** - Succinct, memorable definition
-2. **What the product does** - Core capabilities in plain language  
+2. **What the product does** - Core capabilities in plain language
 3. **What problem the product solves** - The need it meets
 4. **Who the product is for** - Target audience
 
 **Template example**:
+
 ```markdown
 Something that says what the product is, succinctly and memorably consectetur adipiscing elit, sed do eiusmod tempor.
 

--- a/docs-rtd/explanation/index.md
+++ b/docs-rtd/explanation/index.md
@@ -1,12 +1,13 @@
 ---
 myst:
   html_meta:
-    description: "Understand the Juju Terraform concepts."
+    description: "Understand the Terraform Provider for Juju: provider fundamentals, resource lifecycle patterns, and integration strategies."
 ---
 
 (explanation)=
 # Explanation
 
+Discussion and clarification of key topics, providing background information and context.
 
 ```{toctree}
 :titlesonly:
@@ -16,7 +17,9 @@ myst:
 *
 ```
 
-## Juju Terraform at a glance
+## Provider fundamentals
+
+How the Terraform Provider for Juju works and integrates with Juju controllers.
 
 - {ref}`Security <tf-security-overview>`
 

--- a/docs-rtd/howto/index.md
+++ b/docs-rtd/howto/index.md
@@ -13,17 +13,19 @@ myst:
 :maxdepth: 2
 :hidden:
 
-create-deployment-dependencies
 manage-the-terraform-provider-for-juju
 manage-controllers
 manage-clouds
 manage-credentials
-manage-models
+use-a-bootstrapped-controller
+use-the-juju-cli
 manage-ssh-keys
 manage-users
 manage-service-accounts
 manage-roles
 manage-groups
+create-deployment-dependencies
+manage-models
 manage-charms
 manage-charm-resources
 manage-applications
@@ -32,19 +34,18 @@ manage-offers
 manage-units
 manage-secrets
 manage-machines
-use-a-bootstrapped-controller
-use-the-juju-cli
 ```
 
 ## Set up the Terraform Provider for Juju
 
-Install the client, connect a Juju controller, connect clouds, add models.
+Install the client, connect a Juju controller, connect clouds.
 
 - {ref}`manage-the-terraform-provider-for-juju`
 - {ref}`manage-controllers`
 - {ref}`manage-clouds`
 - {ref}`manage-credentials`
-- {ref}`manage-models`
+- {ref}`use-a-bootstrapped-controller`
+- {ref}`use-the-juju-cli-in-terraform`
 
 ## Handle authentication and authorization
 
@@ -61,6 +62,7 @@ Set up SSH keys. Add users, service accounts, roles, and groups and control thei
 Deploy, configure, integrate, scale, etc., charmed applications. This will automatically provision infrastructure, but you can customise it before, during, or after deploy too.
 
 - {ref}`create-deployment-dependencies`
+- {ref}`manage-models`
 - {ref}`manage-charms`
 - {ref}`manage-charm-resources`
 - {ref}`manage-applications`
@@ -69,5 +71,3 @@ Deploy, configure, integrate, scale, etc., charmed applications. This will autom
 - {ref}`manage-units`
 - {ref}`manage-secrets`
 - {ref}`manage-machines`
-- {ref}`use-the-juju-cli-in-terraform`
-- {ref}`use-a-bootstrapped-controller`

--- a/docs-rtd/howto/manage-users.md
+++ b/docs-rtd/howto/manage-users.md
@@ -24,7 +24,8 @@ resource "juju_user" "alex" {
 > See more: [`juju_user` (resource)](../reference/terraform-provider/resources/user)
 
 
-## Manage a user's access to a controller, cloud, model, offer, role, or group
+(manage-user-access)=
+## Manage user access
 
 > See more: {ref}`manage-access-to-a-controller`, {ref}`manage-access-to-a-cloud`, {ref}`manage-access-to-a-model`, {ref}`manage-access-to-an-offer`, {ref}`manage-access-to-a-role`, {ref}`manage-access-to-a-group`
 

--- a/docs-rtd/index.md
+++ b/docs-rtd/index.md
@@ -26,66 +26,37 @@ The Terraform Provider for Juju combines the power of Terraform -- comprehensive
 
 Like all of Juju, the Terraform Provider for Juju is for SREs, or anyone looking to take control of cloud.
 
----------
-
 ## In this documentation
 
-- **Set up the Terraform Provider for Juju:** {ref}`Install <install-the-terraform-provider-for-juju>`, {ref}`Connect a controller <manage-controllers>`, {ref}`Connect a cloud <manage-clouds>`, {ref}`Add a model <manage-models>`
-- **Handle authentication and authorization:** {ref}`SSH keys <manage-ssh-keys>`, {ref}`Users <manage-users>`, {ref}`Service accounts <manage-service-accounts>`, {ref}`Roles <manage-roles>`, {ref}`Groups <manage-groups>`
-- **Deploy infrastructure and applications:** {ref}`Deploy <deploy-an-application>`, {ref}`Configure <configure-an-application>`, {ref}`Integrate <integrate-an-application-with-another-application>`, {ref}`Scale <scale-an-application>`, {ref}`Upgrade <upgrade-an-application>`, etc.
+- **Set up the Terraform Provider for Juju:** {ref}`Install <install-the-terraform-provider-for-juju>` • {ref}`Connect a controller <manage-controllers>` • {ref}`Connect a cloud <manage-clouds>`
+- **Handle authentication and authorization:** {ref}`Manage users <manage-users>` • {ref}`Manage service accounts <manage-service-accounts>`
+- **Deploy infrastructure and applications:** {ref}`Deploy <deploy-an-application>` • {ref}`Configure <configure-an-application>` • {ref}`Integrate <integrate-an-application-with-another-application>` • {ref}`Scale <scale-an-application>` • {ref}`Upgrade <upgrade-an-application>`
 
-````{grid} 1 1 2 2
+## How this documentation is organised
 
-```{grid-item-card} [Tutorial](tutorial)
-:link: tutorial
-:link-type: doc
-
-**Start here**: a hands-on introduction to the Terraform Provider for Juju for new users <br>
-```
-
-```{grid-item-card} [How-to guides](/index)
-:link: howto/index
-:link-type: doc
-
-**Step-by-step guides** covering key operations and common tasks
-```
-
-```{grid-item-card} [Reference](/index)
-:link: reference/index
-:link-type: doc
-
-**Technical information** - specifications, APIs, architecture
-```
-
-```{grid-item-card} [Explanation](/index)
-:link: explanation/index
-:link-type: doc
-
-**Discussion and clarification** of key topics
-```
-````
-
----------
-
-<!-- {ref}`tutorial-plan` | {ref}`tutorial-deploy-configure-integrate` | {ref}`tutorial-scale` -->
-
+This documentation uses the [Diátaxis documentation structure](https://diataxis.fr/).
+The {ref}`Tutorial <tutorial>` takes you step-by-step through using the provider to deploy an application. {ref}`How-to guides <howtos>` assume you have basic familiarity with Terraform and Juju. {ref}`Reference <reference>` provides technical specifications for provider resources and data sources. {ref}`Explanation <explanation>` includes security models and integration patterns.
 
 ## Project and community
 
-The Terraform Provider for Juju is a member of the Ubuntu family. It’s an open source project that warmly welcomes community projects, contributions, suggestions, fixes and constructive feedback.
+The Terraform Provider for Juju is a member of the Ubuntu family. It's an open source project that warmly welcomes community contributions, suggestions, fixes and constructive feedback.
 
-* [Release notes](https://github.com/juju/terraform-provider-juju/releases )
+### Get involved
+
+* [Join our chat](https://matrix.to/#/#terraform-provider-juju:ubuntu.com)
+* [Join our forum](https://discourse.charmhub.io/)
+* [Report a bug](https://github.com/juju/terraform-provider-juju/issues/new?title=doc%3A+ADD+A+TITLE&body=DESCRIBE+THE+ISSUE%0A%0A---%0ADocument:%20index.md)
+* [Contribute](https://github.com/juju/terraform-provider-juju/blob/main/CONTRIBUTING.md)
+* [Visit our careers page](https://canonical.com/careers/engineering)
+
+### Releases
+
+* [Release notes](https://github.com/juju/terraform-provider-juju/releases)
+
+### Governance and policies
 
 * [Code of conduct](https://ubuntu.com/community/ethos/code-of-conduct)
 
-* [Join our chat](https://matrix.to/#/#terraform-provider-juju:ubuntu.com)
+### Commercial support
 
-* [Join our forum](https://discourse.charmhub.io/)
-
-* [Report a bug](https://github.com/juju/terraform-provider-juju/issues/new?title=doc%3A+ADD+A+TITLE&body=DESCRIBE+THE+ISSUE%0A%0A---%0ADocument:%20index.md)
-
-* [Contribute](https://github.com/juju/terraform-provider-juju/blob/main/CONTRIBUTING.md)
-
-* [Visit our careers page](https://canonical.com/careers)
-
-Thinking about using Juju for your next project? [Get in touch!](https://canonical.com/contact-us)
+Thinking about using the Terraform Provider for Juju for your next project? [Get in touch!](https://canonical.com/contact-us)


### PR DESCRIPTION
## Description

This PR replicates https://github.com/juju/juju/pull/22173 in JujuTF docs to meet our landing pages objectives for JujuTF.
## Test instructions

In `terraform-provider-juju/docs-rtd` run `make clean && make run` and inspect the preview for the homepage and the how-to, reference, and explanation landing pages.