### PR TITLE
fix: remove unneeded destroy flag in ResourceOffer test

### DIFF
--- a/internal/juju/offers.go
+++ b/internal/juju/offers.go
@@ -297,6 +297,8 @@ func (c *offersClient) DestroyOffer(ctx context.Context, input *DestroyOfferInpu
 				return err
 			}
 		}
+	} else {
+		c.Tracef(fmt.Sprintf("offer %q has no connections, destroying", offer.OfferURL))
 	}
 
 	err = client.DestroyOffers(ctx, forceDestroy, input.OfferURL)

--- a/internal/provider/resource_offer_test.go
+++ b/internal/provider/resource_offer_test.go
@@ -45,7 +45,6 @@ func TestAcc_ResourceOffer(t *testing.T) {
 				),
 			},
 			{
-				Destroy:           true,
 				ImportStateVerify: true,
 				ImportState:       true,
 				ResourceName:      "juju_offer.offerone",


### PR DESCRIPTION
## Description

Attempt to fix the test `TestAcc_ResourceOffer`. The `Destroy` flag is set to `true` in the final step, this flag's docstring says,
> // Destroy will create a destroy plan if set to true.

The flag is unnecessary since TF destroys the resources after the test and removing seemed to have fixed the test failure locally. I'm unsure why this would change anything because if I understand it correctly, it would just generate a destroy plan, not actually execute it. To add to the confusion, this step has no `Config` field set, so the destroy should be a no-op anyway.
