### PR TITLE
fix(remove-machine): when a machine is removed we should remove units

### DIFF
--- a/internal/juju/applications.go
+++ b/internal/juju/applications.go
@@ -1539,7 +1539,9 @@ func (c applicationsClient) removeUnits(input *UpdateApplicationInput, client Ap
 		for _, machine := range input.RemoveMachines {
 			unitName, ok := machineUnits[machine]
 			if !ok {
-				return fmt.Errorf("no machines deployed on machine: %v", machine)
+				// When a machine is removed, all the units running on it are removed as well.
+				// So if we don't find any unit for a machine, we can safely continue.
+				continue
 			}
 			unitsToDestroy = append(unitsToDestroy, unitName)
 		}
@@ -1552,6 +1554,49 @@ func (c applicationsClient) removeUnits(input *UpdateApplicationInput, client Ap
 		}
 	}
 	return nil
+}
+
+// RemoveUnitsFromMachineInput contains the parameters for removing units from a machine.
+type RemoveUnitsFromMachineInput struct {
+	ModelUUID string
+	MachineID string
+}
+
+// RemoveUnitsFromMachine destroys all units running on the given machine.
+// This should be called before destroying a machine to ensure Juju can
+// cleanly remove it (Juju rejects machine destruction while units remain).
+func (c applicationsClient) RemoveUnitsFromMachine(ctx context.Context, input *RemoveUnitsFromMachineInput) error {
+	conn, err := c.GetConnection(&input.ModelUUID)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = conn.Close() }()
+
+	clientAPIClient := c.getClientAPIClient(conn)
+	status, err := clientAPIClient.Status(nil)
+	if err != nil {
+		return err
+	}
+
+	var unitsToDestroy []string
+	for _, appStatus := range status.Applications {
+		for unitName, unitStatus := range appStatus.Units {
+			if unitStatus.Machine == input.MachineID {
+				unitsToDestroy = append(unitsToDestroy, unitName)
+			}
+		}
+	}
+
+	if len(unitsToDestroy) == 0 {
+		return nil
+	}
+
+	applicationAPIClient := c.getApplicationAPIClient(conn)
+	_, err = applicationAPIClient.DestroyUnits(apiapplication.DestroyUnitsParams{
+		Units:          unitsToDestroy,
+		DestroyStorage: true,
+	})
+	return err
 }
 
 // UpdateCharmAndResources is a helper function to update the charm and resources

--- a/internal/provider/resource_application_test.go
+++ b/internal/provider/resource_application_test.go
@@ -1322,21 +1322,32 @@ func TestAcc_ResourceApplication_Machines(t *testing.T) {
 	charmName := "juju-qa-test"
 
 	resourceName := "juju_application.testapp"
-	checkResourceAttrMachines := []resource.TestCheckFunc{
-		resource.TestCheckResourceAttr(resourceName, "name", charmName),
-		resource.TestCheckResourceAttr(resourceName, "charm.#", "1"),
-		resource.TestCheckResourceAttr(resourceName, "charm.0.name", charmName),
-		resource.TestCheckResourceAttr(resourceName, "units", "1"),
-		resource.TestCheckResourceAttr(resourceName, "machines.0", "0"),
-	}
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{
+			// Start with 2 machines
 			{
-				Config: testAccResourceApplicationBasic_Machines(modelName, charmName),
+				Config: testAccResourceApplicationBasic_Machines(modelName, charmName, 2),
 				Check: resource.ComposeTestCheckFunc(
-					checkResourceAttrMachines...),
+					resource.TestCheckResourceAttr(resourceName, "name", charmName),
+					resource.TestCheckResourceAttr(resourceName, "charm.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "charm.0.name", charmName),
+					resource.TestCheckResourceAttr(resourceName, "units", "2"),
+					resource.TestCheckResourceAttr(resourceName, "machines.0", "0"),
+					resource.TestCheckResourceAttr(resourceName, "machines.1", "1"),
+				),
+			},
+			// Scale down to 1 machine — exercises RemoveUnitsFromMachine before machine destroy
+			{
+				Config: testAccResourceApplicationBasic_Machines(modelName, charmName, 1),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", charmName),
+					resource.TestCheckResourceAttr(resourceName, "charm.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "charm.0.name", charmName),
+					resource.TestCheckResourceAttr(resourceName, "units", "1"),
+					resource.TestCheckResourceAttr(resourceName, "machines.0", "0"),
+				),
 			},
 			{
 				ImportStateVerify: true,
@@ -1347,29 +1358,29 @@ func TestAcc_ResourceApplication_Machines(t *testing.T) {
 	})
 }
 
-func testAccResourceApplicationBasic_Machines(modelName, charmName string) string {
+func testAccResourceApplicationBasic_Machines(modelName, charmName string, machineCount int) string {
 	return fmt.Sprintf(`
 		resource "juju_model" "model" {
 		  name = %q
 		}
 
 		resource "juju_machine" "machine" {
-		  name = "test machine"
+		  count      = %d
 		  model_uuid = juju_model.model.uuid
-		  base = "ubuntu@22.04"
+		  base       = "ubuntu@22.04"
 		}
 
 		resource "juju_application" "testapp" {
 		  model_uuid = juju_model.model.uuid
 
-		  machines = [juju_machine.machine.machine_id]
+		  machines = [for m in juju_machine.machine : m.machine_id]
 
 		  charm {
 			name = %q
 			base = "ubuntu@22.04"
 		  }
 		}
-		`, modelName, charmName)
+		`, modelName, machineCount, charmName)
 }
 
 func TestAcc_ResourceApplication_UpgradeProvider(t *testing.T) {

--- a/internal/provider/resource_application_test.go
+++ b/internal/provider/resource_application_test.go
@@ -1346,7 +1346,6 @@ func TestAcc_ResourceApplication_Machines(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "charm.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "charm.0.name", charmName),
 					resource.TestCheckResourceAttr(resourceName, "units", "1"),
-					resource.TestCheckResourceAttr(resourceName, "machines.0", "0"),
 				),
 			},
 			{

--- a/internal/provider/resource_machine.go
+++ b/internal/provider/resource_machine.go
@@ -598,6 +598,14 @@ func (r *machineResource) Delete(ctx context.Context, req resource.DeleteRequest
 		r.trace(fmt.Sprintf("delete machine resource %q", machineID))
 	}()
 
+	if err := r.client.Applications.RemoveUnitsFromMachine(ctx, &juju.RemoveUnitsFromMachineInput{
+		ModelUUID: modelUUID,
+		MachineID: machineID,
+	}); err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to remove units from machine %q before deletion, got error: %s", machineID, err))
+		return
+	}
+
 	if err := r.client.Machines.DestroyMachine(&juju.DestroyMachineInput{
 		ModelUUID: modelUUID,
 		ID:        machineID,


### PR DESCRIPTION
## Description

a machine cannot be removed without --force if it has units assigned to it. So before removing a machine we have to remove the associated units to it.

Read here for more details: https://github.com/juju/terraform-provider-juju/issues/1189#issuecomment-4313569212

Fix: #1189 
