### PR TITLE
fix: allow last key to be deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ ENHANCEMENTS
 BUG FIXES
 
 * Fix `juju_machine` constraints state inconsistency when constraints are inherited from model defaults rather than being set directly on the machine by @ale8k in [#1157](https://github.com/juju/terraform-provider-juju/pull/1157).
+* Fix `juju_ssh_key` to allow deletion of the final key within a model by @ale8k in [#1188](https://github.com/juju/terraform-provider-juju/pull/1188).
 
 DOCUMENTATION
 

--- a/internal/juju/sshKeys.go
+++ b/internal/juju/sshKeys.go
@@ -146,30 +146,8 @@ func (c *sshKeysClient) DeleteSSHKey(input *DeleteSSHKeyInput) error {
 
 	client := keymanager.NewClient(conn)
 
-	// NOTE: Unfortunately Juju will return an error if we try to
-	// remove the last ssh key from the controller. This is something
-	// that impacts the current Juju logic. As a temporal workaround
-	// we will check if this is the latest SSH key of this model and
-	// skip the delete.
-	returnedKeys, err := client.ListKeys(ssh.FullKeys, input.Username)
-	if err != nil {
-		return err
-	}
-	// only check if there is one key
-	if len(returnedKeys) == 1 {
-		fingerprint, comment, err := ssh.KeyFingerprint(returnedKeys[0].Result[0])
-		if err != nil {
-			return fmt.Errorf("error getting fingerprint for ssh key: %w", err)
-		}
-		if input.KeyIdentifier == fingerprint || input.KeyIdentifier == comment {
-			// This is the latest key, do not remove it
-			c.Warnf(fmt.Sprintf("ssh key from user %s is the last one and will not be removed", input.KeyIdentifier))
-			return nil
-		}
-	}
-
 	// NOTE: In Juju 3.6 ssh keys are not associated with user - they are global per model. We pass in
-	// the logged-in user for completeness. In Juju 4 ssh keys will be associated with users.<
+	// the logged-in user for completeness. In Juju 4 ssh keys will be associated with users.
 	params, err := client.DeleteKeys(input.Username, input.KeyIdentifier)
 	if len(params) != 0 {
 		messages := make([]string, 0)

--- a/internal/provider/resource_ssh_key_test.go
+++ b/internal/provider/resource_ssh_key_test.go
@@ -10,6 +10,9 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+
+	"github.com/juju/terraform-provider-juju/internal/juju"
 )
 
 func TestAcc_ResourceSSHKey(t *testing.T) {
@@ -37,6 +40,11 @@ func TestAcc_ResourceSSHKey(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair("juju_model.this", "uuid", "juju_ssh_key.this", "model_uuid"),
 					resource.TestCheckResourceAttr("juju_ssh_key.this", "payload", sshKey2)),
+			},
+			// remove the ssh key resource but keep the model, then verify the key is gone in Juju
+			{
+				Config: testAccResourceSSHKeyModelOnly(modelName),
+				Check:  testAccCheckSSHKeyAbsent(modelName, sshKey2),
 			},
 		},
 	})
@@ -195,6 +203,49 @@ func TestAcc_ResourceSSHKey_UpgradeV0ToV1(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testAccCheckSSHKeyAbsent(modelName string, payload string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if TestClient == nil {
+			return fmt.Errorf("TestClient is not configured")
+		}
+
+		// Retrieve the model UUID from state so we can query the key manager.
+		var modelUUID string
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type == "juju_model" && rs.Primary != nil {
+				modelUUID = rs.Primary.Attributes["uuid"]
+				break
+			}
+		}
+		if modelUUID == "" {
+			return fmt.Errorf("could not find model UUID in state")
+		}
+
+		keys, err := TestClient.SSHKeys.ListKeys(juju.ListSSHKeysInput{
+			Username:  TestClient.Username(),
+			ModelUUID: modelUUID,
+		})
+		if err != nil {
+			return fmt.Errorf("error listing ssh keys in model %q: %w", modelName, err)
+		}
+
+		for _, k := range keys {
+			if k == payload {
+				return fmt.Errorf("ssh key still exists in model %q", modelName)
+			}
+		}
+		return nil
+	}
+}
+
+func testAccResourceSSHKeyModelOnly(modelName string) string {
+	return fmt.Sprintf(`
+resource "juju_model" "this" {
+	name = %q
+}
+`, modelName)
 }
 
 func testAccResourceSSHKeyV0(modelName string, sshKey string) string {


### PR DESCRIPTION
## Description
We were preventing the last key to be deleted, but as far as I can tell, in both 2.9 and 3.6, it is now possible to delete the last key as the system key is always present within the model, but not visible.

After a short discussion with Joe, he believes:
```
I don't know that it's possible to hit this bug. On both 2.9 and 3.6 I can add and delete the (reportedly last) key, and still ssh to a machine.

The semantic guard dates from very early days, ~2013.
```

I believe I've hit in 3.6 before, but after testing I cannot reproduce it. So I **think** we are safe to remove it. 

Fixes: #1163 

## Type of change

- Logic changes in resources (the API interaction with Juju has been changed)


## Environment

- Juju controller version: 3.6.14

- Terraform version: 1.14.9

## QA steps

Run:
`make install`

On a 3.6 controller run:
`jj add-model issue1163`

Then:
`jj show-model issue1163` 
And extract the model uuid.

Run:
`jj ssh-keys`
And verify there are no keys.

Apply this plan (update datasource model uuid), and then destroy it.
```tf
terraform {
  required_providers {
    juju = {
      source  = "juju/juju"
      version = "1.3.1"
    }
  }
}


data "juju_model" "this" {
  uuid = "cc7f0959-155c-468c-8628-7971ef328761"
}
resource "juju_ssh_key" "key_set" {
  model_uuid = data.juju_model.this.uuid
  payload    = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPSihXipogdMY70BaZX+owOOi1nBnIYDpDr6iQHIZtE4 blah@blah"
}
```

Run:
`jj ssh-keys`
You should see your blah blah key.

Run:
`tf destroy`

Run:
`jj ssh-keys`
And verify the key is gone.


