### PR TITLE
feat: introduced a juju_bootstrap Terraform module and Terragrunt unit

### DIFF
--- a/.github/workflows/test_terragrunt_bootstrap.yml
+++ b/.github/workflows/test_terragrunt_bootstrap.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Install Terragrunt
         run: |
-          curl -sSfL --proto '=https' --tlsv1.2 https://terragrunt.com/install | bash
+          curl -sSfL --proto '=https' --tlsv1.2 https://terragrunt.com/install | bash -s -- -v v1.0.5
           echo "$HOME/.terragrunt/bin" >> $GITHUB_PATH
 
       - name: Terragrunt apply

--- a/.github/workflows/test_terragrunt_bootstrap.yml
+++ b/.github/workflows/test_terragrunt_bootstrap.yml
@@ -1,0 +1,64 @@
+name: Terragrunt LXD bootstrap test
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  terragrunt-lxd-bootstrap:
+    name: Terragrunt LXD bootstrap
+    runs-on: ubuntu-22.04
+    env:
+      ACTIONS_ALLOW_IPV6: false
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
+          cache: true
+
+      # Set up LXD and bootstrap a throw-away Juju controller so that
+      # the Juju client has LXD certificate credentials stored locally.
+      - name: Setup LXD and Juju
+        uses: charmed-kubernetes/actions-operator@main
+        with:
+          provider: lxd
+          channel: "6"
+          juju-channel: "3/stable"
+          lxd-channel: "5.21/stable"
+
+      # Extract the LXD certificate credentials from the Juju client store
+      # into ~/lxd-credentials.yaml for use by the module.
+      - name: Create LXD credentials file
+        run: ./tools/create_lxd_config.sh
+
+      - name: Build and install provider
+        run: make install
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.14.*"
+          terraform_wrapper: false
+
+      - name: Install Terragrunt
+        run: |
+          curl -sSfL --proto '=https' --tlsv1.2 https://terragrunt.com/install | bash
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Terragrunt apply
+        run: terragrunt apply --auto-approve
+        working-directory: terragrunt/examples/lxd-ci
+
+      - name: Terragrunt destroy
+        if: always()
+        run: terragrunt destroy --auto-approve
+        working-directory: terragrunt/examples/lxd-ci

