### PR TITLE
docs: update tutorial to better reflect TF nature

### DIFF
--- a/docs-rtd/howto/manage-controllers.md
+++ b/docs-rtd/howto/manage-controllers.md
@@ -37,15 +37,56 @@ This enables bootstrapping and restricts resource creation to controllers only.
 
 > See more: {ref}`Set up the provider in controller mode (bootstrapping) <set-up-the-terraform-provider-for-juju>`
 
-2. Gather the necessary cloud credentials for your target cloud (e.g., LXD, AWS, Kubernetes).
+2. Gather the necessary cloud credentials for your target cloud. The required credentials depend on the cloud type and authentication method:
+
+For **oauth2** authentication (common with Kubernetes clouds like MicroK8s):
 
 ```bash
-juju show-credentials --client localhost localhost --show-secrets
+juju credentials <cloud-name> --show-secrets --format yaml
 ```
 
-From the output, you will need the values `client-cert`, `client-key`, and `server-cert`. Keep them out of version control (for example, pass them via `TF_VAR_...` environment variables, a secrets manager, or a `.tfvars` file you do not commit).
+From the output, copy the `Token` value. You'll also need the Kubernetes endpoint and CA certificate from the kubeconfig (e.g., `microk8s config`).
 
-3. Create a `juju_controller` resource with your controller name, cloud configuration, and credentials. You can also include `controller_config` and `controller_model_config` to configure the controller during bootstrap. For example, for a LXD cloud:
+For **certificate** authentication (common with LXD):
+
+```bash
+juju show-credentials --client <cloud-name> <credential-name> --show-secrets
+```
+
+From the output, you'll need the `client-cert`, `client-key`, and `server-cert` values.
+
+Keep these credentials out of version control (for example, pass them via `TF_VAR_...` environment variables, a secrets manager, or a `.tfvars` file you do not commit).
+
+3. Create a `juju_controller` resource with your controller name, cloud configuration, and credentials. You can also include `controller_config` and `controller_model_config` to configure the controller during bootstrap.
+
+**Example for Kubernetes with oauth2:**
+
+```{code-block} terraform
+:caption: `main.tf`
+
+resource "juju_controller" "microk8s" {
+  name = "my-k8s-controller"
+  juju_binary = "/snap/juju/current/bin/juju"
+
+  cloud = {
+    name       = "microk8s"
+    type       = "kubernetes"
+    auth_types = ["oauth2"]
+    endpoint   = var.k8s_endpoint
+    ca_certificates = [var.k8s_ca_cert]
+  }
+
+  cloud_credential = {
+    name      = "microk8s-cred"
+    auth_type = "oauth2"
+    attributes = {
+      "Token" = var.k8s_token
+    }
+  }
+}
+```
+
+**Example for LXD with certificate auth:**
 
 ```{code-block} terraform
 :caption: `main.tf`
@@ -71,13 +112,20 @@ resource "juju_controller" "this" {
       "server-cert" = var.lxd_server_cert
     }
   }
+}
+```
 
-  # Bootstrap is a good time to set configurations, constraints, etc.
+You can also configure the controller and controller model during bootstrap:
 
-  # Settings here map to flags/config used by `juju controller-config`.
+```{code-block} terraform
+:caption: `main.tf`
+
+resource "juju_controller" "this" {
+  # ... cloud and credential configuration ...
+
   controller_config = {
-    "audit-log-max-backups"     = "10"
-    "query-tracing-enabled"     = "true"
+    "audit-log-max-backups"  = "10"
+    "query-tracing-enabled"  = "true"
   }
 
   # Settings here map to flags/config used by `juju model-config`.
@@ -86,6 +134,8 @@ resource "juju_controller" "this" {
   }
 }
 ```
+
+The cloud type, auth method, and required attributes will vary based on your cloud provider. See {external+juju:doc}`Juju | Clouds <clouds>` for cloud-specific requirements.
 
 After `terraform apply`, the resource will expose useful read-only attributes such as the controller `api_addresses`, `ca_cert`, `username`, and `password`.
 

--- a/docs-rtd/howto/manage-controllers.md
+++ b/docs-rtd/howto/manage-controllers.md
@@ -45,7 +45,9 @@ For **oauth2** authentication (common with Kubernetes clouds like MicroK8s):
 juju credentials <cloud-name> --show-secrets --format yaml
 ```
 
-From the output, copy the `Token` value. You'll also need the Kubernetes endpoint and CA certificate from the kubeconfig (e.g., `microk8s config`).
+From this output, copy the `Token` value.
+
+You'll also need the Kubernetes endpoint and CA certificate. Get these from the kubeconfig (e.g., run `microk8s config`).
 
 For **certificate** authentication (common with LXD):
 
@@ -53,7 +55,7 @@ For **certificate** authentication (common with LXD):
 juju show-credentials --client <cloud-name> <credential-name> --show-secrets
 ```
 
-From the output, you'll need the `client-cert`, `client-key`, and `server-cert` values.
+From this output, copy the `client-cert`, `client-key`, and `server-cert` values.
 
 Keep these credentials out of version control (for example, pass them via `TF_VAR_...` environment variables, a secrets manager, or a `.tfvars` file you do not commit).
 

--- a/docs-rtd/index.md
+++ b/docs-rtd/index.md
@@ -12,8 +12,8 @@ relatedlinks: "[Charmcraft](https://documentation.ubuntu.com/charmcraft/), [Char
 :maxdepth: 2
 :hidden: true
 
-tutorial
-howto/index
+Tutorial <tutorial>
+How-to guides <howto/index>
 Reference <reference/index>
 Explanation <explanation/index>
 ```

--- a/docs-rtd/tutorial.md
+++ b/docs-rtd/tutorial.md
@@ -22,7 +22,7 @@ In this tutorial you will define and deploy a chat service (Mattermost backed by
 - Set things up: launch a Juju-ready VM using Multipass, install Terraform, and bootstrap a Juju controller.
 - See how to manage users and access control as code.
 - Deploy infrastructure and applications with Terraform configuration files.
-- Scale your deployment and clean up resources.
+- Clean up resources.
 
 ## Set things up
 
@@ -236,7 +236,7 @@ This design requires separating controller bootstrap from application deployment
 
 Now bootstrap a Juju controller. A Juju controller is your Juju control plane -- the entity that holds the Juju API server and Juju's database. With the Terraform Provider, you can bootstrap a controller by defining it in your Terraform configuration.
 
-View the MicroK8s credentials that you'll need for your Terraform configuration:
+On your VM, view the MicroK8s credentials that you'll need for your Terraform configuration:
 
 ```{terminal}
 :copy:
@@ -357,19 +357,25 @@ k8s_endpoint = "https://10.x.x.x:16443"
 The values shown above are examples only. Use your actual values from the previous commands -- the token and certificate will be much longer than shown here.
 ```
 
-Before continuing, keep credentials, connection info, and Terraform state safe and out of version control:
+Before continuing, keep credentials, connection info, and Terraform state safe and out of version control.
+
+Create `1-bootstrap/.gitignore`:
 
 ```{terminal}
 :copy:
 :user:
 :host:
 :dir: ~/terraform-juju
-cat > 1-bootstrap/.gitignore << 'EOF'
+touch 1-bootstrap/.gitignore
+```
+
+```{code-block} text
+:caption: `1-bootstrap/.gitignore`
+
 terraform.tfvars
 conn_info.json
 .terraform*
 terraform.tfstate*
-EOF
 ```
 
 Now create `1-bootstrap/main.tf` to define your controller:
@@ -459,8 +465,7 @@ Initialize the bootstrap directory:
 :copy:
 :user: ubuntu
 :host: my-juju-vm
-:dir: ~/terraform-juju
-terraform -chdir=1-bootstrap init
+terraform -chdir=terraform-juju/1-bootstrap init
 ```
 
 This downloads the Juju provider plugin and prepares your workspace.
@@ -471,8 +476,7 @@ Preview what Terraform will create:
 :copy:
 :user: ubuntu
 :host: my-juju-vm
-:dir: ~/terraform-juju
-terraform -chdir=1-bootstrap plan
+terraform -chdir=terraform-juju/1-bootstrap plan
 ```
 
 This shows what Terraform will create without actually creating anything. Review the output carefully -- you'll see the controller resource that will be created.
@@ -487,8 +491,7 @@ Apply your infrastructure definition:
 :copy:
 :user: ubuntu
 :host: my-juju-vm
-:dir: ~/terraform-juju
-terraform -chdir=1-bootstrap apply
+terraform -chdir=terraform-juju/1-bootstrap apply
 ```
 
 Terraform will show you the plan again and ask for confirmation. Type `yes` to proceed.
@@ -497,7 +500,7 @@ Terraform will show you the plan again and ask for confirmation. Type `yes` to p
 The bootstrap process typically takes 1-2 minutes, but may vary depending on your system and network speed. Terraform will show progress as it creates the controller.
 ```
 
-Once complete, your Juju controller is running on MicroK8s, and Terraform has recorded its state.
+Once complete, your Juju controller is running on MicroK8s, and Terraform has recorded its state. Terraform has also created `1-bootstrap/conn_info.json` with the controller's connection details (minified JSON on one line; to view formatted, run `cat terraform-juju/1-bootstrap/conn_info.json | jq .`).
 
 ## Handle authentication and authorization
 
@@ -507,7 +510,7 @@ While you could manage users via the `juju` CLI, the Terraform Provider lets you
 
 > See more: {ref}`Manage users <manage-users>`, {ref}`Manage access to a controller <manage-access-to-a-controller>`, {ref}`Manage access to a model <manage-access-to-a-model>`
 
-For this tutorial, we'll continue using the admin credentials created during bootstrap.
+For this tutorial, you'll use the admin user that was automatically created during bootstrap. The deployment configuration will read this user's controller login credentials from the `conn_info.json` file.
 
 ## Deploy infrastructure and applications
 
@@ -565,10 +568,14 @@ Create `2-deploy/.gitignore` to keep Terraform state out of version control:
 :user:
 :host:
 :dir: ~/terraform-juju
-cat > 2-deploy/.gitignore << 'EOF'
+touch 2-deploy/.gitignore
+```
+
+```{code-block} text
+:caption: `2-deploy/.gitignore`
+
 .terraform*
 terraform.tfstate*
-EOF
 ```
 
 Now create `2-deploy/main.tf` to define your application resources:
@@ -706,16 +713,14 @@ Now deploy your infrastructure. In your VM, initialize and preview the deploymen
 :copy:
 :user: ubuntu
 :host: my-juju-vm
-:dir: ~/terraform-juju
-terraform -chdir=2-deploy init
+terraform -chdir=terraform-juju/2-deploy init
 ```
 
 ```{terminal}
 :copy:
 :user: ubuntu
 :host: my-juju-vm
-:dir: ~/terraform-juju
-terraform -chdir=2-deploy plan
+terraform -chdir=terraform-juju/2-deploy plan
 ```
 
 This shows what Terraform will create without actually creating anything. Review the output carefully -- you'll see the model, applications, and integrations that will be created.
@@ -726,24 +731,34 @@ Apply your infrastructure definition:
 :copy:
 :user: ubuntu
 :host: my-juju-vm
-:dir: ~/terraform-juju
-terraform -chdir=2-deploy apply
+terraform -chdir=terraform-juju/2-deploy apply
 ```
 
 Terraform will show you the plan again and ask for confirmation. Type `yes` to proceed.
 
 The deployment will take a few minutes. Terraform will show you the progress as it creates each resource.
 
-Once complete, verify your applications are running:
+Once complete, verify your applications are running. Wait for all pods to be ready:
 
 ```{terminal}
 :copy:
 :user: ubuntu
 :host: my-juju-vm
-microk8s kubectl get pods -n chat
+microk8s kubectl wait --for=condition=ready pod -l operator.juju.is/name -n chat --timeout=300s
 ```
 
-Wait until all pods show `Running` status. Then test your chat service:
+The Mattermost charm needs time to complete database setup before creating its workload pod. Monitor the pods until the `mattermost-k8s-0` pod appears and shows `Running` status:
+
+```{terminal}
+:copy:
+:user: ubuntu
+:host: my-juju-vm
+watch microk8s kubectl get pods -n chat
+```
+
+Press {kbd}`Ctrl` + {kbd}`C` to exit once all pods show `Running`. This may take several minutes.
+
+Once all pods are running, get the service address:
 
 ```{terminal}
 :copy:
@@ -752,7 +767,7 @@ Wait until all pods show `Running` status. Then test your chat service:
 microk8s kubectl get svc -n chat mattermost-k8s -o jsonpath='{.spec.clusterIP}:{.spec.ports[0].port}'
 ```
 
-This displays the service address. Use it to test the service (replace `<address>` with the output from above):
+Test your chat service (replace `<address>` with the output from above):
 
 ```{terminal}
 :copy:
@@ -773,77 +788,7 @@ Congratulations! Your chat service is up and running, and your entire infrastruc
 **Infrastructure-as-code benefit**: Terraform's state tracking means you can't accidentally create duplicate resources. It knows what exists and only makes necessary changes.
 ```
 
-Now let's scale your PostgreSQL database to enable high availability. On your local workstation, open `terraform-juju/2-deploy/main.tf` in your IDE and modify the `postgresql-k8s` resource to change `units` from `1` to `3`:
-
-```{code-block} terraform
-:caption: `2-deploy/main.tf` (partial)
-
-resource "juju_application" "postgresql-k8s" {
-  model_uuid = juju_model.chat.uuid
-
-  charm {
-    name    = "postgresql-k8s"
-    channel = "14/stable"
-  }
-
-  trust = true
-  units = 3  # Changed from 1 - enables high availability
-
-  config = {
-    profile = "testing"
-  }
-}
-```
-
-In your VM, preview the change:
-
-```{terminal}
-:copy:
-:user: ubuntu
-:host: my-juju-vm
-:dir: ~/terraform-juju
-terraform -chdir=2-deploy plan
-```
-
-Notice Terraform detected the difference between your desired state (3 units) and actual state (1 unit), and shows it will add two units. This is the power of declarative infrastructure -- you describe what you want, and Terraform figures out how to get there.
-
-```{tip}
-**Infrastructure-as-code benefit**: Terraform's state tracking prevents accidental changes. It knows the current state and only makes necessary modifications to reach your desired state.
-```
-
-Apply the change:
-
-```{terminal}
-:copy:
-:user: ubuntu
-:host: my-juju-vm
-:dir: ~/terraform-juju
-terraform -chdir=2-deploy apply
-```
-
-The scaling operation will complete in a few moments.
-
-Back on your local workstation, commit your change:
-
-```{terminal}
-:copy:
-:user:
-:host:
-:dir: ~/terraform-juju
-git add 2-deploy/main.tf && git commit -m "feat: scale postgresql to 3 units for high availability"
-```
-
-## Next steps
-
-You've experienced the core infrastructure-as-code workflow with the Terraform Provider for Juju. To build on what you've learned:
-
-- **Bootstrap with more control**: Configure controller and model settings during bootstrap. See: {ref}`configure-a-controller`.
-- **Manage controllers post-bootstrap**: Configure controllers, enable high availability, or import existing controllers. See: {ref}`manage-controllers`.
-- **Manage multiple environments**: Use Terraform workspaces or separate configurations to manage development, staging, and production. See: {ref}`manage-models`.
-- **Integrate with other cloud resources**: Combine the Juju provider with AWS, GCP, or Azure providers to manage applications and underlying cloud resources together in a single Terraform plan.
-- **Enable team collaboration**: Set up remote state storage and implement GitOps workflows for infrastructure changes.
-- **Explore all provider features**: The provider supports credentials, users, offers, secrets, and more. See: {ref}`reference`.
-
+To build on what you've learned: configure controller and model settings during bootstrap ({ref}`configure-a-controller`), manage controllers post-bootstrap ({ref}`manage-controllers`), use Terraform workspaces for multiple environments ({ref}`manage-models`), integrate with other cloud providers, set up remote state storage for team collaboration, and explore all provider features ({ref}`reference`).
 
 ## Tear things down
 
@@ -855,8 +800,7 @@ In your VM, destroy the application infrastructure first, then the controller:
 :copy:
 :user: ubuntu
 :host: my-juju-vm
-:dir: ~/terraform-juju
-terraform -chdir=2-deploy destroy
+terraform -chdir=terraform-juju/2-deploy destroy
 ```
 
 Terraform will show you everything it will remove and ask for confirmation. Type `yes` to proceed.
@@ -867,8 +811,7 @@ This removes the applications, integrations, and model. Now destroy the controll
 :copy:
 :user: ubuntu
 :host: my-juju-vm
-:dir: ~/terraform-juju
-terraform -chdir=1-bootstrap destroy
+terraform -chdir=terraform-juju/1-bootstrap destroy
 ```
 
 Type `yes` to confirm. This removes the Juju controller.

