### PR TITLE
test: disable OS updates in tests

### DIFF
--- a/.github/workflows/test_integration.yml
+++ b/.github/workflows/test_integration.yml
@@ -229,6 +229,9 @@ jobs:
           export TEST_SSH_PRIV_KEY_PATH=$(pwd)/test-add-machine
           echo "Testing with machine at $TEST_ADD_MACHINE_IP with keys $TEST_SSH_PUB_KEY_PATH and $TEST_SSH_PRIV_KEY_PATH"
 
+          echo "Running apt update"
+          /snap/bin/lxc exec mtest -- sudo apt update
+
           echo "Pushing the ssh public key at $TEST_SSH_PUB_KEY_PATH into the container"
           /snap/bin/lxc file push $TEST_SSH_PUB_KEY_PATH mtest/home/ubuntu/.ssh/authorized_keys
 

--- a/internal/juju/clouds.go
+++ b/internal/juju/clouds.go
@@ -478,6 +478,29 @@ func (c *cloudsClient) ReadCloud(input ReadCloudInput) (*ReadCloudOutput, error)
 	}, nil
 }
 
+// ListClouds returns the names of all clouds available on the controller.
+func (c *cloudsClient) ListClouds() ([]string, error) {
+	conn, err := c.GetConnection(nil)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = conn.Close() }()
+
+	cloudClient := c.getCloudAPIClient(conn)
+
+	jjClouds, err := cloudClient.Clouds()
+	if err != nil {
+		return nil, errors.Annotate(err, "getting clouds")
+	}
+
+	clouds := make([]string, 0, len(jjClouds))
+	for cloudTag := range jjClouds {
+		clouds = append(clouds, cloudTag.Id())
+	}
+
+	return clouds, nil
+}
+
 // createKubernetesConfig creates a Kubernetes configuration from the provided config data.
 // If createServiceAccount is true, it will create or get the Juju admin service account credentials.
 // If createServiceAccount is false, it will use the credentials already present in the config data.

--- a/internal/juju/interfaces.go
+++ b/internal/juju/interfaces.go
@@ -125,6 +125,7 @@ type JaasAPIClient interface {
 type CloudAPIClient interface {
 	AddCloud(cloud jujucloud.Cloud, force bool) error
 	Cloud(tag names.CloudTag) (jujucloud.Cloud, error)
+	Clouds() (map[names.CloudTag]jujucloud.Cloud, error)
 	UpdateCloud(cloud jujucloud.Cloud) error
 	RemoveCloud(cloud string) error
 	AddCredential(cloud string, credential jujucloud.Credential) error

--- a/internal/juju/mock_test.go
+++ b/internal/juju/mock_test.go
@@ -2701,6 +2701,45 @@ func (c *MockCloudAPIClientCloudCall) DoAndReturn(f func(names.CloudTag) (cloud.
 	return c
 }
 
+// Clouds mocks base method.
+func (m *MockCloudAPIClient) Clouds() (map[names.CloudTag]cloud.Cloud, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Clouds")
+	ret0, _ := ret[0].(map[names.CloudTag]cloud.Cloud)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Clouds indicates an expected call of Clouds.
+func (mr *MockCloudAPIClientMockRecorder) Clouds() *MockCloudAPIClientCloudsCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Clouds", reflect.TypeOf((*MockCloudAPIClient)(nil).Clouds))
+	return &MockCloudAPIClientCloudsCall{Call: call}
+}
+
+// MockCloudAPIClientCloudsCall wrap *gomock.Call
+type MockCloudAPIClientCloudsCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockCloudAPIClientCloudsCall) Return(arg0 map[names.CloudTag]cloud.Cloud, arg1 error) *MockCloudAPIClientCloudsCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockCloudAPIClientCloudsCall) Do(f func() (map[names.CloudTag]cloud.Cloud, error)) *MockCloudAPIClientCloudsCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockCloudAPIClientCloudsCall) DoAndReturn(f func() (map[names.CloudTag]cloud.Cloud, error)) *MockCloudAPIClientCloudsCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // RemoveCloud mocks base method.
 func (m *MockCloudAPIClient) RemoveCloud(cloud string) error {
 	m.ctrl.T.Helper()

--- a/internal/juju/models.go
+++ b/internal/juju/models.go
@@ -583,3 +583,21 @@ func (c *modelsClient) DestroyAccessModel(input DestroyAccessModelInput) error {
 
 	return nil
 }
+
+// SetModelDefaults sets the default model configuration for a cloud and region.
+func (c *modelsClient) SetModelDefaults(cloud string, region string, config map[string]interface{}) error {
+	conn, err := c.GetConnection(nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = conn.Close() }()
+
+	client := modelmanager.NewClient(conn)
+
+	err = client.SetModelDefaults(cloud, region, config)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -286,6 +286,22 @@ func setupAcceptanceTests(t *testing.T) {
 	providerData, ok := confResp.ResourceData.(juju.ProviderData)
 	require.Truef(t, ok, "ResourceData, not of type ProviderData")
 	TestClient = providerData.Client
+
+	// Disable OS updates to speed up tests.
+	clouds, err := TestClient.Clouds.ListClouds()
+	if err != nil {
+		t.Fatalf("failed to list clouds: %v", err)
+	}
+	for _, cloud := range clouds {
+		err := TestClient.Models.SetModelDefaults(cloud, "", map[string]any{
+			"enable-os-upgrade":        false,
+			"enable-os-refresh-update": false,
+		})
+		if err != nil {
+			t.Fatalf("failed to set model defaults: %v", err)
+		}
+	}
+
 	createCloudCredential(t)
 }
 


### PR DESCRIPTION
## Description

During debugging of some TF->Juju 4 issues, I've spent a lot of time waiting for machines to be provisioned. While waiting, one can `lxc shell` into the machine and observe the cloud-init logs at `tail -f /var/log/cloud-init-output.log` and often I've seen we're busy running apt update logic. This PR adds a default model config to disable these updates on machine provisioning.

This should speed up any test that creates a machine.

Update: Comparing the Juju 3 + LXD test in this PR against a recent PR into `main` in https://github.com/juju/terraform-provider-juju/actions/runs/24239664379/job/70770857208 the speedup is significant.

The run with OS updates enabled took 2003s (about 33m 24s), while the run with them disabled took 1539s (about 25m 39s). Roughly ~464s saved, or a 23.2% reduction in runtime.

The biggest wins are in machine-heavy tests. Examples:

`TestAcc_ResourceApplication_SwitchMachinestoUnits`: 333.17s to 60.27s
`TestAcc_ResourceApplication_MachinesWithSubordinates`: 557.25s to 364.80s
`TestAcc_ResourceMachine_ConstraintsNormalization`: 156.94s to 83.26s
`TestAccListMachines_Query`: 106.96s to 41.85s
`TestAcc_ResourceMachineWaitForHostname`: 83.57s to 43.70s