--- a/.github/workflows/test_terragrunt_bootstrap.yml
+++ b/.github/workflows/test_terragrunt_bootstrap.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Install Terragrunt
         run: |
           curl -sSfL --proto '=https' --tlsv1.2 https://terragrunt.com/install | bash
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          echo "$HOME/.terragrunt/bin" >> $GITHUB_PATH
 
       - name: Terragrunt apply
         run: terragrunt apply --auto-approve

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ modules-dev/
 *.backup
 ./*.tfstate
 .terraform*
+.terragrunt-cache/
 *.log
 *.bak
 *~

--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,3 @@ vendor/
 __debug_bin
 test.env
 /tmp
-modules/

--- a/modules/juju_bootstrap/README.md
+++ b/modules/juju_bootstrap/README.md
@@ -28,10 +28,10 @@ module "juju_bootstrap_example" {
     auth_types = ["certificate"]
     name       = "lxd-cloud"
     type       = "lxd"
-    endpoint   = "https://10.0.0.1:8383"
+    endpoint   = "https://10.0.0.1:8443"
     region = {
       name     = "default"
-      endpoint = "https://10.0.0.1:8383"
+      endpoint = "https://10.0.0.1:8443"
     }
   }
 

--- a/modules/juju_bootstrap/README.md
+++ b/modules/juju_bootstrap/README.md
@@ -1,0 +1,107 @@
+# juju_bootstrap module
+
+This module bootstraps a Juju controller and optionally enables high availability (HA).
+
+## What it does
+
+- Configures the `juju` provider in `controller_mode`.
+- Creates a `juju_controller` resource with configurable cloud, credential, and bootstrap settings.
+- Optionally runs `juju enable-ha` using a local-exec provisioner when `controller_num_units > 0`.
+
+## Requirements
+
+- Terraform/OpenTofu compatible with the module syntax used here.
+- Juju provider: `juju/juju ~> 1.0`.
+- `juju` CLI available on the machine running apply.
+
+## Usage
+
+### LXD cloud
+
+```hcl
+module "juju_bootstrap_example" {
+  source = "/path/to/module"
+
+  name = "my-controller"
+
+  cloud = {
+    auth_types = ["certificate"]
+    name       = "lxd-cloud"
+    type       = "lxd"
+    endpoint   = "https://10.0.0.1:8383"
+    region = {
+      name     = "default"
+      endpoint = "https://10.0.0.1:8383"
+    }
+  }
+
+  cloud_credential = {
+    auth_type = "interactive"
+    name      = "lxd-token"
+    attributes = {
+      trust-token = trimspace(file("/path/to/token"))
+    }
+  }
+
+  controller_num_units = 3
+}
+```
+
+### MAAS cloud
+
+```hcl
+module "juju_bootstrap_example" {
+  source = "/path/to/module"
+
+  name = "my-controller"
+
+  cloud_details = {
+    auth_types = ["oauth1"]
+    type     = "maas"
+    name     = "maas-cloud"
+    endpoint  = "http://10.0.0.1:5240/MAAS/"
+    api_key  = trimspace(file("/path/to/maas_api_key"))
+  }
+
+  cloud_credential = {
+    auth_type = "oauth1"
+    name      = "maas-creds"
+    attributes = {
+      maas-oauth  = trimspace(file("/path/to/maas_api_key"))
+      }
+    }
+
+  controller_num_units = 3
+}
+```
+
+## Inputs
+
+| Name | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `name` | `string` | Yes | n/a | Name of the Juju controller to bootstrap. |
+| `cloud` | `object(...)` | Yes | n/a | Cloud definition used for bootstrap. |
+| `cloud_credential` | `object(...)` | Yes | n/a | Credential used for bootstrap on the target cloud. |
+| `controller_num_units` | `number` | Yes | n/a | Number of controller units to deploy. If greater than `0`, HA enablement runs. |
+| `path_juju_binary` | `string` | No | `/snap/juju/current/bin/juju` | Path to Juju binary. |
+| `agent_version` | `string` | No | `null` | Juju agent version to use. |
+| `bootstrap_base` | `string` | No | `null` | Bootstrap base for controller machine. |
+| `bootstrap_config` | `map(string)` | No | `null` | Bootstrap configuration values. |
+| `bootstrap_constraints` | `map(string)` | No | `null` | Bootstrap constraints. |
+| `controller_config` | `map(string)` | No | `null` | Controller configuration. |
+| `controller_model_config` | `map(string)` | No | `null` | Controller model configuration. |
+| `destroy_flags` | `object(...)` | No | `{ destroy_all_models = true, destroy_storage = true }` | Flags for `juju destroy-controller`. |
+| `model_constraints` | `map(string)` | No | `null` | Constraints for all models. |
+| `model_default` | `map(string)` | No | `null` | Default values for all models. |
+| `storage_pool` | `object(...)` | No | `null` | Storage pool definition for the controller. |
+
+## Outputs
+
+| Name | Sensitive | Description |
+| --- | --- | --- |
+| `juju_cloud` | No | Cloud name used by the created controller. |
+| `juju_credentials` | Yes | Controller API addresses, username, password, and CA certificate. |
+
+## Notes
+
+- HA enablement is implemented with `terraform_data` + `local-exec` and Juju CLI commands as oppoed to Terraform actions to ensure compatibility with OpenTofu.

--- a/modules/juju_bootstrap/README.md
+++ b/modules/juju_bootstrap/README.md
@@ -121,7 +121,7 @@ EOT
 | Name | Sensitive | Description |
 | --- | --- | --- |
 | `juju_cloud` | No | Cloud name used by the created controller. |
-| `juju_credentials` | Yes | Controller API addresses, username, password, and CA certificate. |
+| `juju_controller` | Yes | Controller API addresses, username, password, and CA certificate. |
 
 ## Notes
 

--- a/modules/juju_bootstrap/README.md
+++ b/modules/juju_bootstrap/README.md
@@ -11,7 +11,7 @@ This module bootstraps a Juju controller and optionally enables high availabilit
 ## Requirements
 
 - Terraform/OpenTofu 1.12+.
-- Juju provider: `juju/juju ~> 1.3`.
+- Juju provider: `juju/juju > 1.3`.
 - `juju` CLI available on the machine running apply.
 
 ## Usage
@@ -103,7 +103,7 @@ EOT
 | `name` | `string` | Yes | n/a | Name of the Juju controller to bootstrap. |
 | `cloud` | `object(...)` | Yes | n/a | Cloud definition used for bootstrap. |
 | `cloud_credential` | `object(...)` | Yes | n/a | Credential used for bootstrap on the target cloud. |
-| `controller_num_units` | `number` | Yes | n/a | Number of controller units to deploy. If greater than `0`, HA enablement runs. |
+| `controller_num_units` | `number` | Yes | n/a | Number of controller units to deploy. If greater than `1`, HA enablement runs. |
 | `path_juju_binary` | `string` | No | `/snap/juju/current/bin/juju` | Path to Juju binary. |
 | `agent_version` | `string` | No | `null` | Juju agent version to use. |
 | `bootstrap_base` | `string` | No | `null` | Bootstrap base for controller machine. |

--- a/modules/juju_bootstrap/README.md
+++ b/modules/juju_bootstrap/README.md
@@ -10,8 +10,8 @@ This module bootstraps a Juju controller and optionally enables high availabilit
 
 ## Requirements
 
-- Terraform/OpenTofu compatible with the module syntax used here.
-- Juju provider: `juju/juju ~> 1.0`.
+- Terraform/OpenTofu 1.12+.
+- Juju provider: `juju/juju ~> 1.3`.
 - `juju` CLI available on the machine running apply.
 
 ## Usage
@@ -75,6 +75,27 @@ module "juju_bootstrap_example" {
 }
 ```
 
+### Example of controller_model_config or model_default
+```
+controller_model_config = {
+  default-base = "ubuntu@22.04"
+  lxd-snap-channel = "5.0/stable"
+  cloudinit-userdata = <<EOT
+#cloud-config
+
+ca-certs:
+  trusted:
+  - |
+    -----BEGIN CERTIFICATE-----
+    ROOT CA
+    -----END CERTIFICATE-----
+    -----BEGIN CERTIFICATE-----
+    INTERMEDIATE CA
+    -----END CERTIFICATE-----
+EOT
+}
+```
+
 ## Inputs
 
 | Name | Type | Required | Default | Description |
@@ -104,4 +125,4 @@ module "juju_bootstrap_example" {
 
 ## Notes
 
-- HA enablement is implemented with `terraform_data` + `local-exec` and Juju CLI commands as oppoed to Terraform actions to ensure compatibility with OpenTofu.
+- HA enablement is implemented with `terraform_data` + `local-exec` and Juju CLI commands as oppoed to Terraform actions to ensure compatibility with OpenTofu as actions are not yet supported. See https://github.com/opentofu/opentofu/issues/3309.

--- a/modules/juju_bootstrap/main.tf
+++ b/modules/juju_bootstrap/main.tf
@@ -24,7 +24,7 @@ resource "juju_controller" "controller" {
 # TODO: Terraform actions are available to enable HA, however actions are not yet supported by OpenTofu, thus we stick with local-exec for now.
 # https://documentation.ubuntu.com/terraform-provider-juju/v1.4.3/howto/manage-controllers/#enable-controller-high-availability
 resource "terraform_data" "juju_enable_ha" {
-  count = var.controller_num_units > 0 ? 1 : 0
+  count = var.controller_num_units > 1 ? 1 : 0
   provisioner "local-exec" {
     command = <<-EOT
       echo "$JUJU_PASSWORD" | juju login -c "$CONTROLLER_NAME" "$JUJU_CONTROLLER" -u "$JUJU_USERNAME" --trust --no-prompt

--- a/modules/juju_bootstrap/main.tf
+++ b/modules/juju_bootstrap/main.tf
@@ -1,0 +1,42 @@
+provider "juju" {
+  controller_mode = true
+}
+
+resource "juju_controller" "controller" {
+  juju_binary = var.path_juju_binary
+  name        = var.name
+
+  cloud            = var.cloud
+  cloud_credential = var.cloud_credential
+
+  agent_version           = var.agent_version
+  bootstrap_base          = var.bootstrap_base
+  bootstrap_config        = var.bootstrap_config
+  bootstrap_constraints   = var.bootstrap_constraints
+  controller_config       = var.controller_config
+  controller_model_config = var.controller_model_config
+  destroy_flags           = var.destroy_flags
+  model_constraints       = var.model_constraints
+  model_default           = var.model_default
+  storage_pool            = var.storage_pool
+}
+
+# TODO: Terraform actions are available to enable HA, however actions are not yet supported by OpenTofu, thus we stick with local-exec for now.
+# https://documentation.ubuntu.com/terraform-provider-juju/v1.4.3/howto/manage-controllers/#enable-controller-high-availability
+resource "terraform_data" "juju_enable_ha" {
+  count = var.controller_num_units > 0 ? 1 : 0
+  provisioner "local-exec" {
+    command = <<-EOT
+      echo "$JUJU_PASSWORD" | juju login -c "$CONTROLLER_NAME" "$JUJU_CONTROLLER" -u "$JUJU_USERNAME" --trust --no-prompt
+      juju enable-ha -c "$CONTROLLER_NAME" -n "$HA_COUNT"
+      juju wait-for model "$CONTROLLER_NAME":controller --timeout 3600s --query='forEach(units, unit => (unit.workload-status == "active"))'
+    EOT
+    environment = {
+      CONTROLLER_NAME = juju_controller.controller.name
+      JUJU_CONTROLLER = juju_controller.controller.api_addresses[0]
+      JUJU_USERNAME   = juju_controller.controller.username
+      JUJU_PASSWORD   = juju_controller.controller.password
+      HA_COUNT        = var.controller_num_units
+    }
+  }
+}

--- a/modules/juju_bootstrap/outputs.tf
+++ b/modules/juju_bootstrap/outputs.tf
@@ -2,7 +2,7 @@ output "juju_cloud" {
   value = juju_controller.controller.cloud.name
 }
 
-output "juju_credentials" {
+output "juju_controller" {
   value = {
     controller_addresses = juju_controller.controller.api_addresses
     username             = juju_controller.controller.username

--- a/modules/juju_bootstrap/outputs.tf
+++ b/modules/juju_bootstrap/outputs.tf
@@ -1,0 +1,13 @@
+output "juju_cloud" {
+  value = juju_controller.controller.cloud.name
+}
+
+output "juju_credentials" {
+  value = {
+    controller_addresses = juju_controller.controller.api_addresses
+    username             = juju_controller.controller.username
+    password             = juju_controller.controller.password
+    ca_certificate       = juju_controller.controller.ca_cert
+  }
+  sensitive = true
+}

--- a/modules/juju_bootstrap/variables.tf
+++ b/modules/juju_bootstrap/variables.tf
@@ -10,7 +10,23 @@ variable "name" {
 }
 
 variable "cloud" {
-  description = "Cloud to bootstrap juju controller on"
+  description = <<EOT
+Cloud to bootstrap juju controller on.
+
+Fields:
+- auth_types: (set of string) The authentication type(s) supported by the cloud.
+- name: (string) The name of the cloud.
+- type: (string) The type of the cloud.
+- ca_certificates: (optional set of string) CA certificates for the cloud.
+- config: (optional map of string) Configuration options for the cloud.
+- endpoint: (optional string) The API endpoint for the cloud.
+- host_cloud_region: (optional string) The host cloud region for the cloud.
+- region: (optional object)
+    - name: (string) The name of the region.
+    - endpoint: (optional string) The API endpoint for the region.
+    - identity_endpoint: (optional string) The identity endpoint for the region.
+    - storage_endpoint: (optional string) The storage endpoint for the region.
+EOT
   type = object({
     auth_types        = set(string)
     name              = string
@@ -28,19 +44,6 @@ variable "cloud" {
   })
 }
 
-/* Example of LXD cloud
-  cloud = {
-    auth_types = ["certificate"]
-    name       = "lxd-cloud"
-    type       = "lxd"
-    endpoint   = "https://10.0.0.1:8383"
-    region = {
-      name     = "default"
-      endpoint = "https://10.0.0.1:8383"
-    }
-  }
-*/
-
 variable "cloud_credential" {
   description = "Cloud credentials to bootstrap juju controller"
   type = object({
@@ -49,16 +52,6 @@ variable "cloud_credential" {
     name       = string
   })
 }
-
-/* Example of LXD cloud credentials
-  cloud_credential = {
-    auth_type = "interactive"
-    name      = "lxd-token"
-    attributes = {
-      trust-token = trimspace(file("/path/to/token"))
-    }
-  }
-*/
 
 variable "agent_version" {
   description = "juju agent version to use"
@@ -96,26 +89,6 @@ variable "controller_model_config" {
   default     = null
 }
 
-/* Example of controller_model_config
-  controller_model_config = {
-    default-base = "ubuntu@22.04"
-    lxd-snap-channel = "5.0/stable"
-    cloudinit-userdata = <<EOT
-#cloud-config
-
-  ca-certs:
-    trusted:
-    - |
-      -----BEGIN CERTIFICATE-----
-      ROOT CA
-      -----END CERTIFICATE-----
-      -----BEGIN CERTIFICATE-----
-      INTERMEDIATE CA
-      -----END CERTIFICATE-----
-EOT
-  }
-*/
-
 variable "destroy_flags" {
   description = "Flags to pass to juju destroy-controller command"
   type = object({
@@ -142,26 +115,6 @@ variable "model_default" {
   type        = map(string)
   default     = null
 }
-
-/* Example of model_default
-  model_default = {
-    default-base = "ubuntu@22.04"
-    lxd-snap-channel = "5.0/stable"
-    cloudinit-userdata = <<EOT
-#cloud-config
-
-  ca-certs:
-    trusted:
-    - |
-      -----BEGIN CERTIFICATE-----
-      ROOT CA
-      -----END CERTIFICATE-----
-      -----BEGIN CERTIFICATE-----
-      INTERMEDIATE CA
-      -----END CERTIFICATE-----
-EOT
-  }
-*/
 
 variable "storage_pool" {
   description = "Storage pool to use for juju controller"

--- a/modules/juju_bootstrap/variables.tf
+++ b/modules/juju_bootstrap/variables.tf
@@ -1,0 +1,179 @@
+variable "path_juju_binary" {
+  description = "Path to Juju binary"
+  type        = string
+  default     = "/snap/juju/current/bin/juju"
+}
+
+variable "name" {
+  description = "Name of the juju controller to bootstrap"
+  type        = string
+}
+
+variable "cloud" {
+  description = "Cloud to bootstrap juju controller on"
+  type = object({
+    auth_types        = set(string)
+    name              = string
+    type              = string
+    ca_certificates   = optional(set(string))
+    config            = optional(map(string))
+    endpoint          = optional(string)
+    host_cloud_region = optional(string)
+    region = optional(object({
+      name              = string
+      endpoint          = optional(string)
+      identity_endpoint = optional(string)
+      storage_endpoint  = optional(string)
+    }))
+  })
+}
+
+/* Example of LXD cloud
+  cloud = {
+    auth_types = ["certificate"]
+    name       = "lxd-cloud"
+    type       = "lxd"
+    endpoint   = "https://10.0.0.1:8383"
+    region = {
+      name     = "default"
+      endpoint = "https://10.0.0.1:8383"
+    }
+  }
+*/
+
+variable "cloud_credential" {
+  description = "Cloud credentials to bootstrap juju controller"
+  type = object({
+    attributes = map(string)
+    auth_type  = string
+    name       = string
+  })
+}
+
+/* Example of LXD cloud credentials
+  cloud_credential = {
+    auth_type = "interactive"
+    name      = "lxd-token"
+    attributes = {
+      trust-token = trimspace(file("/path/to/token"))
+    }
+  }
+*/
+
+variable "agent_version" {
+  description = "juju agent version to use"
+  type        = string
+  default     = null
+}
+
+variable "bootstrap_base" {
+  description = "Bootstrap base to use for juju controller"
+  type        = string
+  default     = null
+}
+
+variable "bootstrap_config" {
+  description = "Bootstrap config to use for juju controller"
+  type        = map(string)
+  default     = null
+}
+
+variable "bootstrap_constraints" {
+  description = "Bootstrap constraints to use for juju controller"
+  type        = map(string)
+  default     = null
+}
+
+variable "controller_config" {
+  description = "Controller config"
+  type        = map(string)
+  default     = null
+}
+
+variable "controller_model_config" {
+  description = "Controller model config"
+  type        = map(string)
+  default     = null
+}
+
+/* Example of controller_model_config
+  controller_model_config = {
+    default-base = "ubuntu@22.04"
+    lxd-snap-channel = "5.0/stable"
+    cloudinit-userdata = <<EOT
+#cloud-config
+
+  ca-certs:
+    trusted:
+    - |
+      -----BEGIN CERTIFICATE-----
+      ROOT CA
+      -----END CERTIFICATE-----
+      -----BEGIN CERTIFICATE-----
+      INTERMEDIATE CA
+      -----END CERTIFICATE-----
+EOT
+  }
+*/
+
+variable "destroy_flags" {
+  description = "Flags to pass to juju destroy-controller command"
+  type = object({
+    destroy_all_models = optional(bool)
+    destroy_storage    = optional(bool)
+    force              = optional(bool)
+    model_timeout      = optional(number)
+    release_storage    = optional(bool)
+  })
+  default = {
+    destroy_all_models = true
+    destroy_storage    = true
+  }
+}
+
+variable "model_constraints" {
+  description = "Model constraints to set for all models"
+  type        = map(string)
+  default     = null
+}
+
+variable "model_default" {
+  description = "Model defaults to set for all models"
+  type        = map(string)
+  default     = null
+}
+
+/* Example of model_default
+  model_default = {
+    default-base = "ubuntu@22.04"
+    lxd-snap-channel = "5.0/stable"
+    cloudinit-userdata = <<EOT
+#cloud-config
+
+  ca-certs:
+    trusted:
+    - |
+      -----BEGIN CERTIFICATE-----
+      ROOT CA
+      -----END CERTIFICATE-----
+      -----BEGIN CERTIFICATE-----
+      INTERMEDIATE CA
+      -----END CERTIFICATE-----
+EOT
+  }
+*/
+
+variable "storage_pool" {
+  description = "Storage pool to use for juju controller"
+  type = object({
+    name       = string
+    type       = string
+    attributes = optional(map(string))
+  })
+  default = null
+}
+
+variable "controller_num_units" {
+  description = "Number of controller units to deploy"
+  type        = number
+}

--- a/modules/juju_bootstrap/variables.tf
+++ b/modules/juju_bootstrap/variables.tf
@@ -129,4 +129,9 @@ variable "storage_pool" {
 variable "controller_num_units" {
   description = "Number of controller units to deploy"
   type        = number
+
+  validation {
+    condition     = var.controller_num_units > 0 && floor(var.controller_num_units) == var.controller_num_units
+    error_message = "controller_num_units must be a positive integer greater than 0."
+  }
 }

--- a/modules/juju_bootstrap/versions.tf
+++ b/modules/juju_bootstrap/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = "~> 1.0"
+    }
+  }
+}

--- a/modules/juju_bootstrap/versions.tf
+++ b/modules/juju_bootstrap/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 1.0"
+      version = "~> 1.3"
     }
   }
 }

--- a/modules/juju_bootstrap/versions.tf
+++ b/modules/juju_bootstrap/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 1.3"
+      version = "> 1.3"
     }
   }
 }