--- a/docs-rtd/tutorial.md
+++ b/docs-rtd/tutorial.md
@@ -19,11 +19,11 @@ In this tutorial you will define and deploy a chat service (Mattermost backed by
 
 **What you'll do:**
 
-- Set up your environment: launch a Juju-ready VM using Multipass, install Terraform, and bootstrap a Juju controller.
-- Define and deploy a chat service with Terraform configuration files.
+- Set things up: launch a Juju-ready VM using Multipass, install Terraform, and bootstrap a Juju controller.
+- Deploy infrastructure and applications with Terraform configuration files.
 - Scale your deployment and clean up resources.
 
-## Set up your environment
+## Set things up
 
 To work with the Terraform Provider for Juju, you'll need:
 - A cloud (MicroK8s for this tutorial)
@@ -515,7 +515,7 @@ The bootstrap process typically takes 1-2 minutes, but may vary depending on you
 
 Once complete, your Juju controller is running on MicroK8s, and Terraform has recorded its state. Your environment is ready!
 
-## Provision infrastructure and operate applications
+## Deploy infrastructure and applications
 
 With your controller bootstrapped, you'll now define and deploy the applications that make up your chat service. You'll deploy Mattermost for the chat service, PostgreSQL for its backing database, and self-signed certificates to TLS-encrypt traffic from PostgreSQL.
 
@@ -855,7 +855,7 @@ You've experienced the core infrastructure-as-code workflow with the Terraform P
 - **Explore all provider features**: The provider supports credentials, users, offers, secrets, and more. See: {ref}`reference`.
 
 
-## Tear down your test environment
+## Tear things down
 
 With Terraform, tearing down your infrastructure is as simple as deploying it.
 

--- a/docs-rtd/tutorial.md
+++ b/docs-rtd/tutorial.md
@@ -1,14 +1,14 @@
 ---
 myst:
   html_meta:
-    description: "Learn to manage Juju deployments as code with the Terraform Provider, using declarative configuration files, version control, and infrastructure-as-code workflows."
+    description: "Learn to manage Juju infrastructure as code with the Terraform Provider, using declarative configuration files, version control, and infrastructure-as-code workflows."
 ---
 
 # Get started with the Terraform Provider for Juju
 
-The Terraform Provider for Juju brings infrastructure-as-code capabilities to {external+juju:doc}`Juju <index>`. With it, you can define your cloud infrastructure and applications in version-controlled configuration files, preview changes before applying them, and collaborate with your team using familiar GitOps workflows.
+The Terraform Provider for Juju brings infrastructure-as-code capabilities to {external+juju:doc}`Juju <index>`.
 
-In this tutorial you will define and deploy a chat service (Mattermost backed by PostgreSQL) as code, experiencing the benefits of declarative infrastructure management.
+In this tutorial you will define and deploy a chat service (Mattermost backed by PostgreSQL) using declarative configuration files managed with Terraform.
 
 **What you'll need:**
 
@@ -19,23 +19,11 @@ In this tutorial you will define and deploy a chat service (Mattermost backed by
 
 **What you'll do:**
 
-- Set up your environment: launch a VM with MicroK8s, install Terraform, initialize version control, and bootstrap a Juju controller.
-- Define your application infrastructure as code, preview changes before applying them, and deploy a chat service.
-- Experience infrastructure-as-code workflows: manage your infrastructure, track changes in version control, and tear down resources.
+- Set up your environment: launch a Juju-ready VM using Multipass, install Terraform, and bootstrap a Juju controller.
+- Define and deploy a chat service with Terraform configuration files.
+- Scale your deployment and clean up resources.
 
 ## Set up your environment
-
-```{tip}
-**Recommended workflow setup:**
-
-You'll be working across two contexts: your local workstation and a VM. To work efficiently:
-
-1. **Two terminal windows (or one split terminal):**
-   - One terminal for your local workstation (where you'll run `multipass` commands and `git` commands)
-   - One terminal for the VM shell (where you'll run `terraform` and `juju` commands)
-
-2. **Your favorite text editor** on your local workstation to create and edit `.tf` files. Changes you make locally will be automatically visible in the VM via the mounted directory.
-```
 
 To work with the Terraform Provider for Juju, you'll need:
 - A cloud (MicroK8s for this tutorial)
@@ -116,8 +104,6 @@ Verify this in your VM:
 :user: ubuntu
 :host: my-juju-vm
 microk8s status --wait-ready
-
-microk8s is running
 ```
 
 ```{terminal}
@@ -125,8 +111,6 @@ microk8s is running
 :user: ubuntu
 :host: my-juju-vm
 juju version
-
-3.6.0-ubuntu-amd64
 ```
 
 ```{terminal}
@@ -134,10 +118,6 @@ juju version
 :user: ubuntu
 :host: my-juju-vm
 juju clouds --client
-
-Cloud      Regions  Default    Type
-localhost  1        localhost  lxd
-microk8s   1        localhost  k8s
 ```
 
 Now install Terraform in your VM:
@@ -164,32 +144,68 @@ The Terraform Provider for Juju works by calling the `juju` CLI in the backgroun
 :copy:
 :user: ubuntu
 :host: my-juju-vm
-sudo sh -c "mkdir -p /var/snap/terraform/current/microk8s/credentials" && sudo sh -c "microk8s config | tee /var/snap/terraform/current/microk8s/credentials/client.config" && sudo chown -f -R $USER:$USER /var/snap/terraform/current/microk8s/credentials/client.config
+sudo sh -c "mkdir -p /var/snap/terraform/current/microk8s/credentials"
+```
+
+```{terminal}
+:copy:
+:user: ubuntu
+:host: my-juju-vm
+sudo sh -c "microk8s config > /var/snap/terraform/current/microk8s/credentials/client.config"
+```
+
+```{terminal}
+:copy:
+:user: ubuntu
+:host: my-juju-vm
+sudo chown -f -R $USER:$USER /var/snap/terraform/current/microk8s/credentials/client.config
 ```
 
 ```{dropdown} Why is this necessary?
 
-Both Terraform and Juju are installed as snaps. When snap-installed Terraform calls snap-installed Juju, Juju looks for MicroK8s credentials in Terraform's snap storage directory (`/var/snap/terraform/current/`), not in MicroK8s's own directory.
-
-Since MicroK8s was installed by charm-dev and is not strictly confined, its credentials aren't automatically shared with the Terraform snap. This command copies the credentials to where Terraform's Juju can find them.
-
-This is the same credential-sharing pattern used in Juju's documentation when working with non-strictly-confined MicroK8s.
+When the Terraform Provider bootstraps the controller, it needs access to the MicroK8s credentials. This command copies the credentials to a location where they can be found during the bootstrap process.
 ```
 
-Now, on your local workstation (not the VM), create a directory for your Terraform configuration and mount it to your VM:
+Now, on your local workstation (not the VM), create a directory for your Terraform configuration:
 
 ```{terminal}
 :copy:
 :user:
 :host:
-mkdir ~/terraform-juju && cd ~/terraform-juju && multipass mount ~/terraform-juju my-juju-vm:terraform-juju
+mkdir ~/terraform-juju
 ```
 
-This lets you create and edit Terraform files in your local editor while running them inside the VM.
+```{terminal}
+:copy:
+:user:
+:host:
+cd ~/terraform-juju
+```
 
-Now set up version control. A key benefit of infrastructure-as-code is version control -- your infrastructure definitions become code that can be tracked, reviewed, and collaborated on.
+Mount it to your VM:
 
-On your local workstation, in your `terraform-juju` directory, initialize a git repository:
+```{terminal}
+:copy:
+:user:
+:host:
+multipass mount ~/terraform-juju my-juju-vm:terraform-juju
+```
+
+This lets you create files locally and run Terraform on them inside the VM, while using your IDE to view and edit the files.
+
+```{tip}
+**Recommended workflow setup:**
+
+You'll be working across two contexts: your local workstation and the VM. To work efficiently:
+
+1. **Two terminal windows (or one split terminal):**
+   - One terminal for your local workstation (where you'll create files, run `multipass` commands, and run `git` commands)
+   - One terminal for the VM shell (where you'll run `terraform` and `juju` commands)
+
+2. **Your favorite text editor** on your local workstation to view and edit `.tf` files. Changes you make locally will be automatically visible in the VM via the mounted directory.
+```
+
+Initialize version control. On your local workstation, in your `terraform-juju` directory:
 
 ```{terminal}
 :copy:
@@ -197,8 +213,6 @@ On your local workstation, in your `terraform-juju` directory, initialize a git 
 :host:
 git init
 ```
-
-As you create and modify files in this tutorial, you'll commit them to track your infrastructure's evolution.
 
 Create two subdirectories to organize your infrastructure:
 
@@ -219,27 +233,6 @@ The Terraform Juju provider has a `controller_mode` setting that determines whic
 This design requires separating controller bootstrap from application deployment into two distinct Terraform configurations. This tutorial uses `1-bootstrap/` for the controller and `2-deploy/` for your applications.
 ```
 
-Before bootstrapping a controller, it's helpful to understand how the Terraform Provider for Juju works. The provider is a Juju client -- it talks to a Juju controller just like the `juju` CLI does. You define your desired infrastructure state in `.tf` files, the `terraform` CLI reads those files and uses the Juju provider plugin to communicate with a Juju controller, and the controller provisions resources and deploys applications. Your infrastructure definitions are code that can be version-controlled, reviewed, and shared with your team.
-
-```{figure}
-:align: center
-
-:::{mermaid}
-graph LR
-    A[.tf files<br/>Infrastructure as Code] --> B[terraform CLI]
-    B --> C[Juju Provider<br/>Juju client]
-    C --> D[Juju Controller]
-    D --> E[Cloud<br/>MicroK8s]
-    D --> F[Charmhub]
-
-    style A fill:#e1f5ff
-    style C fill:#fff3e0
-    style D fill:#f3e5f5
-:::
-
-The Terraform Provider acts as a Juju client, translating your infrastructure-as-code definitions into API calls to the Juju controller. The controller then provisions resources on the cloud and deploys charms from Charmhub.
-```
-
 Now bootstrap a Juju controller. A Juju controller is your Juju control plane -- the entity that holds the Juju API server and Juju's database. With the Terraform Provider, you can bootstrap a controller by defining it in your Terraform configuration.
 
 View the MicroK8s credentials that you'll need for your Terraform configuration:
@@ -248,14 +241,11 @@ View the MicroK8s credentials that you'll need for your Terraform configuration:
 :copy:
 :user: ubuntu
 :host: my-juju-vm
-juju credentials microk8s --show-secrets --format yaml
+juju show-credential microk8s microk8s --show-secrets
 
-client-credentials:
-  microk8s:
-    default-credential: microk8s
-    microk8s:
-      auth-type: oauth2
-      Token: eyJhbGciOiJSUzI1NiIsImtpZCI6IldBbERh...
+microk8s:
+  auth-type: oauth2
+  Token: eyJhbGciOiJSUzI1NiIsImtpZCI6IldBbERh...
 ```
 
 From the output, copy the full `Token` value (it will be much longer than shown here). You'll also need the MicroK8s endpoint and CA certificate, which you can get from the kubeconfig:
@@ -279,9 +269,17 @@ From the output, copy the full `certificate-authority-data` value and the `serve
 
 ## Bootstrap a controller
 
-Now, on your local workstation, create your controller bootstrap configuration in the `1-bootstrap/` directory.
+Now, on your local workstation, in your `terraform-juju` directory, create your controller bootstrap configuration.
 
 First, create `1-bootstrap/terraform.tf` to configure Terraform to use the Juju provider in controller mode:
+
+```{terminal}
+:copy:
+:user:
+:host:
+:dir: ~/terraform-juju
+touch 1-bootstrap/terraform.tf
+```
 
 ```{code-block} terraform
 :caption: `1-bootstrap/terraform.tf`
@@ -306,6 +304,14 @@ Notice `controller_mode = true`. This setting restricts the provider to only man
 
 Next, create `1-bootstrap/variables.tf` to define variables for your sensitive credentials:
 
+```{terminal}
+:copy:
+:user:
+:host:
+:dir: ~/terraform-juju
+touch 1-bootstrap/variables.tf
+```
+
 ```{code-block} terraform
 :caption: `1-bootstrap/variables.tf`
 
@@ -329,6 +335,14 @@ variable "k8s_token" {
 
 Create `1-bootstrap/terraform.tfvars` with your actual credential values (from the commands above):
 
+```{terminal}
+:copy:
+:user:
+:host:
+:dir: ~/terraform-juju
+touch 1-bootstrap/terraform.tfvars
+```
+
 ```{code-block} terraform
 :caption: `1-bootstrap/terraform.tfvars`
 
@@ -338,19 +352,32 @@ k8s_endpoint = "https://10.x.x.x:16443"
 ```
 
 ```{note}
-The values shown above are examples only. Use your actual values from the previous commands - the token and certificate will be much longer than shown here.
+The values shown above are examples only. Use your actual values from the previous commands -- the token and certificate will be much longer than shown here.
 ```
 
-Before continuing, keep credentials and Terraform state out of version control. On your local workstation, create a `.gitignore` file in the `1-bootstrap/` directory:
+Before continuing, keep credentials and Terraform state out of version control:
 
 ```{terminal}
 :copy:
 :user:
 :host:
-echo "terraform.tfvars" >> 1-bootstrap/.gitignore && echo ".terraform*" >> 1-bootstrap/.gitignore && echo "terraform.tfstate*" >> 1-bootstrap/.gitignore
+:dir: ~/terraform-juju
+cat > 1-bootstrap/.gitignore << 'EOF'
+terraform.tfvars
+.terraform*
+terraform.tfstate*
+EOF
 ```
 
-Now, create `1-bootstrap/main.tf` to define your controller:
+Now create `1-bootstrap/main.tf` to define your controller:
+
+```{terminal}
+:copy:
+:user:
+:host:
+:dir: ~/terraform-juju
+touch 1-bootstrap/main.tf
+```
 
 ```{code-block} terraform
 :caption: `1-bootstrap/main.tf`
@@ -388,17 +415,51 @@ resource "juju_controller" "microk8s" {
 
 Notice how this declarative definition makes your infrastructure intentions clear: you want a Juju controller named `my-chat-controller` on MicroK8s with specific credentials.
 
-Commit your controller infrastructure definition (excluding sensitive files):
+To allow the deployment configuration to connect to this controller, add outputs that expose the connection details. Create `1-bootstrap/outputs.tf`:
 
 ```{terminal}
 :copy:
 :user:
 :host:
-git add 1-bootstrap && git commit -m "feat: define Juju controller infrastructure"
+:dir: ~/terraform-juju
+touch 1-bootstrap/outputs.tf
 ```
 
-```{tip}
-**Infrastructure-as-code benefit**: Your controller infrastructure is now tracked in version control. You can see the history of changes, revert if needed, and share with your team for review.
+```{code-block} terraform
+:caption: `1-bootstrap/outputs.tf`
+
+output "controller_addresses" {
+  description = "API addresses of the bootstrapped controller"
+  value       = juju_controller.microk8s.api_addresses
+}
+
+output "username" {
+  description = "Admin username for the controller"
+  value       = juju_controller.microk8s.username
+  sensitive   = true
+}
+
+output "password" {
+  description = "Admin password for the controller"
+  value       = juju_controller.microk8s.password
+  sensitive   = true
+}
+
+output "ca_cert" {
+  description = "CA certificate for the controller"
+  value       = juju_controller.microk8s.ca_cert
+  sensitive   = true
+}
+```
+
+On your local workstation, in your `terraform-juju` directory, commit your controller infrastructure definition (excluding sensitive files):
+
+```{terminal}
+:copy:
+:user:
+:host:
+:dir: ~/terraform-juju
+git add 1-bootstrap && git commit -m "feat: define Juju controller infrastructure"
 ```
 
 Now, in your VM, initialize Terraform in the bootstrap directory. If you exited the VM shell, reopen it:
@@ -410,14 +471,14 @@ Now, in your VM, initialize Terraform in the bootstrap directory. If you exited 
 multipass shell my-juju-vm
 ```
 
-Navigate to your bootstrap directory and initialize:
+Initialize the bootstrap directory:
 
 ```{terminal}
 :copy:
 :user: ubuntu
 :host: my-juju-vm
 :dir: ~/terraform-juju
-cd 1-bootstrap && terraform init
+terraform -chdir=1-bootstrap init
 ```
 
 This downloads the Juju provider plugin and prepares your workspace.
@@ -428,8 +489,8 @@ Preview what Terraform will create:
 :copy:
 :user: ubuntu
 :host: my-juju-vm
-:dir: ~/terraform-juju/1-bootstrap
-terraform plan
+:dir: ~/terraform-juju
+terraform -chdir=1-bootstrap plan
 ```
 
 This shows what Terraform will create without actually creating anything. Review the output carefully -- you'll see the controller resource that will be created.
@@ -444,13 +505,17 @@ Apply your infrastructure definition:
 :copy:
 :user: ubuntu
 :host: my-juju-vm
-:dir: ~/terraform-juju/1-bootstrap
-terraform apply
+:dir: ~/terraform-juju
+terraform -chdir=1-bootstrap apply
 ```
 
 Terraform will show you the plan again and ask for confirmation. Type `yes` to proceed.
 
-The bootstrap process will take a few minutes. Once complete, your Juju controller is running on MicroK8s, and Terraform has recorded its state.
+```{note}
+The bootstrap process typically takes 1-2 minutes, but may vary depending on your system and network speed. Terraform will show progress as it creates the controller.
+```
+
+Once complete, your Juju controller is running on MicroK8s, and Terraform has recorded its state.
 
 Your controller is now bootstrapped and ready. Next, you'll define and deploy applications.
 
@@ -458,9 +523,19 @@ Your controller is now bootstrapped and ready. Next, you'll define and deploy ap
 
 With your controller bootstrapped, now define the applications that make up your chat service in a separate configuration. You'll deploy Mattermost for the chat service, PostgreSQL for its backing database, and self-signed certificates to TLS-encrypt traffic from PostgreSQL.
 
-On your local workstation, create your application deployment configuration in the `2-deploy/` directory.
+To connect to your bootstrapped controller, you'll need to extract its connection details from the bootstrap state. The bootstrap created a controller with specific API addresses, credentials, and a CA certificate -- you'll use these to configure the provider for application deployment.
 
-First, create `2-deploy/terraform.tf` to configure the provider without `controller_mode`:
+On your local workstation, in your `terraform-juju` directory, create your application deployment configuration.
+
+First, create `2-deploy/terraform.tf` to configure the provider to connect to your controller:
+
+```{terminal}
+:copy:
+:user:
+:host:
+:dir: ~/terraform-juju
+touch 2-deploy/terraform.tf
+```
 
 ```{code-block} terraform
 :caption: `2-deploy/terraform.tf`
@@ -474,26 +549,51 @@ terraform {
   }
 }
 
+# Read connection details from the bootstrap state
+data "terraform_remote_state" "bootstrap" {
+  backend = "local"
+
+  config = {
+    path = "${path.module}/../1-bootstrap/terraform.tfstate"
+  }
+}
+
 provider "juju" {
-  # Connect to the bootstrapped controller
-  # The provider will discover the controller automatically
+  controller_addresses = join(",", data.terraform_remote_state.bootstrap.outputs.controller_addresses)
+  username             = data.terraform_remote_state.bootstrap.outputs.username
+  password             = data.terraform_remote_state.bootstrap.outputs.password
+  ca_certificate       = data.terraform_remote_state.bootstrap.outputs.ca_cert
 }
 ```
 
 ```{important}
 Notice there's no `controller_mode` setting (it defaults to `false`). This configuration can manage models, applications, and integrations, but cannot manage `juju_controller` resources.
+
+The provider connects to the bootstrapped controller by reading its connection details from the bootstrap state via `terraform_remote_state`. This is necessary because Terraform cannot configure a provider from resource outputs in the same plan.
 ```
 
-Create a `.gitignore` file for this directory:
+Create `2-deploy/.gitignore` to keep Terraform state out of version control:
 
 ```{terminal}
 :copy:
 :user:
 :host:
-echo ".terraform*" >> 2-deploy/.gitignore && echo "terraform.tfstate*" >> 2-deploy/.gitignore
+:dir: ~/terraform-juju
+cat > 2-deploy/.gitignore << 'EOF'
+.terraform*
+terraform.tfstate*
+EOF
 ```
 
-Now, create `2-deploy/main.tf` to define your application resources:
+Now create `2-deploy/main.tf` to define your application resources:
+
+```{terminal}
+:copy:
+:user:
+:host:
+:dir: ~/terraform-juju
+touch 2-deploy/main.tf
+```
 
 ```{code-block} terraform
 :caption: `2-deploy/main.tf`
@@ -512,7 +612,7 @@ resource "juju_application" "mattermost-k8s" {
   }
 }
 
-# Define the database with high availability
+# Define the database
 resource "juju_application" "postgresql-k8s" {
   model_uuid = juju_model.chat.uuid
 
@@ -522,7 +622,7 @@ resource "juju_application" "postgresql-k8s" {
   }
 
   trust = true
-  units = 2  # High availability configuration
+  units = 1
 
   config = {
     profile = "testing"
@@ -598,75 +698,43 @@ resource "juju_integration" "postgresql-tls" {
 }
 ```
 
-Notice how this declarative definition makes your infrastructure intentions clear: you want a chat model with Mattermost, PostgreSQL (with 2 units for high availability), TLS certificates, and specific integrations between them.
+Notice how this declarative definition makes your infrastructure intentions clear: you want a chat model with Mattermost, PostgreSQL, TLS certificates, and specific integrations between them.
 
 ```{note}
-Notice the use of `model_uuid` instead of `model` for applications. This ensures Terraform uses the UUID reference, which is more reliable than name-based references.
-
-Also notice the explicit `endpoint` values in the TLS integration -- this ensures the correct relation endpoints are used.
+Notice the explicit `endpoint` values in the TLS integration -- this ensures the correct relation endpoints are used.
 ```
 
-Commit your application infrastructure definition:
+On your local workstation, in your `terraform-juju` directory, commit your application infrastructure definition:
 
 ```{terminal}
 :copy:
 :user:
 :host:
+:dir: ~/terraform-juju
 git add 2-deploy && git commit -m "feat: define chat application infrastructure"
-```
-
-```{tip}
-**Infrastructure-as-code benefit**: Your entire application infrastructure is now defined as code and tracked in version control. Anyone reviewing your git history can see exactly what applications are deployed, how they're configured, and how they integrate.
 ```
 
 ## Deploy your application infrastructure
 
-Unlike imperative commands that execute immediately, Terraform's workflow includes a review step. You'll see what Terraform plans to do before any changes are made.
-
-```{figure}
-:align: center
-
-:::{mermaid}
-graph TB
-    A[Modify .tf files] --> B[terraform plan]
-    B --> C{Review changes}
-    C -->|Approve| D[terraform apply]
-    C -->|Revise| A
-    D --> E[Update infrastructure]
-    E --> F[Update state file]
-
-    style B fill:#e3f2fd
-    style C fill:#fff9c4
-    style D fill:#e8f5e9
-    style F fill:#fce4ec
-:::
-
-Terraform's plan-review-apply workflow ensures you always preview infrastructure changes before they're executed. This is a key infrastructure-as-code benefit for team collaboration and change management.
-```
-
-In your VM, navigate to the deployment directory, initialize, and preview the changes:
+In your VM, initialize and preview the deployment:
 
 ```{terminal}
 :copy:
 :user: ubuntu
 :host: my-juju-vm
-:dir: ~/terraform-juju/1-bootstrap
-cd ../2-deploy && terraform init
+:dir: ~/terraform-juju
+terraform -chdir=2-deploy init
 ```
 
 ```{terminal}
 :copy:
 :user: ubuntu
 :host: my-juju-vm
-:dir: ~/terraform-juju/2-deploy
-terraform plan
+:dir: ~/terraform-juju
+terraform -chdir=2-deploy plan
 ```
 
 This shows what Terraform will create without actually creating anything. Review the output carefully -- you'll see the model, applications, and integrations that will be created.
-
-```{tip}
-**Infrastructure-as-code benefit**: The plan step lets you (and your team) review changes before applying them. In a team setting, you'd commit your `.tf` changes, open a pull request, and have teammates review the plan output before merging and applying.
-```
 
 Apply your infrastructure definition:
 
@@ -674,30 +742,39 @@ Apply your infrastructure definition:
 :copy:
 :user: ubuntu
 :host: my-juju-vm
-:dir: ~/terraform-juju/2-deploy
-terraform apply
+:dir: ~/terraform-juju
+terraform -chdir=2-deploy apply
 ```
 
 Terraform will show you the plan again and ask for confirmation. Type `yes` to proceed.
 
-Watch the deployment progress. You can use the `juju` CLI to inspect status:
+The deployment will take a few minutes. Terraform will show you the progress as it creates each resource.
+
+Once complete, verify your applications are running:
 
 ```{terminal}
 :copy:
 :user: ubuntu
 :host: my-juju-vm
-juju status --relations --watch 1s
+microk8s kubectl get pods -n chat
 ```
 
-Things are all set when your `App Status` shows `active` and your `Unit - Workload` shows `active`.
-
-Once deployed, test your chat service. From the output of `juju status` > `Unit` > `mattermost-k8s/0`, retrieve the IP address and port, then use `curl` to test:
+Wait until all pods show `Running` status. Then test your chat service:
 
 ```{terminal}
 :copy:
 :user: ubuntu
 :host: my-juju-vm
-curl <IP address>:<port>/api/v4/system/ping
+microk8s kubectl get svc -n chat mattermost-k8s -o jsonpath='{.spec.clusterIP}:{.spec.ports[0].port}'
+```
+
+This displays the service address. Use it to test the service (replace `<address>` with the output from above):
+
+```{terminal}
+:copy:
+:user: ubuntu
+:host: my-juju-vm
+curl <address>/api/v4/system/ping
 ```
 
 Sample output:
@@ -708,55 +785,15 @@ Sample output:
 
 Congratulations! Your chat service is up and running, and your entire infrastructure is defined as code.
 
-```{figure}
-:align: center
-
-:::{mermaid}
-graph TB
-    subgraph "MicroK8s Cloud"
-        subgraph "Controller Model"
-            C[Juju Controller]
-        end
-
-        subgraph "Chat Model"
-            M[Mattermost<br/>mattermost-k8s/0]
-            P1[PostgreSQL<br/>postgresql-k8s/0<br/>Primary]
-            P2[PostgreSQL<br/>postgresql-k8s/1]
-            S[Self-signed Certs<br/>self-signed-certificates/0]
-
-            P1 -.db relation.-> M
-            S -.certificates relation.-> P1
-            S -.certificates relation.-> P2
-            P1 -.peer relation.-> P2
-        end
-    end
-
-    T[Terraform State] -.tracks.-> C
-    T -.tracks.-> M
-    T -.tracks.-> P1
-    T -.tracks.-> P2
-    T -.tracks.-> S
-
-    style C fill:#f3e5f5
-    style M fill:#e1f5ff
-    style P1 fill:#e8f5e9
-    style P2 fill:#e8f5e9
-    style S fill:#fff3e0
-    style T fill:#fce4ec
-:::
-
-Your deployed infrastructure: a Juju controller, a chat model with integrated applications (Mattermost, PostgreSQL with high availability, and TLS certificates), all tracked by Terraform state.
-```
-
 ```{tip}
 **Infrastructure-as-code benefit**: Terraform's state tracking means you can't accidentally create duplicate resources. It knows what exists and only makes necessary changes.
 ```
 
 ## Manage your infrastructure
 
-A key benefit of infrastructure-as-code is that the same workflow handles all changes. Let's scale your PostgreSQL database for improved availability.
+A key benefit of infrastructure-as-code is that the same workflow handles all changes. Let's scale your PostgreSQL database to enable high availability.
 
-On your local workstation, in `2-deploy/main.tf`, modify the `postgresql-k8s` resource to change `units` from `2` to `3`:
+On your local workstation, open `terraform-juju/2-deploy/main.tf` in your IDE and modify the `postgresql-k8s` resource to change `units` from `1` to `3`:
 
 ```{code-block} terraform
 :caption: `2-deploy/main.tf` (partial)
@@ -770,7 +807,7 @@ resource "juju_application" "postgresql-k8s" {
   }
 
   trust = true
-  units = 3  # Changed from 2
+  units = 3  # Changed from 1 - enables high availability
 
   config = {
     profile = "testing"
@@ -784,11 +821,11 @@ In your VM, preview the change:
 :copy:
 :user: ubuntu
 :host: my-juju-vm
-:dir: ~/terraform-juju/2-deploy
-terraform plan
+:dir: ~/terraform-juju
+terraform -chdir=2-deploy plan
 ```
 
-Notice Terraform detected the difference between your desired state (3 units) and actual state (2 units), and shows it will add one unit. This is the power of declarative infrastructure -- you describe what you want, and Terraform figures out how to get there.
+Notice Terraform detected the difference between your desired state (3 units) and actual state (1 unit), and shows it will add two units. This is the power of declarative infrastructure -- you describe what you want, and Terraform figures out how to get there.
 
 ```{tip}
 **Infrastructure-as-code benefit**: Terraform's state tracking prevents accidental changes. It knows the current state and only makes necessary modifications to reach your desired state.
@@ -800,49 +837,46 @@ Apply the change:
 :copy:
 :user: ubuntu
 :host: my-juju-vm
-:dir: ~/terraform-juju/2-deploy
-terraform apply
+:dir: ~/terraform-juju
+terraform -chdir=2-deploy apply
 ```
 
-Watch the scaling operation with `juju status --relations`.
+The scaling operation will complete in a few moments.
 
-On your local workstation, commit your change:
+Back on your local workstation, commit your change:
 
 ```{terminal}
 :copy:
 :user:
 :host:
-git add 2-deploy/main.tf && git commit -m "feat: scale postgresql to 3 units for improved availability"
-```
-
-```{tip}
-**Infrastructure-as-code benefit**: Your git history now shows why and when you scaled. Anyone on your team can see the evolution of your infrastructure and the reasoning behind each change (captured in commit messages).
+:dir: ~/terraform-juju
+git add 2-deploy/main.tf && git commit -m "feat: scale postgresql to 3 units for high availability"
 ```
 
 ## Next steps
 
 You've experienced the core infrastructure-as-code workflow with the Terraform Provider for Juju. To build on what you've learned:
 
-- **Bootstrap with more control**: Configure controller and model settings during bootstrap. See: {ref}`configure-a-controller`
-- **Manage controllers post-bootstrap**: Configure controllers, enable high availability, or import existing controllers. See: {ref}`manage-controllers`
-- **Manage multiple environments**: Use Terraform workspaces or separate configurations to manage dev, staging, and production. See: {ref}`manage-models`
+- **Bootstrap with more control**: Configure controller and model settings during bootstrap. See: {ref}`configure-a-controller`.
+- **Manage controllers post-bootstrap**: Configure controllers, enable high availability, or import existing controllers. See: {ref}`manage-controllers`.
+- **Manage multiple environments**: Use Terraform workspaces or separate configurations to manage development, staging, and production. See: {ref}`manage-models`.
 - **Integrate with other cloud resources**: Combine the Juju provider with AWS, GCP, or Azure providers to manage applications and underlying cloud resources together in a single Terraform plan.
 - **Enable team collaboration**: Set up remote state storage and implement GitOps workflows for infrastructure changes.
-- **Explore all provider features**: The provider supports credentials, users, offers, secrets, and more. See: {ref}`reference`
+- **Explore all provider features**: The provider supports credentials, users, offers, secrets, and more. See: {ref}`reference`.
 
 
 ## Tear down your test environment
 
 With Terraform, tearing down your infrastructure is as simple as deploying it.
 
-In your VM, destroy the application infrastructure first, then the controller. Start with the deployment directory:
+In your VM, destroy the application infrastructure first, then the controller:
 
 ```{terminal}
 :copy:
 :user: ubuntu
 :host: my-juju-vm
-:dir: ~/terraform-juju/2-deploy
-terraform destroy
+:dir: ~/terraform-juju
+terraform -chdir=2-deploy destroy
 ```
 
 Terraform will show you everything it will remove and ask for confirmation. Type `yes` to proceed.
@@ -853,8 +887,8 @@ This removes the applications, integrations, and model. Now destroy the controll
 :copy:
 :user: ubuntu
 :host: my-juju-vm
-:dir: ~/terraform-juju/2-deploy
-cd ../1-bootstrap && terraform destroy
+:dir: ~/terraform-juju
+terraform -chdir=1-bootstrap destroy
 ```
 
 Type `yes` to confirm. This removes the Juju controller.

--- a/docs-rtd/tutorial.md
+++ b/docs-rtd/tutorial.md
@@ -289,6 +289,9 @@ terraform {
       version = "~> 1.4"
       source  = "juju/juju"
     }
+    local = {
+      source = "hashicorp/local"
+    }
   }
 }
 
@@ -354,7 +357,7 @@ k8s_endpoint = "https://10.x.x.x:16443"
 The values shown above are examples only. Use your actual values from the previous commands -- the token and certificate will be much longer than shown here.
 ```
 
-Before continuing, keep credentials and Terraform state safe and out of version control:
+Before continuing, keep credentials, connection info, and Terraform state safe and out of version control:
 
 ```{terminal}
 :copy:
@@ -363,6 +366,7 @@ Before continuing, keep credentials and Terraform state safe and out of version 
 :dir: ~/terraform-juju
 cat > 1-bootstrap/.gitignore << 'EOF'
 terraform.tfvars
+conn_info.json
 .terraform*
 terraform.tfstate*
 EOF
@@ -414,40 +418,19 @@ resource "juju_controller" "microk8s" {
 
 Notice how this declarative definition makes your infrastructure intentions clear: you want a Juju controller named `my-chat-controller` on MicroK8s with specific credentials.
 
-To allow the deployment configuration to connect to this controller, add outputs that expose the connection details. Create `1-bootstrap/outputs.tf`:
-
-```{terminal}
-:copy:
-:user:
-:host:
-:dir: ~/terraform-juju
-touch 1-bootstrap/outputs.tf
-```
+To allow the deployment configuration to connect to this controller, add a resource that writes the connection details to a JSON file. Add this to `1-bootstrap/main.tf`:
 
 ```{code-block} terraform
-:caption: `1-bootstrap/outputs.tf`
+:caption: `1-bootstrap/main.tf` (add after juju_controller resource)
 
-output "controller_addresses" {
-  description = "API addresses of the bootstrapped controller"
-  value       = juju_controller.microk8s.api_addresses
-}
-
-output "username" {
-  description = "Admin username for the controller"
-  value       = juju_controller.microk8s.username
-  sensitive   = true
-}
-
-output "password" {
-  description = "Admin password for the controller"
-  value       = juju_controller.microk8s.password
-  sensitive   = true
-}
-
-output "ca_cert" {
-  description = "CA certificate for the controller"
-  value       = juju_controller.microk8s.ca_cert
-  sensitive   = true
+resource "local_file" "conn_info" {
+  filename = "${path.module}/conn_info.json"
+  content = jsonencode({
+    addresses = juju_controller.microk8s.api_addresses
+    username  = juju_controller.microk8s.username
+    password  = juju_controller.microk8s.password
+    ca_cert   = juju_controller.microk8s.ca_cert
+  })
 }
 ```
 
@@ -518,7 +501,7 @@ Once complete, your Juju controller is running on MicroK8s, and Terraform has re
 
 ## Handle authentication and authorization
 
-When you bootstrap a controller, Juju automatically creates an admin user with superuser access. This user's credentials are available in the controller outputs that you defined earlier.
+When you bootstrap a controller, Juju automatically creates an admin user with superuser access. This user's credentials are available in the connection info JSON file created by the bootstrap plan.
 
 While you could manage users via the `juju` CLI, the Terraform Provider lets you manage users as code using `juju_user` resources. You can also manage access control for users across controllers, models, and other resources using `juju_access_*` resources.
 
@@ -530,7 +513,7 @@ For this tutorial, we'll continue using the admin credentials created during boo
 
 With your controller bootstrapped, you'll now define and deploy the applications that make up your chat service. You'll deploy Mattermost for the chat service, PostgreSQL for its backing database, and self-signed certificates to TLS-encrypt traffic from PostgreSQL.
 
-To connect to your bootstrapped controller, you'll need to extract its connection details from the bootstrap state. The bootstrap created a controller with specific API addresses, credentials, and a CA certificate -- you'll use these to configure the provider for application deployment.
+To connect to your bootstrapped controller, you'll read its connection details from the JSON file created by the bootstrap plan. This file contains the controller's API addresses, credentials, and CA certificate.
 
 On your local workstation, in your `terraform-juju` directory, create your application deployment configuration.
 
@@ -556,27 +539,23 @@ terraform {
   }
 }
 
-# Read connection details from the bootstrap state
-data "terraform_remote_state" "bootstrap" {
-  backend = "local"
-
-  config = {
-    path = "${path.module}/../1-bootstrap/terraform.tfstate"
-  }
+# Read connection details from the bootstrap JSON file
+locals {
+  conn_info = jsondecode(file("${path.module}/../1-bootstrap/conn_info.json"))
 }
 
 provider "juju" {
-  controller_addresses = join(",", data.terraform_remote_state.bootstrap.outputs.controller_addresses)
-  username             = data.terraform_remote_state.bootstrap.outputs.username
-  password             = data.terraform_remote_state.bootstrap.outputs.password
-  ca_certificate       = data.terraform_remote_state.bootstrap.outputs.ca_cert
+  controller_addresses = join(",", local.conn_info.addresses)
+  username             = local.conn_info.username
+  password             = local.conn_info.password
+  ca_certificate       = local.conn_info.ca_cert
 }
 ```
 
 ```{important}
 Notice there's no `controller_mode` setting (it defaults to `false`). This configuration can manage models, applications, and integrations, but cannot manage `juju_controller` resources.
 
-The provider connects to the bootstrapped controller by reading its connection details from the bootstrap state via `terraform_remote_state`. This is necessary because Terraform cannot configure a provider from resource outputs in the same plan.
+The provider connects to the bootstrapped controller by reading connection details from the JSON file created by the bootstrap plan. This separation is necessary because Terraform cannot configure a provider from resource outputs in the same plan.
 ```
 
 Create `2-deploy/.gitignore` to keep Terraform state out of version control:

--- a/docs-rtd/tutorial.md
+++ b/docs-rtd/tutorial.md
@@ -267,9 +267,7 @@ clusters:
 
 From the output, copy the full `certificate-authority-data` value and the `server` (endpoint) URL.
 
-## Bootstrap a controller
-
-Now, on your local workstation, in your `terraform-juju` directory, create your controller bootstrap configuration.
+On your local workstation, in your `terraform-juju` directory, create your controller bootstrap configuration.
 
 First, create `1-bootstrap/terraform.tf` to configure Terraform to use the Juju provider in controller mode:
 
@@ -515,13 +513,11 @@ Terraform will show you the plan again and ask for confirmation. Type `yes` to p
 The bootstrap process typically takes 1-2 minutes, but may vary depending on your system and network speed. Terraform will show progress as it creates the controller.
 ```
 
-Once complete, your Juju controller is running on MicroK8s, and Terraform has recorded its state.
+Once complete, your Juju controller is running on MicroK8s, and Terraform has recorded its state. Your environment is ready!
 
-Your controller is now bootstrapped and ready. Next, you'll define and deploy applications.
+## Provision infrastructure and operate applications
 
-## Define your application infrastructure as code
-
-With your controller bootstrapped, now define the applications that make up your chat service in a separate configuration. You'll deploy Mattermost for the chat service, PostgreSQL for its backing database, and self-signed certificates to TLS-encrypt traffic from PostgreSQL.
+With your controller bootstrapped, you'll now define and deploy the applications that make up your chat service. You'll deploy Mattermost for the chat service, PostgreSQL for its backing database, and self-signed certificates to TLS-encrypt traffic from PostgreSQL.
 
 To connect to your bootstrapped controller, you'll need to extract its connection details from the bootstrap state. The bootstrap created a controller with specific API addresses, credentials, and a CA certificate -- you'll use these to configure the provider for application deployment.
 
@@ -714,9 +710,7 @@ On your local workstation, in your `terraform-juju` directory, commit your appli
 git add 2-deploy && git commit -m "feat: define chat application infrastructure"
 ```
 
-## Deploy your application infrastructure
-
-In your VM, initialize and preview the deployment:
+Now deploy your infrastructure. In your VM, initialize and preview the deployment:
 
 ```{terminal}
 :copy:

--- a/docs-rtd/tutorial.md
+++ b/docs-rtd/tutorial.md
@@ -1,22 +1,26 @@
 ---
 myst:
   html_meta:
-    description: "Learn how to deploy Mattermost and PostgreSQL on Kubernetes using the Terraform Provider for Juju in this hands-on introductory tutorial."
+    description: "Learn to manage Juju deployments as code with the Terraform Provider, using declarative configuration files, version control, and infrastructure-as-code workflows."
 ---
 
-# Tutorial
+# Manage your first Juju deployment as code
 
-Imagine your business needs a chat service such as Mattermost backed up by a database such as PostgreSQL. In a traditional setup, this can be quite a challenge, but with Juju you'll find yourself deploying, configuring, scaling, integrating, etc., applications in no time. Let's get started!
+The Terraform Provider for Juju brings infrastructure-as-code capabilities to Juju. With it, you can define your cloud infrastructure and applications in version-controlled configuration files, preview changes before applying them, and collaborate with your team using familiar GitOps workflows.
+
+In this tutorial you will define and deploy a chat service (Mattermost backed by PostgreSQL) as code, experiencing the benefits of declarative infrastructure management.
 
 **What you'll need:**
 
 - A workstation, e.g., a laptop, that has sufficient resources to launch a virtual machine with 4 CPUs, 8 GB RAM, and 50 GB disk space.
+- Familiarity with a terminal.
+- Basic familiarity with Juju concepts (controllers, models, charms, applications).
+- Basic familiarity with Terraform (providers, resources, state).
 
 **What you'll do:**
 
-- Set up an isolated test environment with Multipass and the `charm-dev` blueprint, which will provide all the necessary tools and configuration for the tutorial (a localhost machine cloud and Kubernetes cloud, Juju, etc.).
-
-- Plan, then deploy, configure, and scale a chat service based on Mattermost and backed by PostgreSQL on a local Kubernetes cloud with Juju.
+- Set up an isolated test environment with Multipass, then set up Terraform with the Juju provider to bootstrap a controller and deploy applications on MicroK8s.
+- Define your infrastructure as code, preview changes before applying them, and experience infrastructure-as-code workflows.
 
 ## Set up an isolated test environment
 
@@ -25,118 +29,410 @@ Imagine your business needs a chat service such as Mattermost backed up by a dat
 **Tempted to skip this step?** We strongly recommend that you do not! As you will see in a minute, the VM you set up in this step does not just provide you with an isolated test environment but also with almost everything else you’ll need in the rest of this tutorial (and the non-VM alternative may not yield exactly the same results).
 ```
 
-Follow the instructions for the `juju` CLI.
+When you're trying things out it's nice to work in an isolated test environment. Let's spin up an Ubuntu virtual machine (VM) with Multipass!
 
-> See more: {external+juju:ref}`Juju | Set things up <set-things-up>`
+First, [install Multipass](https://documentation.ubuntu.com/multipass/en/latest/how-to-guides/install-multipass/). For example, on Linux with `snapd`:
 
-In addition to that, on your local workstation, create a directory called `terraform-juju`, then use Multipass to mount it to your Multipass VM. For example, on Linux:
+```{terminal}
+:copy:
+:user:
+:host:
+sudo snap install multipass
+```
 
-```text
-user@ubuntu:~$ mkdir terraform-juju
-user@ubuntu:~$ cd terraform-juju/
-user@ubuntu:~$ multipass mount ~/terraform-juju my-juju-vm:~/terraform-juju
+```{important}
+If on Windows: Note that Multipass can only be installed on Windows 10 Pro or Enterprise. If you are using a different version, you'll need to manually set up MicroK8s and the `juju` CLI outside of a Multipass VM.
+```
+
+Now, use Multipass to launch a Juju-ready VM using the `charm-dev` cloud-init configuration:
+
+```{note}
+This step may take a few minutes to complete (e.g., 10 mins).
+
+This is because the command downloads, installs, (updates,) and configures a number of packages (including MicroK8s, the `juju` CLI, Terraform, and development tools), and the speed will be affected by network bandwidth.
+
+However, once it's done, you'll have everything you'll need -- all in a nice isolated environment that you can clean up easily.
+```
+
+```{terminal}
+:copy:
+:user:
+:host:
+multipass launch 24.04 \
+  --name my-juju-vm \
+  --cpus 4 \
+  --memory 8G \
+  --disk 50G \
+  --timeout 1800 \
+  --cloud-init https://raw.githubusercontent.com/canonical/multipass/refs/heads/main/data/cloud-init-yaml/cloud-init-charm-dev.yaml
+```
+
+```{dropdown} Tips for troubleshooting
+If the VM launch fails, run `multipass delete --purge my-juju-vm` to clean up, then try the launch command again.
+```
+
+Open a shell into the VM:
+
+```{terminal}
+:copy:
+:user:
+:host:
+multipass shell my-juju-vm
+```
+
+Anything you type after the VM shell prompt (`ubuntu@my-juju-vm:~$`) will run on the VM.
+
+```{dropdown} Tips for usage
+
+At any point:
+- To exit the shell, press {kbd}`Ctrl` + {kbd}`D` or type `exit`.
+- To stop the VM after exiting the VM shell, run `multipass stop my-juju-vm`.
+- To restart the VM and re-open a shell into it, type `multipass shell my-juju-vm`.
+```
+
+Congratulations! Your cloud is ready, and thanks to the `charm-dev` cloud-init, you already have:
+- MicroK8s configured and running
+- The `juju` CLI installed
+- Terraform installed
+- A MicroK8s cloud registered with Juju
+
+On your local workstation (not the VM), create a directory for your Terraform configuration and mount it to your VM:
+
+```{terminal}
+:copy:
+:user:
+:host:
+mkdir ~/terraform-juju && cd ~/terraform-juju
+multipass mount ~/terraform-juju my-juju-vm:~/terraform-juju
 ```
 
 This setup will enable you to create and edit Terraform files in your local editor while running them inside your VM.
 
-(tutorial-plan)=
-## Plan
+## Set up version control
 
-In this tutorial your goal is to set up a chat service on a cloud.
+A key benefit of infrastructure-as-code is version control. Your infrastructure definitions become code that can be tracked, reviewed, and collaborated on.
 
-First, decide which cloud (i.e., anything that provides storage, compute, and networking) you want to use. Juju supports a long list of clouds; in this tutorial we will use a low-ops, minimal production Kubernetes called 'MicroK8s'. In a terminal, open a shell into your VM and verify that you already have MicroK8s installed (`microk8s version`).
+On your local workstation, in your `terraform-juju` directory, initialize a git repository:
 
-> See more: {external+juju:ref}`Juju | Cloud <cloud>`, {external+juju:ref}`Juju | List of supported clouds <list-of-supported-clouds>`, {external+juju:ref}`Juju | The MicroK8s cloud and Juju <cloud-kubernetes-microk8s>`, {external+juju:ref}`Juju | Set things up automatically <set-things-up>`
-
-Next, decide which charms (i.e., software operators) you want to use. Charmhub provides a large collection. For this tutorial we will use `mattermost-k8s`  for the chat service,  `postgresql-k8s` for its backing database, and `self-signed-certificates` to TLS-encrypt traffic from PostgreSQL.
-
-> See more: {external+juju:ref}`Juju | Charm <charm>`, [Charmhub](https://charmhub.io/), Charmhub | [`mattermost-k8s`](https://charmhub.io/mattermost-k8s), [`postgresql-k8s`](https://charmhub.io/postgresql-k8s), [`self-signed-certificates`](https://charmhub.io/self-signed-certificates)
-
-
-(tutorial-deploy-configure-integrate)=
-## Deploy, configure, integrate
-
-You will need to install a Juju client; on the client, add your cloud and cloud credentials; on the cloud, bootstrap a controller (i.e., control plan); on the controller, add a model (i.e., canvas to deploy things on; namespace); on the model, deploy, configure, and integrate the charms that make up your chat service.
-
-the Terraform Provider for Juju is not self-sufficient -- follow the instructions for the `juju` CLI all the way up to and including the step where you create the  `34microk8s` controller. Also get the details of that controller: `juju show-controller --show-password 34microk8s`.
-
-> See more: {external+juju:ref}`Juju | Tutorial: Deploy <tutorial>`
-
-Then, on your VM, install the `terraform` CLI:
-
-```text
-ubuntu@my-juju-vm:~$ sudo snap install terraform --classic
-terraform 1.7.5 from Snapcrafters✪ installed
+```{terminal}
+:copy:
+:user:
+:host:
+git init
 ```
 
-Next, in your local `terraform-juju` directory, create three files as follows:
+As you create and modify files in this tutorial, you'll commit them to track your infrastructure's evolution.
 
-(a) a `terraform.tf`file , where you'll configure `terraform` to use the `juju` provider:
+## Set up Terraform with the Juju provider
 
-```text
+The way Terraform with the Juju provider works is: you define your desired infrastructure state in `.tf` files, the `terraform` CLI reads those files and talks to a Juju controller via the `juju` provider plugin, and the controller provisions resources and deploys applications. Your infrastructure definitions are code that can be version-controlled, reviewed, and shared with your team.
+
+Thanks to the `charm-dev` cloud-init, the `terraform` CLI is already installed in your VM. You can verify this:
+
+```{terminal}
+:copy:
+:user: ubuntu
+:host: my-juju-vm
+terraform version
+```
+
+## Bootstrap a Juju controller
+
+A Juju controller is your Juju control plane -- the entity that holds the Juju API server and Juju's database. With the Terraform Provider, you can bootstrap a controller declaratively by defining it in your Terraform configuration.
+
+Thanks to the `charm-dev` cloud-init, the `juju` CLI is already installed and the MicroK8s cloud is already registered with Juju. You can verify this in your VM:
+
+```{terminal}
+:copy:
+:user: ubuntu
+:host: my-juju-vm
+juju clouds --client
+```
+
+You should see `microk8s` listed. Now, view the MicroK8s credentials that you'll need for your Terraform configuration:
+
+```{terminal}
+:copy:
+:user: ubuntu
+:host: my-juju-vm
+juju show-credentials microk8s --show-secrets --client
+```
+
+From the output, note the values for the client certificate, client key, server certificate, and endpoint. You'll use these in your Terraform configuration.
+
+Now, on your local workstation, in your `terraform-juju` directory, create your Terraform configuration files.
+
+First, create `terraform.tf` to configure Terraform to use the Juju provider in controller mode:
+
+```{code-block} terraform
+:caption: `terraform.tf`
+
 terraform {
   required_providers {
     juju = {
-      version = "~> 0.11.0"
+      version = "~> 1.0.0"
       source  = "juju/juju"
     }
   }
 }
+
+provider "juju" {
+  controller_mode = true
+}
 ```
 
-(b) a `ca-cert.pem` file, where you'll copy-paste the `ca_certificate` from the details of your `juju`-client-bootstrapped controller; and
+Next, create `variables.tf` to define variables for your sensitive credentials:
 
-(c) a `main.tf` file, where you'll configure the `juju` provider to point to the `juju`-client-bootstrapped controller and the `ca-cert.pem` file where you've saved it's certificate, then create resources to add a model and deploy, configure, and integrate applications:
+```{code-block} terraform
+:caption: `variables.tf`
 
-```terraform
-provider "juju" {
-   controller_addresses = "10.152.183.27:17070"
-   username = "admin"
-   password = "40ec19f8bebe353e122f7f020cdb6949"
-   ca_certificate = file("~/terraform-juju/ca-cert.pem")
+variable "k8s_endpoint" {
+  description = "MicroK8s API endpoint"
+  type        = string
 }
 
+variable "k8s_ca_cert" {
+  description = "MicroK8s CA certificate"
+  type        = string
+  sensitive   = true
+}
+
+variable "k8s_client_cert" {
+  description = "MicroK8s client certificate"
+  type        = string
+  sensitive   = true
+}
+
+variable "k8s_client_key" {
+  description = "MicroK8s client key"
+  type        = string
+  sensitive   = true
+}
+```
+
+Create `terraform.tfvars` with your actual credential values (from the `juju show-credentials` output):
+
+```{code-block} terraform
+:caption: `terraform.tfvars`
+
+k8s_endpoint    = "https://<your-microk8s-ip>:16443"
+k8s_ca_cert     = "<your-ca-certificate>"
+k8s_client_cert = "<your-client-certificate>"
+k8s_client_key  = "<your-client-key>"
+```
+
+```{important}
+**Keep credentials out of version control!** Add `terraform.tfvars` to your `.gitignore` file:
+
+```{terminal}
+:copy:
+:user:
+:host:
+echo "terraform.tfvars" >> .gitignore
+echo ".terraform*" >> .gitignore
+echo "terraform.tfstate*" >> .gitignore
+```
+```
+
+Now, create `main.tf` to define your controller:
+
+```{code-block} terraform
+:caption: `main.tf`
+
+resource "juju_controller" "microk8s" {
+  name = "my-chat-controller"
+
+  # Use the snap-installed juju binary to avoid confinement issues
+  juju_binary = "/snap/juju/current/bin/juju"
+
+  cloud = {
+    name       = "microk8s"
+    type       = "kubernetes"
+    auth_types = ["clientcertificate"]
+    endpoint   = var.k8s_endpoint
+    ca_certificates = [var.k8s_ca_cert]
+    host_cloud_region = "localhost"
+  }
+
+  cloud_credential = {
+    name      = "microk8s-cred"
+    auth_type = "clientcertificate"
+    attributes = {
+      "ClientCertificateData" = var.k8s_client_cert
+      "ClientKeyData"         = var.k8s_client_key
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      cloud.region,
+      cloud.host_cloud_region
+    ]
+  }
+}
+```
+
+Notice how this declarative definition makes your infrastructure intentions clear: you want a Juju controller named "my-chat-controller" on MicroK8s with specific credentials.
+
+Commit your infrastructure definition (excluding sensitive files):
+
+```{terminal}
+:copy:
+:user:
+:host:
+git add terraform.tf variables.tf main.tf .gitignore
+git commit -m "feat: define Juju controller infrastructure"
+```
+
+> **Infrastructure-as-code benefit**: Your controller infrastructure is now tracked in version control. You can see the history of changes, revert if needed, and share with your team for review.
+
+Now, in your VM, initialize Terraform and preview your changes:
+
+```{terminal}
+:copy:
+:user: ubuntu
+:host: my-juju-vm
+cd ~/terraform-juju
+terraform init
+```
+
+This downloads the Juju provider plugin and prepares your workspace.
+
+Preview what Terraform will create:
+
+```{terminal}
+:copy:
+:user: ubuntu
+:host: my-juju-vm
+terraform plan
+```
+
+This shows what Terraform will create without actually creating anything. Review the output carefully -- this is your opportunity to catch issues before they affect your infrastructure.
+
+> **Infrastructure-as-code benefit**: The plan step lets you (and your team) review changes before applying them. In a team setting, you'd commit your `.tf` changes, open a pull request, and have teammates review the plan output before merging and applying.
+
+Apply your infrastructure definition:
+
+```{terminal}
+:copy:
+:user: ubuntu
+:host: my-juju-vm
+terraform apply
+```
+
+Terraform will show you the plan again and ask for confirmation. Type `yes` to proceed.
+
+The bootstrap process will take a few minutes. Once complete, your Juju controller is running on MicroK8s, and Terraform has recorded its state.
+
+Congratulations! You've bootstrapped a Juju controller as code.
+
+
+## Define your application infrastructure as code
+
+With your controller bootstrapped, now define the applications that make up your chat service. You'll deploy Mattermost for the chat service, PostgreSQL for its backing database, and self-signed certificates to TLS-encrypt traffic from PostgreSQL.
+
+First, update your Terraform configuration to switch from controller mode to regular mode. On your local workstation, in `terraform.tf`, remove the `controller_mode` setting and configure the provider to use your bootstrapped controller:
+
+```{code-block} terraform
+:caption: `terraform.tf`
+
+terraform {
+  required_providers {
+    juju = {
+      version = "~> 1.0.0"
+      source  = "juju/juju"
+    }
+  }
+}
+
+provider "juju" {
+  # The provider will automatically use the controller bootstrapped by Terraform
+  # by reading from the terraform state
+}
+```
+
+Now, update `main.tf` to add your application resources. Replace the entire contents with:
+
+```{code-block} terraform
+:caption: `main.tf`
+
+resource "juju_controller" "microk8s" {
+  name = "my-chat-controller"
+
+  juju_binary = "/snap/juju/current/bin/juju"
+
+  cloud = {
+    name       = "microk8s"
+    type       = "kubernetes"
+    auth_types = ["clientcertificate"]
+    endpoint   = var.k8s_endpoint
+    ca_certificates = [var.k8s_ca_cert]
+    host_cloud_region = "localhost"
+  }
+
+  cloud_credential = {
+    name      = "microk8s-cred"
+    auth_type = "clientcertificate"
+    attributes = {
+      "ClientCertificateData" = var.k8s_client_cert
+      "ClientKeyData"         = var.k8s_client_key
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      cloud.region,
+      cloud.host_cloud_region
+    ]
+  }
+}
+
+# Define the workspace for your applications
 resource "juju_model" "chat" {
   name = "chat"
+
+  # Ensure the controller is bootstrapped first
+  depends_on = [juju_controller.microk8s]
 }
 
+# Define the chat application
 resource "juju_application" "mattermost-k8s" {
-  model_uuid = juju_model.chat.uuid
+  model = juju_model.chat.name
 
   charm {
     name = "mattermost-k8s"
   }
-
 }
 
+# Define the database with high availability
 resource "juju_application" "postgresql-k8s" {
-
-  model_uuid = juju_model.chat.uuid
+  model = juju_model.chat.name
 
   charm {
-    name = "postgresql-k8s"
-    channel  = "14/stable"
+    name    = "postgresql-k8s"
+    channel = "14/stable"
   }
 
   trust = true
+  units = 2  # High availability configuration
 
   config = {
     profile = "testing"
-   }
-
+  }
 }
 
+# Define the TLS certificate provider
 resource "juju_application" "self-signed-certificates" {
-  model_uuid = juju_model.chat.uuid
+  model = juju_model.chat.name
 
   charm {
     name = "self-signed-certificates"
   }
-
 }
 
+# Integrate PostgreSQL with Mattermost
 resource "juju_integration" "postgresql-mattermost" {
-  model_uuid = juju_model.chat.uuid
+  model = juju_model.chat.name
 
   application {
     name     = juju_application.postgresql-k8s.name
@@ -144,13 +440,9 @@ resource "juju_integration" "postgresql-mattermost" {
   }
 
   application {
-    name     = juju_application.mattermost-k8s.name
+    name = juju_application.mattermost-k8s.name
   }
 
-  # Add any RequiresReplace schema attributes of
-  # an application in this integration to ensure
-  # it is recreated if one of the applications
-  # is Destroyed and Recreated by terraform. E.G.:
   lifecycle {
     replace_triggered_by = [
       juju_application.postgresql-k8s.name,
@@ -167,21 +459,18 @@ resource "juju_integration" "postgresql-mattermost" {
   }
 }
 
+# Integrate PostgreSQL with TLS certificates
 resource "juju_integration" "postgresql-tls" {
-  model_uuid = juju_model.chat.uuid
+  model = juju_model.chat.name
 
   application {
-    name     = juju_application.postgresql-k8s.name
+    name = juju_application.postgresql-k8s.name
   }
 
   application {
-    name     = juju_application.self-signed-certificates.name
+    name = juju_application.self-signed-certificates.name
   }
 
-  # Add any RequiresReplace schema attributes of
-  # an application in this integration to ensure
-  # it is recreated if one of the applications
-  # is Destroyed and Recreated by terraform. E.G.:
   lifecycle {
     replace_triggered_by = [
       juju_application.postgresql-k8s.name,
@@ -199,181 +488,188 @@ resource "juju_integration" "postgresql-tls" {
 }
 ```
 
-Next, in your Multipass VM, initialise your provider's configuration (`terraform init`), preview your plan (`terraform plan`), and apply your plan to your infrastructure (`terraform apply`):
+Notice how this declarative definition makes your infrastructure intentions clear: you want a chat model with Mattermost, PostgreSQL (with 2 units for high availability), TLS certificates, and specific integrations between them.
 
-```{important}
-You can always repeat all three, though technically you only need to run `terraform init` if your `terraform.tf` or the `provider` bit of your `main.tf` has changed, and you only need to run `terraform plan` if you want to preview the changes before applying them.
+Commit your application infrastructure definition:
+
+```{terminal}
+:copy:
+:user:
+:host:
+git add main.tf terraform.tf
+git commit -m "feat: define chat application infrastructure"
 ```
 
-```text
-ubuntu@my-juju-vm:~/terraform-juju$ terraform init && terraform plan && terraform apply
+> **Infrastructure-as-code benefit**: Your entire application infrastructure is now defined as code and tracked in version control. Anyone reviewing your git history can see exactly what applications are deployed, how they're configured, and how they integrate.
+
+## Deploy your application infrastructure
+
+Unlike imperative commands that execute immediately, Terraform's workflow includes a review step. You'll see what Terraform plans to do before any changes are made.
+
+In your VM, preview the changes:
+
+```{terminal}
+:copy:
+:user: ubuntu
+:host: my-juju-vm
+terraform plan
 ```
 
-Finally, use the `juju` client to inspect the results:
+This shows what Terraform will create without actually creating anything. Review the output carefully -- you'll see the model, applications, and integrations that will be created.
 
-```text
-ubuntu@my-juju-vm:~/terraform-juju$ juju status --relations
+> **Infrastructure-as-code benefit**: The plan step lets you (and your team) review changes before applying them. In a team setting, you'd commit your `.tf` changes, open a pull request, and have teammates review the plan output before merging and applying.
+
+Apply your infrastructure definition:
+
+```{terminal}
+:copy:
+:user: ubuntu
+:host: my-juju-vm
+terraform apply
 ```
 
-Done!
+Terraform will show you the plan again and ask for confirmation. Type `yes` to proceed.
 
-Now, from the output of `juju status`> `Unit` > `mattermost-k8s/0`, retrieve the IP address and the port and feed them to `curl` on the template below:
+Watch the deployment progress. You can use the `juju` CLI to inspect status:
 
-```text
+```{terminal}
+:copy:
+:user: ubuntu
+:host: my-juju-vm
+juju status --relations --watch 1s
+```
+
+Things are all set when your `App Status` shows `active` and your `Unit - Workload` shows `active`.
+
+Once deployed, test your chat service. From the output of `juju status` > `Unit` > `mattermost-k8s/0`, retrieve the IP address and port, then use `curl` to test:
+
+```{terminal}
+:copy:
+:user: ubuntu
+:host: my-juju-vm
 curl <IP address>:<port>/api/v4/system/ping
 ```
 
-Sample session:
+Sample output:
 
 ```text
-ubuntu@my-juju-vm:~$ curl 10.1.170.150:8065/api/v4/system/ping
 {"ActiveSearchBackend":"database","AndroidLatestVersion":"","AndroidMinVersion":"","IosLatestVersion":"","IosMinVersion":"","status":"OK"}
 ```
 
-Congratulations, your chat service is up and running!
+Congratulations! Your chat service is up and running, and your entire infrastructure is defined as code.
 
-> See more: {external+juju:ref}`Juju | Set things up <set-things-up>`, {ref}`manage-the-terraform-provider-for-juju`, {external+juju:ref}`Juju | Manage clouds <manage-clouds>`, {external+juju:ref}`Juju | Manage credentials <manage-credentials>`, {external+juju:ref}`Juju | Manage controllers <manage-controllers>`, {external+juju:ref}`Juju | Manage models <manage-models>`, {external+juju:ref}`Juju | Manage applications <manage-applications>`
+> **Infrastructure-as-code benefit**: Terraform's state tracking means you can't accidentally create duplicate resources. It knows what exists and only makes necessary changes.
 
-(tutorial-scale)=
-## Scale
+## Manage your infrastructure
 
-A database failure can be very costly. Let's scale it!
+A key benefit of infrastructure-as-code is that the same workflow handles all changes. Let's scale your PostgreSQL database for improved availability.
 
-On your local machine, in you `main.tf` file, in the definition of the resource for `postgresql-k8s`, add a `units` block and set it to `3`:
+On your local workstation, in `main.tf`, modify the `postgresql-k8s` resource to change `units` from `2` to `3`:
 
-```terraform
-provider "juju" {
-   controller_addresses = "10.152.183.27:17070"
-   username = "admin"
-   password = "40ec19f8bebe353e122f7f020cdb6949"
-   ca_certificate = file("~/terraform-juju/ca-cert.pem")
-}
-
-resource "juju_model" "chat" {
-  name = "chat"
-}
-
-
-resource "juju_application" "mattermost-k8s" {
-  model_uuid = juju_model.chat.uuid
-
-  charm {
-    name = "mattermost-k8s"
-  }
-
-}
-
+```{code-block} terraform
+:caption: `main.tf`
 
 resource "juju_application" "postgresql-k8s" {
-
-  model_uuid = juju_model.chat.uuid
+  model = juju_model.chat.name
 
   charm {
-    name = "postgresql-k8s"
-    channel  = "14/stable"
+    name    = "postgresql-k8s"
+    channel = "14/stable"
   }
 
   trust = true
+  units = 3  # Changed from 2
 
   config = {
     profile = "testing"
-   }
-
-  units = 3
-
-}
-
-
-resource "juju_application" "self-signed-certificates" {
-  model_uuid = juju_model.chat.uuid
-
-  charm {
-    name = "self-signed-certificates"
-  }
-
-}
-
-
-resource "juju_integration" "postgresql-mattermost" {
-  model_uuid = juju_model.chat.uuid
-
-  application {
-    name     = juju_application.postgresql-k8s.name
-    endpoint = "db"
-  }
-
-  application {
-    name     = juju_application.mattermost-k8s.name
-  }
-
-  # Add any RequiresReplace schema attributes of
-  # an application in this integration to ensure
-  # it is recreated if one of the applications
-  # is Destroyed and Recreated by terraform. E.G.:
-  lifecycle {
-    replace_triggered_by = [
-      juju_application.postgresql-k8s.name,
-      juju_application.postgresql-k8s.model,
-      juju_application.postgresql-k8s.constraints,
-      juju_application.postgresql-k8s.placement,
-      juju_application.postgresql-k8s.charm.name,
-      juju_application.mattermost-k8s.name,
-      juju_application.mattermost-k8s.model,
-      juju_application.mattermost-k8s.constraints,
-      juju_application.mattermost-k8s.placement,
-      juju_application.mattermost-k8s.charm.name,
-    ]
-  }
-}
-
-
-resource "juju_integration" "postgresql-tls" {
-  model_uuid = juju_model.chat.uuid
-
-  application {
-    name     = juju_application.postgresql-k8s.name
-  }
-
-  application {
-    name     = juju_application.self-signed-certificates.name
-  }
-
-  # Add any RequiresReplace schema attributes of
-  # an application in this integration to ensure
-  # it is recreated if one of the applications
-  # is Destroyed and Recreated by terraform. E.G.:
-  lifecycle {
-    replace_triggered_by = [
-      juju_application.postgresql-k8s.name,
-      juju_application.postgresql-k8s.model,
-      juju_application.postgresql-k8s.constraints,
-      juju_application.postgresql-k8s.placement,
-      juju_application.postgresql-k8s.charm.name,
-      juju_application.self-signed-certificates.name,
-      juju_application.self-signed-certificates.model,
-      juju_application.self-signed-certificates.constraints,
-      juju_application.self-signed-certificates.placement,
-      juju_application.self-signed-certificates.charm.name,
-    ]
   }
 }
 ```
 
-Then, in your VM, use `terraform` to apply the changes and `juju` to inspect the results:
+In your VM, preview the change:
 
-```text
-ubuntu@my-juju-vm:~/terraform-juju$ terraform init && terraform plan && terraform apply
-ubuntu@my-juju-vm:~/terraform-juju$ juju status --relations
+```{terminal}
+:copy:
+:user: ubuntu
+:host: my-juju-vm
+terraform plan
 ```
 
-> See more: {ref}`scale-an-application`
+Notice Terraform detected the difference between your desired state (3 units) and actual state (2 units), and shows it will add one unit. This is the power of declarative infrastructure -- you describe what you want, and Terraform figures out how to get there.
+
+> **Infrastructure-as-code benefit**: Terraform's state tracking prevents accidental changes. It knows the current state and only makes necessary modifications to reach your desired state.
+
+Apply the change:
+
+```{terminal}
+:copy:
+:user: ubuntu
+:host: my-juju-vm
+terraform apply
+```
+
+Watch the scaling operation with `juju status --relations`.
+
+On your local workstation, commit your change:
+
+```{terminal}
+:copy:
+:user:
+:host:
+git add main.tf
+git commit -m "feat: scale postgresql to 3 units for improved availability"
+```
+
+> **Infrastructure-as-code benefit**: Your git history now shows why and when you scaled. Anyone on your team can see the evolution of your infrastructure and the reasoning behind each change (captured in commit messages).
+
+## Next steps
+
+You've experienced the core infrastructure-as-code workflow with the Terraform Provider for Juju. To build on what you've learned:
+
+- **Bootstrap with more control**: Configure controller and model settings during bootstrap. See: {ref}`configure-a-controller`
+- **Manage controllers post-bootstrap**: Configure controllers, enable high availability, or import existing controllers. See: {ref}`manage-controllers`
+- **Manage multiple environments**: Use Terraform workspaces or separate configurations to manage dev, staging, and production. See: {ref}`manage-models`
+- **Integrate with other cloud resources**: Combine the Juju provider with AWS, GCP, or Azure providers to manage applications and underlying cloud resources together in a single Terraform plan.
+- **Enable team collaboration**: Set up remote state storage and implement GitOps workflows for infrastructure changes.
+- **Explore all provider features**: The provider supports credentials, users, offers, secrets, and more. See: {ref}`reference`
 
 
 ## Tear down your test environment
 
-Follow the instructions for the `juju` CLI.
+With Terraform, tearing down your infrastructure is as simple as deploying it.
 
-> See more: {external+juju:ref}`Juju | Set things up <tear-things-down>`
+In your VM, destroy all Terraform-managed infrastructure:
 
-In addition to that, on your host machine, delete your the `terraform-juju` directory.
+```{terminal}
+:copy:
+:user: ubuntu
+:host: my-juju-vm
+terraform destroy
+```
+
+Terraform will show you everything it will remove and ask for confirmation. Type `yes` to proceed.
+
+This removes all infrastructure Terraform created: applications, integrations, model, and controller. Notice how Terraform maintains consistency -- it knows exactly what it created from the state, so it can cleanly remove everything.
+
+Exit the VM:
+
+```{terminal}
+:copy:
+:user: ubuntu
+:host: my-juju-vm
+exit
+```
+
+From your local workstation, delete the VM:
+
+```{terminal}
+:copy:
+:user:
+:host:
+multipass delete --purge my-juju-vm
+```
+
+Finally, [uninstall Multipass](https://documentation.ubuntu.com/multipass/en/latest/how-to-guides/install-multipass/#uninstall) if you no longer need it.
+
+Your local `terraform-juju` directory contains your infrastructure definitions -- keep this git repository to preserve your infrastructure history, or delete it if you're done experimenting.
 

--- a/docs-rtd/tutorial.md
+++ b/docs-rtd/tutorial.md
@@ -20,6 +20,7 @@ In this tutorial you will define and deploy a chat service (Mattermost backed by
 **What you'll do:**
 
 - Set things up: launch a Juju-ready VM using Multipass, install Terraform, and bootstrap a Juju controller.
+- See how to manage users and access control as code.
 - Deploy infrastructure and applications with Terraform configuration files.
 - Scale your deployment and clean up resources.
 
@@ -513,7 +514,17 @@ Terraform will show you the plan again and ask for confirmation. Type `yes` to p
 The bootstrap process typically takes 1-2 minutes, but may vary depending on your system and network speed. Terraform will show progress as it creates the controller.
 ```
 
-Once complete, your Juju controller is running on MicroK8s, and Terraform has recorded its state. Your environment is ready!
+Once complete, your Juju controller is running on MicroK8s, and Terraform has recorded its state.
+
+## Handle authentication and authorization
+
+When you bootstrap a controller, Juju automatically creates an admin user with superuser access. This user's credentials are available in the controller outputs that you defined earlier.
+
+While you could manage users via the `juju` CLI, the Terraform Provider lets you manage users as code using `juju_user` resources. You can also manage access control for users across controllers, models, and other resources using `juju_access_*` resources.
+
+> See more: {ref}`Manage users <manage-users>`, {ref}`Manage access to a controller <manage-access-to-a-controller>`, {ref}`Manage access to a model <manage-access-to-a-model>`
+
+For this tutorial, we'll continue using the admin credentials created during bootstrap.
 
 ## Deploy infrastructure and applications
 

--- a/docs-rtd/tutorial.md
+++ b/docs-rtd/tutorial.md
@@ -783,11 +783,7 @@ Congratulations! Your chat service is up and running, and your entire infrastruc
 **Infrastructure-as-code benefit**: Terraform's state tracking means you can't accidentally create duplicate resources. It knows what exists and only makes necessary changes.
 ```
 
-## Manage your infrastructure
-
-A key benefit of infrastructure-as-code is that the same workflow handles all changes. Let's scale your PostgreSQL database to enable high availability.
-
-On your local workstation, open `terraform-juju/2-deploy/main.tf` in your IDE and modify the `postgresql-k8s` resource to change `units` from `1` to `3`:
+Now let's scale your PostgreSQL database to enable high availability. On your local workstation, open `terraform-juju/2-deploy/main.tf` in your IDE and modify the `postgresql-k8s` resource to change `units` from `1` to `3`:
 
 ```{code-block} terraform
 :caption: `2-deploy/main.tf` (partial)

--- a/docs-rtd/tutorial.md
+++ b/docs-rtd/tutorial.md
@@ -4,9 +4,9 @@ myst:
     description: "Learn to manage Juju deployments as code with the Terraform Provider, using declarative configuration files, version control, and infrastructure-as-code workflows."
 ---
 
-# Manage your first Juju deployment as code
+# Get started with the Terraform Provider for Juju
 
-The Terraform Provider for Juju brings infrastructure-as-code capabilities to Juju. With it, you can define your cloud infrastructure and applications in version-controlled configuration files, preview changes before applying them, and collaborate with your team using familiar GitOps workflows.
+The Terraform Provider for Juju brings infrastructure-as-code capabilities to {external+juju:doc}`Juju <index>`. With it, you can define your cloud infrastructure and applications in version-controlled configuration files, preview changes before applying them, and collaborate with your team using familiar GitOps workflows.
 
 In this tutorial you will define and deploy a chat service (Mattermost backed by PostgreSQL) as code, experiencing the benefits of declarative infrastructure management.
 
@@ -19,17 +19,31 @@ In this tutorial you will define and deploy a chat service (Mattermost backed by
 
 **What you'll do:**
 
-- Set up an isolated test environment with Multipass, then set up Terraform with the Juju provider to bootstrap a controller and deploy applications on MicroK8s.
-- Define your infrastructure as code, preview changes before applying them, and experience infrastructure-as-code workflows.
+- Set up your environment: launch a VM with MicroK8s, install Terraform, initialize version control, and bootstrap a Juju controller.
+- Define your application infrastructure as code, preview changes before applying them, and deploy a chat service.
+- Experience infrastructure-as-code workflows: manage your infrastructure, track changes in version control, and tear down resources.
 
-## Set up an isolated test environment
+## Set up your environment
 
-```{important}
+```{tip}
+**Recommended workflow setup:**
 
-**Tempted to skip this step?** We strongly recommend that you do not! As you will see in a minute, the VM you set up in this step does not just provide you with an isolated test environment but also with almost everything else you’ll need in the rest of this tutorial (and the non-VM alternative may not yield exactly the same results).
+You'll be working across two contexts: your local workstation and a VM. To work efficiently:
+
+1. **Two terminal windows (or one split terminal):**
+   - One terminal for your local workstation (where you'll run `multipass` commands and `git` commands)
+   - One terminal for the VM shell (where you'll run `terraform` and `juju` commands)
+
+2. **Your favorite text editor** on your local workstation to create and edit `.tf` files. Changes you make locally will be automatically visible in the VM via the mounted directory.
 ```
 
-When you're trying things out it's nice to work in an isolated test environment. Let's spin up an Ubuntu virtual machine (VM) with Multipass!
+To work with the Terraform Provider for Juju, you'll need:
+- A cloud (MicroK8s for this tutorial)
+- The `juju` CLI (to extract cloud credentials)
+- The `terraform` CLI (to run your infrastructure-as-code definitions)
+- A Juju controller (which you'll bootstrap with Terraform)
+
+You'll get most of these automatically by launching a Juju-ready Ubuntu VM with Multipass using the `charm-dev` cloud-init configuration, then install Terraform manually.
 
 First, [install Multipass](https://documentation.ubuntu.com/multipass/en/latest/how-to-guides/install-multipass/). For example, on Linux with `snapd`:
 
@@ -93,24 +107,69 @@ At any point:
 Congratulations! Your cloud is ready, and thanks to the `charm-dev` cloud-init, you already have:
 - MicroK8s configured and running
 - The `juju` CLI installed
-- Terraform installed
 - A MicroK8s cloud registered with Juju
 
-On your local workstation (not the VM), create a directory for your Terraform configuration and mount it to your VM:
+Verify this in your VM:
+
+```{terminal}
+:copy:
+:user: ubuntu
+:host: my-juju-vm
+microk8s status --wait-ready
+
+microk8s is running
+```
+
+```{terminal}
+:copy:
+:user: ubuntu
+:host: my-juju-vm
+juju version
+
+3.6.0-ubuntu-amd64
+```
+
+```{terminal}
+:copy:
+:user: ubuntu
+:host: my-juju-vm
+juju clouds --client
+
+Cloud      Regions  Default    Type
+localhost  1        localhost  lxd
+microk8s   1        localhost  k8s
+```
+
+Now install Terraform in your VM:
+
+```{terminal}
+:copy:
+:user: ubuntu
+:host: my-juju-vm
+sudo snap install terraform --classic
+```
+
+Verify the installation:
+
+```{terminal}
+:copy:
+:user: ubuntu
+:host: my-juju-vm
+terraform version
+```
+
+Now, on your local workstation (not the VM), create a directory for your Terraform configuration and mount it to your VM:
 
 ```{terminal}
 :copy:
 :user:
 :host:
-mkdir ~/terraform-juju && cd ~/terraform-juju
-multipass mount ~/terraform-juju my-juju-vm:~/terraform-juju
+mkdir ~/terraform-juju && cd ~/terraform-juju && multipass mount ~/terraform-juju my-juju-vm:terraform-juju
 ```
 
-This setup will enable you to create and edit Terraform files in your local editor while running them inside your VM.
+This lets you create and edit Terraform files in your local editor while running them inside the VM.
 
-## Set up version control
-
-A key benefit of infrastructure-as-code is version control. Your infrastructure definitions become code that can be tracked, reviewed, and collaborated on.
+Now set up version control. A key benefit of infrastructure-as-code is version control -- your infrastructure definitions become code that can be tracked, reviewed, and collaborated on.
 
 On your local workstation, in your `terraform-juju` directory, initialize a git repository:
 
@@ -123,42 +182,63 @@ git init
 
 As you create and modify files in this tutorial, you'll commit them to track your infrastructure's evolution.
 
-## Set up Terraform with the Juju provider
+Before bootstrapping a controller, it's helpful to understand how the Terraform Provider for Juju works. The provider is a Juju client -- it talks to a Juju controller just like the `juju` CLI does. You define your desired infrastructure state in `.tf` files, the `terraform` CLI reads those files and uses the Juju provider plugin to communicate with a Juju controller, and the controller provisions resources and deploys applications. Your infrastructure definitions are code that can be version-controlled, reviewed, and shared with your team.
 
-The way Terraform with the Juju provider works is: you define your desired infrastructure state in `.tf` files, the `terraform` CLI reads those files and talks to a Juju controller via the `juju` provider plugin, and the controller provisions resources and deploys applications. Your infrastructure definitions are code that can be version-controlled, reviewed, and shared with your team.
+```{figure}
+:align: center
 
-Thanks to the `charm-dev` cloud-init, the `terraform` CLI is already installed in your VM. You can verify this:
+:::{mermaid}
+graph LR
+    A[.tf files<br/>Infrastructure as Code] --> B[terraform CLI]
+    B --> C[Juju Provider<br/>Juju client]
+    C --> D[Juju Controller]
+    D --> E[Cloud<br/>MicroK8s]
+    D --> F[Charmhub]
+
+    style A fill:#e1f5ff
+    style C fill:#fff3e0
+    style D fill:#f3e5f5
+:::
+
+The Terraform Provider acts as a Juju client, translating your infrastructure-as-code definitions into API calls to the Juju controller. The controller then provisions resources on the cloud and deploys charms from Charmhub.
+```
+
+Now bootstrap a Juju controller. A Juju controller is your Juju control plane -- the entity that holds the Juju API server and Juju's database. With the Terraform Provider, you can bootstrap a controller by defining it in your Terraform configuration.
+
+View the MicroK8s credentials that you'll need for your Terraform configuration:
 
 ```{terminal}
 :copy:
 :user: ubuntu
 :host: my-juju-vm
-terraform version
+juju credentials microk8s --show-secrets --format yaml
+
+client-credentials:
+  microk8s:
+    default-credential: microk8s
+    microk8s:
+      auth-type: oauth2
+      Token: eyJhbGciOiJSUzI1NiIsImtpZCI6IldBbERh...
 ```
 
-## Bootstrap a Juju controller
-
-A Juju controller is your Juju control plane -- the entity that holds the Juju API server and Juju's database. With the Terraform Provider, you can bootstrap a controller declaratively by defining it in your Terraform configuration.
-
-Thanks to the `charm-dev` cloud-init, the `juju` CLI is already installed and the MicroK8s cloud is already registered with Juju. You can verify this in your VM:
+From the output, copy the full `Token` value (it will be much longer than shown here). You'll also need the MicroK8s endpoint and CA certificate, which you can get from the kubeconfig:
 
 ```{terminal}
 :copy:
 :user: ubuntu
 :host: my-juju-vm
-juju clouds --client
+microk8s config
+
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: LS0tLS1CRUdJTi...
+    server: https://10.x.x.x:16443
+  name: microk8s-cluster
+...
 ```
 
-You should see `microk8s` listed. Now, view the MicroK8s credentials that you'll need for your Terraform configuration:
-
-```{terminal}
-:copy:
-:user: ubuntu
-:host: my-juju-vm
-juju show-credentials microk8s --show-secrets --client
-```
-
-From the output, note the values for the client certificate, client key, server certificate, and endpoint. You'll use these in your Terraform configuration.
+From the output, copy the full `certificate-authority-data` value and the `server` (endpoint) URL.
 
 Now, on your local workstation, in your `terraform-juju` directory, create your Terraform configuration files.
 
@@ -170,7 +250,7 @@ First, create `terraform.tf` to configure Terraform to use the Juju provider in 
 terraform {
   required_providers {
     juju = {
-      version = "~> 1.0.0"
+      version = "~> 1.4"
       source  = "juju/juju"
     }
   }
@@ -197,41 +277,34 @@ variable "k8s_ca_cert" {
   sensitive   = true
 }
 
-variable "k8s_client_cert" {
-  description = "MicroK8s client certificate"
-  type        = string
-  sensitive   = true
-}
-
-variable "k8s_client_key" {
-  description = "MicroK8s client key"
+variable "k8s_token" {
+  description = "MicroK8s authentication token"
   type        = string
   sensitive   = true
 }
 ```
 
-Create `terraform.tfvars` with your actual credential values (from the `juju show-credentials` output):
+Create `terraform.tfvars` with your actual credential values (from the commands above):
 
 ```{code-block} terraform
 :caption: `terraform.tfvars`
 
-k8s_endpoint    = "https://<your-microk8s-ip>:16443"
-k8s_ca_cert     = "<your-ca-certificate>"
-k8s_client_cert = "<your-client-certificate>"
-k8s_client_key  = "<your-client-key>"
+k8s_token    = "eyJhbGciOiJSUzI1NiIsImtpZCI6IldBbERh..."
+k8s_ca_cert  = "LS0tLS1CRUdJTi..."
+k8s_endpoint = "https://10.x.x.x:16443"
 ```
 
-```{important}
-**Keep credentials out of version control!** Add `terraform.tfvars` to your `.gitignore` file:
+```{note}
+The values shown above are examples only. Use your actual values from the previous commands - the token and certificate will be much longer than shown here.
+```
+
+Before continuing, keep credentials and Terraform state out of version control. On your local workstation, in your `terraform-juju` directory, create a `.gitignore` file:
 
 ```{terminal}
 :copy:
 :user:
 :host:
-echo "terraform.tfvars" >> .gitignore
-echo ".terraform*" >> .gitignore
-echo "terraform.tfstate*" >> .gitignore
-```
+echo "terraform.tfvars" >> .gitignore && echo ".terraform*" >> .gitignore && echo "terraform.tfstate*" >> .gitignore
 ```
 
 Now, create `main.tf` to define your controller:
@@ -248,7 +321,7 @@ resource "juju_controller" "microk8s" {
   cloud = {
     name       = "microk8s"
     type       = "kubernetes"
-    auth_types = ["clientcertificate"]
+    auth_types = ["oauth2"]
     endpoint   = var.k8s_endpoint
     ca_certificates = [var.k8s_ca_cert]
     host_cloud_region = "localhost"
@@ -256,10 +329,9 @@ resource "juju_controller" "microk8s" {
 
   cloud_credential = {
     name      = "microk8s-cred"
-    auth_type = "clientcertificate"
+    auth_type = "oauth2"
     attributes = {
-      "ClientCertificateData" = var.k8s_client_cert
-      "ClientKeyData"         = var.k8s_client_key
+      "Token" = var.k8s_token
     }
   }
 
@@ -272,7 +344,7 @@ resource "juju_controller" "microk8s" {
 }
 ```
 
-Notice how this declarative definition makes your infrastructure intentions clear: you want a Juju controller named "my-chat-controller" on MicroK8s with specific credentials.
+Notice how this declarative definition makes your infrastructure intentions clear: you want a Juju controller named `my-chat-controller` on MicroK8s with specific credentials.
 
 Commit your infrastructure definition (excluding sensitive files):
 
@@ -280,19 +352,29 @@ Commit your infrastructure definition (excluding sensitive files):
 :copy:
 :user:
 :host:
-git add terraform.tf variables.tf main.tf .gitignore
-git commit -m "feat: define Juju controller infrastructure"
+git add terraform.tf variables.tf main.tf .gitignore && git commit -m "feat: define Juju controller infrastructure"
 ```
 
-> **Infrastructure-as-code benefit**: Your controller infrastructure is now tracked in version control. You can see the history of changes, revert if needed, and share with your team for review.
+```{tip}
+**Infrastructure-as-code benefit**: Your controller infrastructure is now tracked in version control. You can see the history of changes, revert if needed, and share with your team for review.
+```
 
-Now, in your VM, initialize Terraform and preview your changes:
+Now, in your VM, initialize Terraform. If you exited the VM shell, reopen it:
+
+```{terminal}
+:copy:
+:user:
+:host:
+multipass shell my-juju-vm
+```
+
+Navigate to your Terraform directory and initialize:
 
 ```{terminal}
 :copy:
 :user: ubuntu
 :host: my-juju-vm
-cd ~/terraform-juju
+:dir: ~/terraform-juju
 terraform init
 ```
 
@@ -309,7 +391,9 @@ terraform plan
 
 This shows what Terraform will create without actually creating anything. Review the output carefully -- this is your opportunity to catch issues before they affect your infrastructure.
 
-> **Infrastructure-as-code benefit**: The plan step lets you (and your team) review changes before applying them. In a team setting, you'd commit your `.tf` changes, open a pull request, and have teammates review the plan output before merging and applying.
+```{tip}
+**Infrastructure-as-code benefit**: The plan step lets you (and your team) review changes before applying them. In a team setting, you'd commit your `.tf` changes, open a pull request, and have teammates review the plan output before merging and applying.
+```
 
 Apply your infrastructure definition:
 
@@ -324,8 +408,7 @@ Terraform will show you the plan again and ask for confirmation. Type `yes` to p
 
 The bootstrap process will take a few minutes. Once complete, your Juju controller is running on MicroK8s, and Terraform has recorded its state.
 
-Congratulations! You've bootstrapped a Juju controller as code.
-
+Your environment is now fully set up. You have a cloud, the necessary tools, version control, and a Juju controller -- all ready for you to define and deploy applications as code.
 
 ## Define your application infrastructure as code
 
@@ -339,7 +422,7 @@ First, update your Terraform configuration to switch from controller mode to reg
 terraform {
   required_providers {
     juju = {
-      version = "~> 1.0.0"
+      version = "~> 1.4"
       source  = "juju/juju"
     }
   }
@@ -364,7 +447,7 @@ resource "juju_controller" "microk8s" {
   cloud = {
     name       = "microk8s"
     type       = "kubernetes"
-    auth_types = ["clientcertificate"]
+    auth_types = ["oauth2"]
     endpoint   = var.k8s_endpoint
     ca_certificates = [var.k8s_ca_cert]
     host_cloud_region = "localhost"
@@ -372,10 +455,9 @@ resource "juju_controller" "microk8s" {
 
   cloud_credential = {
     name      = "microk8s-cred"
-    auth_type = "clientcertificate"
+    auth_type = "oauth2"
     attributes = {
-      "ClientCertificateData" = var.k8s_client_cert
-      "ClientKeyData"         = var.k8s_client_key
+      "Token" = var.k8s_token
     }
   }
 
@@ -496,15 +578,37 @@ Commit your application infrastructure definition:
 :copy:
 :user:
 :host:
-git add main.tf terraform.tf
-git commit -m "feat: define chat application infrastructure"
+git add main.tf terraform.tf && git commit -m "feat: define chat application infrastructure"
 ```
 
-> **Infrastructure-as-code benefit**: Your entire application infrastructure is now defined as code and tracked in version control. Anyone reviewing your git history can see exactly what applications are deployed, how they're configured, and how they integrate.
+```{tip}
+**Infrastructure-as-code benefit**: Your entire application infrastructure is now defined as code and tracked in version control. Anyone reviewing your git history can see exactly what applications are deployed, how they're configured, and how they integrate.
+```
 
 ## Deploy your application infrastructure
 
 Unlike imperative commands that execute immediately, Terraform's workflow includes a review step. You'll see what Terraform plans to do before any changes are made.
+
+```{figure}
+:align: center
+
+:::{mermaid}
+graph TB
+    A[Modify .tf files] --> B[terraform plan]
+    B --> C{Review changes}
+    C -->|Approve| D[terraform apply]
+    C -->|Revise| A
+    D --> E[Update infrastructure]
+    E --> F[Update state file]
+
+    style B fill:#e3f2fd
+    style C fill:#fff9c4
+    style D fill:#e8f5e9
+    style F fill:#fce4ec
+:::
+
+Terraform's plan-review-apply workflow ensures you always preview infrastructure changes before they're executed. This is a key infrastructure-as-code benefit for team collaboration and change management.
+```
 
 In your VM, preview the changes:
 
@@ -517,7 +621,9 @@ terraform plan
 
 This shows what Terraform will create without actually creating anything. Review the output carefully -- you'll see the model, applications, and integrations that will be created.
 
-> **Infrastructure-as-code benefit**: The plan step lets you (and your team) review changes before applying them. In a team setting, you'd commit your `.tf` changes, open a pull request, and have teammates review the plan output before merging and applying.
+```{tip}
+**Infrastructure-as-code benefit**: The plan step lets you (and your team) review changes before applying them. In a team setting, you'd commit your `.tf` changes, open a pull request, and have teammates review the plan output before merging and applying.
+```
 
 Apply your infrastructure definition:
 
@@ -558,7 +664,49 @@ Sample output:
 
 Congratulations! Your chat service is up and running, and your entire infrastructure is defined as code.
 
-> **Infrastructure-as-code benefit**: Terraform's state tracking means you can't accidentally create duplicate resources. It knows what exists and only makes necessary changes.
+```{figure}
+:align: center
+
+:::{mermaid}
+graph TB
+    subgraph "MicroK8s Cloud"
+        subgraph "Controller Model"
+            C[Juju Controller]
+        end
+
+        subgraph "Chat Model"
+            M[Mattermost<br/>mattermost-k8s/0]
+            P1[PostgreSQL<br/>postgresql-k8s/0<br/>Primary]
+            P2[PostgreSQL<br/>postgresql-k8s/1]
+            S[Self-signed Certs<br/>self-signed-certificates/0]
+
+            P1 -.db relation.-> M
+            S -.certificates relation.-> P1
+            S -.certificates relation.-> P2
+            P1 -.peer relation.-> P2
+        end
+    end
+
+    T[Terraform State] -.tracks.-> C
+    T -.tracks.-> M
+    T -.tracks.-> P1
+    T -.tracks.-> P2
+    T -.tracks.-> S
+
+    style C fill:#f3e5f5
+    style M fill:#e1f5ff
+    style P1 fill:#e8f5e9
+    style P2 fill:#e8f5e9
+    style S fill:#fff3e0
+    style T fill:#fce4ec
+:::
+
+Your deployed infrastructure: a Juju controller, a chat model with integrated applications (Mattermost, PostgreSQL with high availability, and TLS certificates), all tracked by Terraform state.
+```
+
+```{tip}
+**Infrastructure-as-code benefit**: Terraform's state tracking means you can't accidentally create duplicate resources. It knows what exists and only makes necessary changes.
+```
 
 ## Manage your infrastructure
 
@@ -597,7 +745,9 @@ terraform plan
 
 Notice Terraform detected the difference between your desired state (3 units) and actual state (2 units), and shows it will add one unit. This is the power of declarative infrastructure -- you describe what you want, and Terraform figures out how to get there.
 
-> **Infrastructure-as-code benefit**: Terraform's state tracking prevents accidental changes. It knows the current state and only makes necessary modifications to reach your desired state.
+```{tip}
+**Infrastructure-as-code benefit**: Terraform's state tracking prevents accidental changes. It knows the current state and only makes necessary modifications to reach your desired state.
+```
 
 Apply the change:
 
@@ -616,11 +766,12 @@ On your local workstation, commit your change:
 :copy:
 :user:
 :host:
-git add main.tf
-git commit -m "feat: scale postgresql to 3 units for improved availability"
+git add main.tf && git commit -m "feat: scale postgresql to 3 units for improved availability"
 ```
 
-> **Infrastructure-as-code benefit**: Your git history now shows why and when you scaled. Anyone on your team can see the evolution of your infrastructure and the reasoning behind each change (captured in commit messages).
+```{tip}
+**Infrastructure-as-code benefit**: Your git history now shows why and when you scaled. Anyone on your team can see the evolution of your infrastructure and the reasoning behind each change (captured in commit messages).
+```
 
 ## Next steps
 

--- a/docs-rtd/tutorial.md
+++ b/docs-rtd/tutorial.md
@@ -39,7 +39,7 @@ You'll be working across two contexts: your local workstation and a VM. To work 
 
 To work with the Terraform Provider for Juju, you'll need:
 - A cloud (MicroK8s for this tutorial)
-- The `juju` CLI (to extract cloud credentials)
+- The `juju` CLI (to extract cloud credentials and to bootstrap controllers -- the Terraform provider calls `juju` commands in the background)
 - The `terraform` CLI (to run your infrastructure-as-code definitions)
 - A Juju controller (which you'll bootstrap with Terraform)
 
@@ -158,6 +158,24 @@ Verify the installation:
 terraform version
 ```
 
+The Terraform Provider for Juju works by calling the `juju` CLI in the background. When you run `terraform apply`, Terraform will call `juju bootstrap`, and Juju needs MicroK8s credentials to connect to your cluster. Copy the credentials to where Juju expects to find them when called by Terraform:
+
+```{terminal}
+:copy:
+:user: ubuntu
+:host: my-juju-vm
+sudo sh -c "mkdir -p /var/snap/terraform/current/microk8s/credentials" && sudo sh -c "microk8s config | tee /var/snap/terraform/current/microk8s/credentials/client.config" && sudo chown -f -R $USER:$USER /var/snap/terraform/current/microk8s/credentials/client.config
+```
+
+```{dropdown} Why is this necessary?
+
+Both Terraform and Juju are installed as snaps. When snap-installed Terraform calls snap-installed Juju, Juju looks for MicroK8s credentials in Terraform's snap storage directory (`/var/snap/terraform/current/`), not in MicroK8s's own directory.
+
+Since MicroK8s was installed by charm-dev and is not strictly confined, its credentials aren't automatically shared with the Terraform snap. This command copies the credentials to where Terraform's Juju can find them.
+
+This is the same credential-sharing pattern used in Juju's documentation when working with non-strictly-confined MicroK8s.
+```
+
 Now, on your local workstation (not the VM), create a directory for your Terraform configuration and mount it to your VM:
 
 ```{terminal}
@@ -181,6 +199,25 @@ git init
 ```
 
 As you create and modify files in this tutorial, you'll commit them to track your infrastructure's evolution.
+
+Create two subdirectories to organize your infrastructure:
+
+```{terminal}
+:copy:
+:user:
+:host:
+mkdir 1-bootstrap 2-deploy
+```
+
+```{note}
+**Why two directories?**
+
+The Terraform Juju provider has a `controller_mode` setting that determines which resources you can manage:
+- When `controller_mode = true`: You can ONLY manage `juju_controller` resources (to bootstrap controllers)
+- When `controller_mode = false` (or omitted): You can manage everything EXCEPT `juju_controller` resources (models, applications, integrations, etc.)
+
+This design requires separating controller bootstrap from application deployment into two distinct Terraform configurations. This tutorial uses `1-bootstrap/` for the controller and `2-deploy/` for your applications.
+```
 
 Before bootstrapping a controller, it's helpful to understand how the Terraform Provider for Juju works. The provider is a Juju client -- it talks to a Juju controller just like the `juju` CLI does. You define your desired infrastructure state in `.tf` files, the `terraform` CLI reads those files and uses the Juju provider plugin to communicate with a Juju controller, and the controller provisions resources and deploys applications. Your infrastructure definitions are code that can be version-controlled, reviewed, and shared with your team.
 
@@ -240,12 +277,14 @@ clusters:
 
 From the output, copy the full `certificate-authority-data` value and the `server` (endpoint) URL.
 
-Now, on your local workstation, in your `terraform-juju` directory, create your Terraform configuration files.
+## Bootstrap a controller
 
-First, create `terraform.tf` to configure Terraform to use the Juju provider in controller mode:
+Now, on your local workstation, create your controller bootstrap configuration in the `1-bootstrap/` directory.
+
+First, create `1-bootstrap/terraform.tf` to configure Terraform to use the Juju provider in controller mode:
 
 ```{code-block} terraform
-:caption: `terraform.tf`
+:caption: `1-bootstrap/terraform.tf`
 
 terraform {
   required_providers {
@@ -261,10 +300,14 @@ provider "juju" {
 }
 ```
 
-Next, create `variables.tf` to define variables for your sensitive credentials:
+```{important}
+Notice `controller_mode = true`. This setting restricts the provider to only managing `juju_controller` resources. You cannot define models, applications, or integrations in this configuration.
+```
+
+Next, create `1-bootstrap/variables.tf` to define variables for your sensitive credentials:
 
 ```{code-block} terraform
-:caption: `variables.tf`
+:caption: `1-bootstrap/variables.tf`
 
 variable "k8s_endpoint" {
   description = "MicroK8s API endpoint"
@@ -284,10 +327,10 @@ variable "k8s_token" {
 }
 ```
 
-Create `terraform.tfvars` with your actual credential values (from the commands above):
+Create `1-bootstrap/terraform.tfvars` with your actual credential values (from the commands above):
 
 ```{code-block} terraform
-:caption: `terraform.tfvars`
+:caption: `1-bootstrap/terraform.tfvars`
 
 k8s_token    = "eyJhbGciOiJSUzI1NiIsImtpZCI6IldBbERh..."
 k8s_ca_cert  = "LS0tLS1CRUdJTi..."
@@ -298,24 +341,23 @@ k8s_endpoint = "https://10.x.x.x:16443"
 The values shown above are examples only. Use your actual values from the previous commands - the token and certificate will be much longer than shown here.
 ```
 
-Before continuing, keep credentials and Terraform state out of version control. On your local workstation, in your `terraform-juju` directory, create a `.gitignore` file:
+Before continuing, keep credentials and Terraform state out of version control. On your local workstation, create a `.gitignore` file in the `1-bootstrap/` directory:
 
 ```{terminal}
 :copy:
 :user:
 :host:
-echo "terraform.tfvars" >> .gitignore && echo ".terraform*" >> .gitignore && echo "terraform.tfstate*" >> .gitignore
+echo "terraform.tfvars" >> 1-bootstrap/.gitignore && echo ".terraform*" >> 1-bootstrap/.gitignore && echo "terraform.tfstate*" >> 1-bootstrap/.gitignore
 ```
 
-Now, create `main.tf` to define your controller:
+Now, create `1-bootstrap/main.tf` to define your controller:
 
 ```{code-block} terraform
-:caption: `main.tf`
+:caption: `1-bootstrap/main.tf`
 
 resource "juju_controller" "microk8s" {
   name = "my-chat-controller"
 
-  # Use the snap-installed juju binary to avoid confinement issues
   juju_binary = "/snap/juju/current/bin/juju"
 
   cloud = {
@@ -346,20 +388,20 @@ resource "juju_controller" "microk8s" {
 
 Notice how this declarative definition makes your infrastructure intentions clear: you want a Juju controller named `my-chat-controller` on MicroK8s with specific credentials.
 
-Commit your infrastructure definition (excluding sensitive files):
+Commit your controller infrastructure definition (excluding sensitive files):
 
 ```{terminal}
 :copy:
 :user:
 :host:
-git add terraform.tf variables.tf main.tf .gitignore && git commit -m "feat: define Juju controller infrastructure"
+git add 1-bootstrap && git commit -m "feat: define Juju controller infrastructure"
 ```
 
 ```{tip}
 **Infrastructure-as-code benefit**: Your controller infrastructure is now tracked in version control. You can see the history of changes, revert if needed, and share with your team for review.
 ```
 
-Now, in your VM, initialize Terraform. If you exited the VM shell, reopen it:
+Now, in your VM, initialize Terraform in the bootstrap directory. If you exited the VM shell, reopen it:
 
 ```{terminal}
 :copy:
@@ -368,14 +410,14 @@ Now, in your VM, initialize Terraform. If you exited the VM shell, reopen it:
 multipass shell my-juju-vm
 ```
 
-Navigate to your Terraform directory and initialize:
+Navigate to your bootstrap directory and initialize:
 
 ```{terminal}
 :copy:
 :user: ubuntu
 :host: my-juju-vm
 :dir: ~/terraform-juju
-terraform init
+cd 1-bootstrap && terraform init
 ```
 
 This downloads the Juju provider plugin and prepares your workspace.
@@ -386,10 +428,11 @@ Preview what Terraform will create:
 :copy:
 :user: ubuntu
 :host: my-juju-vm
+:dir: ~/terraform-juju/1-bootstrap
 terraform plan
 ```
 
-This shows what Terraform will create without actually creating anything. Review the output carefully -- this is your opportunity to catch issues before they affect your infrastructure.
+This shows what Terraform will create without actually creating anything. Review the output carefully -- you'll see the controller resource that will be created.
 
 ```{tip}
 **Infrastructure-as-code benefit**: The plan step lets you (and your team) review changes before applying them. In a team setting, you'd commit your `.tf` changes, open a pull request, and have teammates review the plan output before merging and applying.
@@ -401,6 +444,7 @@ Apply your infrastructure definition:
 :copy:
 :user: ubuntu
 :host: my-juju-vm
+:dir: ~/terraform-juju/1-bootstrap
 terraform apply
 ```
 
@@ -408,16 +452,18 @@ Terraform will show you the plan again and ask for confirmation. Type `yes` to p
 
 The bootstrap process will take a few minutes. Once complete, your Juju controller is running on MicroK8s, and Terraform has recorded its state.
 
-Your environment is now fully set up. You have a cloud, the necessary tools, version control, and a Juju controller -- all ready for you to define and deploy applications as code.
+Your controller is now bootstrapped and ready. Next, you'll define and deploy applications.
 
 ## Define your application infrastructure as code
 
-With your controller bootstrapped, now define the applications that make up your chat service. You'll deploy Mattermost for the chat service, PostgreSQL for its backing database, and self-signed certificates to TLS-encrypt traffic from PostgreSQL.
+With your controller bootstrapped, now define the applications that make up your chat service in a separate configuration. You'll deploy Mattermost for the chat service, PostgreSQL for its backing database, and self-signed certificates to TLS-encrypt traffic from PostgreSQL.
 
-First, update your Terraform configuration to switch from controller mode to regular mode. On your local workstation, in `terraform.tf`, remove the `controller_mode` setting and configure the provider to use your bootstrapped controller:
+On your local workstation, create your application deployment configuration in the `2-deploy/` directory.
+
+First, create `2-deploy/terraform.tf` to configure the provider without `controller_mode`:
 
 ```{code-block} terraform
-:caption: `terraform.tf`
+:caption: `2-deploy/terraform.tf`
 
 terraform {
   required_providers {
@@ -429,57 +475,37 @@ terraform {
 }
 
 provider "juju" {
-  # The provider will automatically use the controller bootstrapped by Terraform
-  # by reading from the terraform state
+  # Connect to the bootstrapped controller
+  # The provider will discover the controller automatically
 }
 ```
 
-Now, update `main.tf` to add your application resources. Replace the entire contents with:
+```{important}
+Notice there's no `controller_mode` setting (it defaults to `false`). This configuration can manage models, applications, and integrations, but cannot manage `juju_controller` resources.
+```
+
+Create a `.gitignore` file for this directory:
+
+```{terminal}
+:copy:
+:user:
+:host:
+echo ".terraform*" >> 2-deploy/.gitignore && echo "terraform.tfstate*" >> 2-deploy/.gitignore
+```
+
+Now, create `2-deploy/main.tf` to define your application resources:
 
 ```{code-block} terraform
-:caption: `main.tf`
-
-resource "juju_controller" "microk8s" {
-  name = "my-chat-controller"
-
-  juju_binary = "/snap/juju/current/bin/juju"
-
-  cloud = {
-    name       = "microk8s"
-    type       = "kubernetes"
-    auth_types = ["oauth2"]
-    endpoint   = var.k8s_endpoint
-    ca_certificates = [var.k8s_ca_cert]
-    host_cloud_region = "localhost"
-  }
-
-  cloud_credential = {
-    name      = "microk8s-cred"
-    auth_type = "oauth2"
-    attributes = {
-      "Token" = var.k8s_token
-    }
-  }
-
-  lifecycle {
-    ignore_changes = [
-      cloud.region,
-      cloud.host_cloud_region
-    ]
-  }
-}
+:caption: `2-deploy/main.tf`
 
 # Define the workspace for your applications
 resource "juju_model" "chat" {
   name = "chat"
-
-  # Ensure the controller is bootstrapped first
-  depends_on = [juju_controller.microk8s]
 }
 
 # Define the chat application
 resource "juju_application" "mattermost-k8s" {
-  model = juju_model.chat.name
+  model_uuid = juju_model.chat.uuid
 
   charm {
     name = "mattermost-k8s"
@@ -488,7 +514,7 @@ resource "juju_application" "mattermost-k8s" {
 
 # Define the database with high availability
 resource "juju_application" "postgresql-k8s" {
-  model = juju_model.chat.name
+  model_uuid = juju_model.chat.uuid
 
   charm {
     name    = "postgresql-k8s"
@@ -505,7 +531,7 @@ resource "juju_application" "postgresql-k8s" {
 
 # Define the TLS certificate provider
 resource "juju_application" "self-signed-certificates" {
-  model = juju_model.chat.name
+  model_uuid = juju_model.chat.uuid
 
   charm {
     name = "self-signed-certificates"
@@ -514,7 +540,7 @@ resource "juju_application" "self-signed-certificates" {
 
 # Integrate PostgreSQL with Mattermost
 resource "juju_integration" "postgresql-mattermost" {
-  model = juju_model.chat.name
+  model_uuid = juju_model.chat.uuid
 
   application {
     name     = juju_application.postgresql-k8s.name
@@ -528,12 +554,12 @@ resource "juju_integration" "postgresql-mattermost" {
   lifecycle {
     replace_triggered_by = [
       juju_application.postgresql-k8s.name,
-      juju_application.postgresql-k8s.model,
+      juju_application.postgresql-k8s.model_uuid,
       juju_application.postgresql-k8s.constraints,
       juju_application.postgresql-k8s.placement,
       juju_application.postgresql-k8s.charm.name,
       juju_application.mattermost-k8s.name,
-      juju_application.mattermost-k8s.model,
+      juju_application.mattermost-k8s.model_uuid,
       juju_application.mattermost-k8s.constraints,
       juju_application.mattermost-k8s.placement,
       juju_application.mattermost-k8s.charm.name,
@@ -543,25 +569,27 @@ resource "juju_integration" "postgresql-mattermost" {
 
 # Integrate PostgreSQL with TLS certificates
 resource "juju_integration" "postgresql-tls" {
-  model = juju_model.chat.name
+  model_uuid = juju_model.chat.uuid
 
   application {
-    name = juju_application.postgresql-k8s.name
+    name     = juju_application.postgresql-k8s.name
+    endpoint = "certificates"
   }
 
   application {
-    name = juju_application.self-signed-certificates.name
+    name     = juju_application.self-signed-certificates.name
+    endpoint = "certificates"
   }
 
   lifecycle {
     replace_triggered_by = [
       juju_application.postgresql-k8s.name,
-      juju_application.postgresql-k8s.model,
+      juju_application.postgresql-k8s.model_uuid,
       juju_application.postgresql-k8s.constraints,
       juju_application.postgresql-k8s.placement,
       juju_application.postgresql-k8s.charm.name,
       juju_application.self-signed-certificates.name,
-      juju_application.self-signed-certificates.model,
+      juju_application.self-signed-certificates.model_uuid,
       juju_application.self-signed-certificates.constraints,
       juju_application.self-signed-certificates.placement,
       juju_application.self-signed-certificates.charm.name,
@@ -572,13 +600,19 @@ resource "juju_integration" "postgresql-tls" {
 
 Notice how this declarative definition makes your infrastructure intentions clear: you want a chat model with Mattermost, PostgreSQL (with 2 units for high availability), TLS certificates, and specific integrations between them.
 
+```{note}
+Notice the use of `model_uuid` instead of `model` for applications. This ensures Terraform uses the UUID reference, which is more reliable than name-based references.
+
+Also notice the explicit `endpoint` values in the TLS integration -- this ensures the correct relation endpoints are used.
+```
+
 Commit your application infrastructure definition:
 
 ```{terminal}
 :copy:
 :user:
 :host:
-git add main.tf terraform.tf && git commit -m "feat: define chat application infrastructure"
+git add 2-deploy && git commit -m "feat: define chat application infrastructure"
 ```
 
 ```{tip}
@@ -610,12 +644,21 @@ graph TB
 Terraform's plan-review-apply workflow ensures you always preview infrastructure changes before they're executed. This is a key infrastructure-as-code benefit for team collaboration and change management.
 ```
 
-In your VM, preview the changes:
+In your VM, navigate to the deployment directory, initialize, and preview the changes:
 
 ```{terminal}
 :copy:
 :user: ubuntu
 :host: my-juju-vm
+:dir: ~/terraform-juju/1-bootstrap
+cd ../2-deploy && terraform init
+```
+
+```{terminal}
+:copy:
+:user: ubuntu
+:host: my-juju-vm
+:dir: ~/terraform-juju/2-deploy
 terraform plan
 ```
 
@@ -631,6 +674,7 @@ Apply your infrastructure definition:
 :copy:
 :user: ubuntu
 :host: my-juju-vm
+:dir: ~/terraform-juju/2-deploy
 terraform apply
 ```
 
@@ -712,13 +756,13 @@ Your deployed infrastructure: a Juju controller, a chat model with integrated ap
 
 A key benefit of infrastructure-as-code is that the same workflow handles all changes. Let's scale your PostgreSQL database for improved availability.
 
-On your local workstation, in `main.tf`, modify the `postgresql-k8s` resource to change `units` from `2` to `3`:
+On your local workstation, in `2-deploy/main.tf`, modify the `postgresql-k8s` resource to change `units` from `2` to `3`:
 
 ```{code-block} terraform
-:caption: `main.tf`
+:caption: `2-deploy/main.tf` (partial)
 
 resource "juju_application" "postgresql-k8s" {
-  model = juju_model.chat.name
+  model_uuid = juju_model.chat.uuid
 
   charm {
     name    = "postgresql-k8s"
@@ -740,6 +784,7 @@ In your VM, preview the change:
 :copy:
 :user: ubuntu
 :host: my-juju-vm
+:dir: ~/terraform-juju/2-deploy
 terraform plan
 ```
 
@@ -755,6 +800,7 @@ Apply the change:
 :copy:
 :user: ubuntu
 :host: my-juju-vm
+:dir: ~/terraform-juju/2-deploy
 terraform apply
 ```
 
@@ -766,7 +812,7 @@ On your local workstation, commit your change:
 :copy:
 :user:
 :host:
-git add main.tf && git commit -m "feat: scale postgresql to 3 units for improved availability"
+git add 2-deploy/main.tf && git commit -m "feat: scale postgresql to 3 units for improved availability"
 ```
 
 ```{tip}
@@ -789,18 +835,31 @@ You've experienced the core infrastructure-as-code workflow with the Terraform P
 
 With Terraform, tearing down your infrastructure is as simple as deploying it.
 
-In your VM, destroy all Terraform-managed infrastructure:
+In your VM, destroy the application infrastructure first, then the controller. Start with the deployment directory:
 
 ```{terminal}
 :copy:
 :user: ubuntu
 :host: my-juju-vm
+:dir: ~/terraform-juju/2-deploy
 terraform destroy
 ```
 
 Terraform will show you everything it will remove and ask for confirmation. Type `yes` to proceed.
 
-This removes all infrastructure Terraform created: applications, integrations, model, and controller. Notice how Terraform maintains consistency -- it knows exactly what it created from the state, so it can cleanly remove everything.
+This removes the applications, integrations, and model. Now destroy the controller:
+
+```{terminal}
+:copy:
+:user: ubuntu
+:host: my-juju-vm
+:dir: ~/terraform-juju/2-deploy
+cd ../1-bootstrap && terraform destroy
+```
+
+Type `yes` to confirm. This removes the Juju controller.
+
+Notice how Terraform maintains consistency -- it knows exactly what it created from the state in each directory, so it can cleanly remove everything.
 
 Exit the VM:
 

--- a/docs-rtd/tutorial.md
+++ b/docs-rtd/tutorial.md
@@ -53,7 +53,7 @@ This step may take a few minutes to complete (e.g., 10 mins).
 
 This is because the command downloads, installs, (updates,) and configures a number of packages (including MicroK8s, the `juju` CLI, Terraform, and development tools), and the speed will be affected by network bandwidth.
 
-However, once it's done, you'll have everything you'll need -- all in a nice isolated environment that you can clean up easily.
+You'll have everything you need in an isolated environment.
 ```
 
 ```{terminal}
@@ -353,7 +353,7 @@ k8s_endpoint = "https://10.x.x.x:16443"
 The values shown above are examples only. Use your actual values from the previous commands -- the token and certificate will be much longer than shown here.
 ```
 
-Before continuing, keep credentials and Terraform state out of version control:
+Before continuing, keep credentials and Terraform state safe and out of version control:
 
 ```{terminal}
 :copy:


### PR DESCRIPTION
## Description

Restructures the Terraform Provider tutorial to emphasize infrastructure-as-code workflows and use Terraform for controller bootstrap. The tutorial now:

- **What**: Complete rewrite positioning the provider as an IaC tool with TF-driven controller bootstrap
- **Why**: Original tutorial positioned TF as "another interface to Juju" rather than highlighting IaC benefits
- **How**: Uses `controller_mode = true` with `juju_controller` resource, charm-dev cloud-init for automated setup, OAuth2 authentication, and integrates git commits throughout
- **When**: Aligns with Juju's main tutorial paradigm introduced in recent documentation updates

Key changes:
- IaC-first narrative throughout
- Terraform bootstrap via `controller_mode = true` and `juju_controller` resource
- Automated environment setup using charm-dev cloud-init
- OAuth2 Token-based authentication (matches charm-dev setup)
- Two-terminal workflow guidance for better UX
- Three Mermaid diagrams (architecture, workflow, deployment)
- Version control demonstrations with git commits

Also updated [howto/manage-controllers.md](docs-rtd/howto/manage-controllers.md) to cover both oauth2 and clientcertificate auth types.

Fixes: #N/A (documentation improvement)

## Type of change

- Requires a documentation update
- Other (complete tutorial restructure)

## Environment

- Juju controller version: 3.6/stable (via charm-dev cloud-init)
- Terraform version: Latest stable via snap
- Terraform Provider for Juju: ~> 1.4

## QA steps

Follow the tutorial end-to-end on Ubuntu (tested on 24.04):

1. Install multipass
2. Launch VM with charm-dev cloud-init
3. Create `.tf` files locally as documented
4. Run `terraform init`, `terraform plan`, `terraform apply` in VM
5. Verify Mattermost deployment
6. Test scaling workflow
7. Run `terraform destroy`

Key files to create:

```tf
# terraform.tf
terraform {
  required_providers {
    juju = {
      version = "~> 1.4"
      source  = "juju/juju"
    }
  }
}

provider "juju" {
  controller_mode = true
}
```

```tf
# main.tf (controller resource)
resource "juju_controller" "microk8s" {
  name = "my-chat-controller"
  juju_binary = "/snap/juju/current/bin/juju"
  
  cloud = {
    name       = "microk8s"
    type       = "kubernetes"
    auth_types = ["oauth2"]
    endpoint   = var.k8s_endpoint
    ca_certificates = [var.k8s_ca_cert]
    host_cloud_region = "localhost"
  }

  cloud_credential = {
    name      = "microk8s-cred"
    auth_type = "oauth2"
    attributes = {
      "Token" = var.k8s_token
    }
  }
}
```

## Additional notes

- Fixed multipass mount command (was using `~/terraform-juju`, now uses `terraform-juju`)
- Updated provider version from `~> 1.5` to `~> 1.4` (latest stable)
- Tutorial tested end-to-end successfully
