### PR TITLE
ci(e2e): miscellanea fix

### DIFF
--- a/.github/workflows/test_integration_cross_controller.yml
+++ b/.github/workflows/test_integration_cross_controller.yml
@@ -31,6 +31,7 @@ jobs:
         terraform: ["1.14.*"]
         action-operator:
           - { lxd-channel: "5.21/stable", cloud: "lxd", cloud-channel: "6", juju: "3" }
+          - { lxd-channel: "5.21/stable", cloud: "lxd", cloud-channel: "6", juju: "4.0/edge" }
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4

--- a/internal/provider/data_source_storage_pool_test.go
+++ b/internal/provider/data_source_storage_pool_test.go
@@ -14,6 +14,8 @@ import (
 )
 
 func TestAcc_DataSourceStoragePool(t *testing.T) {
+	// Storage is not supported in Juju 4.
+	SkipAgainstJuju4(t)
 	// Rootfs, tmpfs and loop are currently not "listable" on k8s (3.6.9) when listing them.
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")

--- a/internal/provider/list_storage_pool_test.go
+++ b/internal/provider/list_storage_pool_test.go
@@ -17,6 +17,8 @@ import (
 )
 
 func TestAccListStoragePools_query(t *testing.T) {
+	// Storage is not supported in Juju 4.
+	SkipAgainstJuju4(t)
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}

--- a/internal/provider/resource_application_test.go
+++ b/internal/provider/resource_application_test.go
@@ -1519,6 +1519,9 @@ func TestAcc_ResourceApplication_UpdateEndpointBindings(t *testing.T) {
 }
 
 func TestAcc_ResourceApplication_StorageLXD(t *testing.T) {
+	// Storage is not supported in Juju 4.
+	SkipAgainstJuju4(t)
+
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}

--- a/internal/provider/resource_storage_pool_test.go
+++ b/internal/provider/resource_storage_pool_test.go
@@ -16,6 +16,8 @@ import (
 )
 
 func TestAcc_ResourceStoragePool(t *testing.T) {
+	// Storage is not supported in Juju 4.
+	SkipAgainstJuju4(t)
 	modelName := acctest.RandomWithPrefix("test-model")
 
 	poolName := "test-pool"
@@ -133,6 +135,8 @@ func TestAcc_ResourceStoragePool(t *testing.T) {
 
 // Tests that creating a pool with no attributes (nulled in state) works as expected when updated to a value.
 func TestAcc_ResourceStoragePool_ImportState(t *testing.T) {
+	// Storage is not supported in Juju 4.
+	SkipAgainstJuju4(t)
 	modelName := acctest.RandomWithPrefix("test-model")
 	poolName := "test-pool"
 	storageProviderName := "tmpfs"


### PR DESCRIPTION
## Description

- Add 4.0/edge to cross controller integration test
- skip storage test for juju 4
- See what's left failing, so we can fix it separately.