--- a/terragrunt/examples/lxd-ci/terragrunt.hcl
+++ b/terragrunt/examples/lxd-ci/terragrunt.hcl
@@ -45,7 +45,7 @@ inputs = {
     }
   }
 
-  controller_num_units = 0
+  controller_num_units = 1
 
   destroy_flags = {
     destroy_all_models = true

--- a/terragrunt/examples/lxd-ci/terragrunt.hcl
+++ b/terragrunt/examples/lxd-ci/terragrunt.hcl
@@ -1,0 +1,54 @@
+terraform {
+  source = "${get_repo_root()}/modules/juju_bootstrap"
+}
+
+locals {
+  lxd_creds = yamldecode(file(pathexpand("~/lxd-credentials.yaml")))
+}
+
+inputs = {
+  name           = "ci-lxd-controller"
+  bootstrap_base = "ubuntu@24.04"
+
+  bootstrap_constraints = {
+    "cores"     = "2"
+    "mem"       = "4G"
+    "root-disk" = "4G"
+  }
+
+  bootstrap_config = {
+    "admin-secret" = "ci-admin-password"
+  }
+
+  controller_config = {
+    "agent-logfile-max-backups" = "3"
+    "audit-log-capture-args"    = "true"
+  }
+
+  controller_model_config = {
+    "disable-telemetry" = "true"
+  }
+
+  cloud = {
+    auth_types = ["certificate"]
+    name       = "localhost"
+    type       = "lxd"
+  }
+
+  cloud_credential = {
+    auth_type = "certificate"
+    name      = "lxd-cred"
+    attributes = {
+      server-cert = local.lxd_creds["server-cert"]
+      client-key  = local.lxd_creds["client-key"]
+      client-cert = local.lxd_creds["client-cert"]
+    }
+  }
+
+  controller_num_units = 0
+
+  destroy_flags = {
+    destroy_all_models = true
+    destroy_storage    = true
+  }
+}

--- a/terragrunt/units/juju_bootstrap/README.md
+++ b/terragrunt/units/juju_bootstrap/README.md
@@ -1,0 +1,40 @@
+# juju_bootstrap Terragrunt unit
+
+This unit wraps the `modules/juju_bootstrap` Terraform module for use from a Terragrunt stack.
+
+This definition expects to be used from within an stack. The enclosing stack is meant to provide a `values` attribute, which is used to populate the module source version, dependencies, required inputs, and any optional inputs.
+
+## Expected stack-provided values
+
+Required `values` entries:
+
+- `version`
+- `name`
+- `cloud`
+- `cloud_credential`
+- `controller_num_units`
+
+Optional `values` entries:
+
+- `dependencies`
+- `path_juju_binary`
+- `agent_version`
+- `bootstrap_base`
+- `bootstrap_config`
+- `bootstrap_constraints`
+- `controller_config`
+- `controller_model_config`
+- `destroy_flags`
+- `model_constraints`
+- `model_default`
+- `storage_pool`
+
+## Behavior
+
+- The module source is pinned from `values.version`.
+- Terragrunt dependencies are populated from `values.dependencies` when present.
+- Optional module inputs are forwarded only when the corresponding `values` entry is not `null`.
+
+## Reference
+
+For the definition of the forwarded inputs and module outputs, see `modules/juju_bootstrap/README.md`.

--- a/terragrunt/units/juju_bootstrap/terragrunt.hcl
+++ b/terragrunt/units/juju_bootstrap/terragrunt.hcl
@@ -1,0 +1,41 @@
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+terraform {
+  source = "git::https://github.com/canonical/terraform-provider-juju.git//modules/juju_bootstrap?ref=${values.version}"
+}
+
+dependencies {
+  paths = try(values.dependencies, [])
+}
+
+locals {
+  optional_inputs = {
+    path_juju_binary        = try(values.path_juju_binary, null)
+    agent_version           = try(values.agent_version, null)
+    bootstrap_base          = try(values.bootstrap_base, null)
+    bootstrap_config        = try(values.bootstrap_config, null)
+    bootstrap_constraints   = try(values.bootstrap_constraints, null)
+    controller_config       = try(values.controller_config, null)
+    controller_model_config = try(values.controller_model_config, null)
+    destroy_flags           = try(values.destroy_flags, null)
+    model_constraints       = try(values.model_constraints, null)
+    model_default           = try(values.model_default, null)
+    storage_pool            = try(values.storage_pool, null)
+  }
+}
+
+inputs = merge({
+  # Optional inputs
+  for k, v in local.optional_inputs :
+  k => v
+  if v != null
+  },
+  {
+    # Required inputs
+    name                 = values.name
+    cloud                = values.cloud
+    cloud_credential     = values.cloud_credential
+    controller_num_units = values.controller_num_units
+})


### PR DESCRIPTION
## Description

This PR adds a new reusable Terraform module and a Terragrunt unit for bootstrapping a Juju controller with optional high availability (HA).

What:
- Added a new module under modules/juju_bootstrap to create a juju_controller and expose bootstrap outputs.
- Added optional HA enablement via local-exec when controller_num_units is greater than 0.
- Added a Terragrunt unit under terragrunt/units/juju_bootstrap that wraps the module and forwards required/optional inputs.
- Added documentation for both the module and the Terragrunt unit.

Why:
- To provide a standard, repeatable way to bootstrap controllers across environments.
- To support stack-driven Terragrunt usage where unit configuration is supplied via a values object.

How:
- The module configures the juju provider in controller mode and creates the controller resource.
- HA is enabled conditionally using juju CLI commands to keep compatibility with OpenTofu until actions are supported.
- The Terragrunt unit is designed to be used inside a stack that passes the values attribute (including version, required inputs, and optional inputs).

Where:
- Module: modules/juju_bootstrap
- Terragrunt unit: terragrunt/units/juju_bootstrap

Who:
- Platform/infrastructure users bootstrapping Juju controllers through Terraform/Terragrunt workflows.

Fixes: N/A

## Type of change

- Other: add new reusable Terraform module + Terragrunt unit for controller bootstrap workflow

## Environment

- Juju controller version: 3.6.21
- OpenTofu version: v1.11.7

## QA steps

Manual QA steps should be done to test this PR.

```tf
provider "juju" {
  controller_mode = true
}

module "juju_bootstrap" {
  source = "git::https://github.com/canonical/terraform-provider-juju.git//modules/juju_bootstrap?ref=<tag-or commit_hash>"

  name = "my-controller"

  cloud = {
    auth_types = ["certificate"]
    name       = "lxd-cloud"
    type       = "lxd"
    endpoint   = "https://10.0.0.1:8383"
    region = {
      name     = "default"
      endpoint = "https://10.0.0.1:8383"
    }
  }

  cloud_credential = {
    auth_type = "interactive"
    name      = "lxd-token"
    attributes = {
      trust-token = trimspace(file("/path/to/token"))
    }
  }

  controller_num_units = 3
}
```

1. Create a LXD trust token: `lxc config trust add --name lxd-token` and place it in `/path/to/token`
1. Run terraform init.
1. Run terraform plan and confirm a juju_controller resource is planned.
1. Run terraform apply and confirm the controller is created.
1. If controller_num_units > 0, verify HA enablement runs and completes successfully.
1. Verify outputs:
   - juju_cloud is set.
   - juju_credentials is marked sensitive and contains controller connection data.
1. Optional Terragrunt validation:
   - Use the juju_bootstrap unit in a stack and pass values with required fields:
     - version, name, cloud, cloud_credential, controller_num_units
   - Run terragrunt plan/apply from the stack and confirm inputs are forwarded correctly.
   - Confirm optional values are passed only when set.

## Additional notes

- The Terragrunt unit is intentionally stack-oriented and expects the enclosing stack to provide a values attribute.
- HA enablement is implemented through local-exec + juju CLI for compatibility until OpenTofu supports actions.
