### PR TITLE
fix: remove implicit force destroy of offers

### DIFF
--- a/docs-rtd/howto/manage-offers.md
+++ b/docs-rtd/howto/manage-offers.md
@@ -200,6 +200,6 @@ resource "juju_jaas_access_offer" "development" {
 
 To remove an offer, remove the `juju_offer` resource definition.
 
-If the offer still has active consumers, the provider returns an error. Remove all consumers (whether added through terraform or manually) then retry.
+If the offer still has active consumers that can't be removed, the provider will return an error. Remove all consumers (whether added through terraform or manually) then retry.
 
 > See more: [`juju_offer`](../reference/terraform-provider/resources/offer)

--- a/docs-rtd/howto/manage-offers.md
+++ b/docs-rtd/howto/manage-offers.md
@@ -198,7 +198,8 @@ resource "juju_jaas_access_offer" "development" {
 ## Remove an offer
 > Who: User with {external+juju:ref}`offer admin access <user-access-offer-admin>`.
 
+To remove an offer, remove the `juju_offer` resource definition from your Terraform plan.
 
-To remove an offer, in your Terraform plan, remove its resource definition.
+If the offer still has active consumers, the provider returns an error instead of force-destroying the offer.
 
 > See more: [`juju_offer`](../reference/terraform-provider/resources/offer)

--- a/docs-rtd/howto/manage-offers.md
+++ b/docs-rtd/howto/manage-offers.md
@@ -198,8 +198,8 @@ resource "juju_jaas_access_offer" "development" {
 ## Remove an offer
 > Who: User with {external+juju:ref}`offer admin access <user-access-offer-admin>`.
 
-To remove an offer, remove the `juju_offer` resource definition from your Terraform plan.
+To remove an offer, remove the `juju_offer` resource definition.
 
-If the offer still has active consumers, the provider returns an error instead of force-destroying the offer.
+If the offer still has active consumers, the provider returns an error instead of force-destroying the offer. In that case, first remove the `juju_integration` resources consuming the offer and apply, then remove the `juju_offer` and apply again.
 
 > See more: [`juju_offer`](../reference/terraform-provider/resources/offer)

--- a/docs-rtd/howto/manage-offers.md
+++ b/docs-rtd/howto/manage-offers.md
@@ -200,6 +200,6 @@ resource "juju_jaas_access_offer" "development" {
 
 To remove an offer, remove the `juju_offer` resource definition.
 
-If the offer still has active consumers, the provider returns an error instead of force-destroying the offer. In that case, first remove the `juju_integration` resources consuming the offer and apply, then remove the `juju_offer` and apply again.
+If the offer still has active consumers, the provider returns an error. Remove all consumers (whether added through terraform or manually) then retry.
 
 > See more: [`juju_offer`](../reference/terraform-provider/resources/offer)

--- a/docs-rtd/howto/manage-offers.md
+++ b/docs-rtd/howto/manage-offers.md
@@ -200,6 +200,6 @@ resource "juju_jaas_access_offer" "development" {
 
 To remove an offer, remove the `juju_offer` resource definition.
 
-If the offer still has active consumers that can't be removed, the provider will return an error. Remove all consumers (whether added through terraform or manually) then retry.
+If the offer still has active consumers that can't be removed, the provider will return an error. Remove all consumers (whether added through Terraform or manually) then retry.
 
 > See more: [`juju_offer`](../reference/terraform-provider/resources/offer)

--- a/docs-rtd/howto/manage-offers.md
+++ b/docs-rtd/howto/manage-offers.md
@@ -200,6 +200,8 @@ resource "juju_jaas_access_offer" "development" {
 
 To remove an offer, remove the `juju_offer` resource definition.
 
-If the offer still has active consumers that can't be removed, the provider will return an error. Remove all consumers (whether added through Terraform or manually) then retry.
+If the offer still has active consumers that can't be removed, the provider will return an error. Remove all consumers (whether added through Terraform or manually), then retry.
+
+To instead force-delete offers after the timeout, configure the provider with `allow_offer_force_deletion = true`.
 
 > See more: [`juju_offer`](../reference/terraform-provider/resources/offer)

--- a/docs-rtd/reference/terraform-provider/index.md
+++ b/docs-rtd/reference/terraform-provider/index.md
@@ -285,6 +285,7 @@ resource "juju_integration" "wp_to_percona" {
 - `offering_controllers` (Attributes Map) Additional controller details for cross-model integrations. The map key is the controller name. (see [below for nested schema](#nestedatt--offering_controllers))
 - `password` (String, Sensitive) This is the password of the username to be used. This can also be set by the `JUJU_PASSWORD` environment variable
 - `skip_failed_deletion` (Boolean) Whether to issue a warning instead of an error and continue if a resource deletion fails. This can also be set by the `JUJU_SKIP_FAILED_DELETION` environment variable. Defaults to false.
+- `allow_offer_force_deletion` (Boolean) Whether to force-destroy an offer that still has active connections after the timeout period has elapsed, instead of returning an error. This can also be set by the `JUJU_ALLOW_OFFER_FORCE_DELETION` environment variable. Defaults to false.
 - `username` (String) This is the username registered with the controller to be used. This can also be set by the `JUJU_USERNAME` environment variable
 
 <a id="nestedatt--offering_controllers"></a>

--- a/docs-rtd/reference/terraform-provider/index.md
+++ b/docs-rtd/reference/terraform-provider/index.md
@@ -277,6 +277,7 @@ resource "juju_integration" "wp_to_percona" {
 
 ### Optional
 
+- `allow_offer_force_deletion` (Boolean) Whether to force-destroy an offer that still has active connections after the timeout period has elapsed, instead of returning an error. This can also be set by the `JUJU_ALLOW_OFFER_FORCE_DELETION` environment variable. Defaults to false.
 - `ca_certificate` (String) If the controller was deployed with a self-signed certificate: This is the certificate to use for identification. This can also be set by the `JUJU_CA_CERT` environment variable
 - `client_id` (String) If using JAAS: This is the client ID (OAuth2.0, created by the external identity provider) to be used. This can also be set by the `JUJU_CLIENT_ID` environment variable
 - `client_secret` (String, Sensitive) If using JAAS: This is the client secret (OAuth2.0, created by the external identity provider) to be used. This can also be set by the `JUJU_CLIENT_SECRET` environment variable
@@ -285,7 +286,6 @@ resource "juju_integration" "wp_to_percona" {
 - `offering_controllers` (Attributes Map) Additional controller details for cross-model integrations. The map key is the controller name. (see [below for nested schema](#nestedatt--offering_controllers))
 - `password` (String, Sensitive) This is the password of the username to be used. This can also be set by the `JUJU_PASSWORD` environment variable
 - `skip_failed_deletion` (Boolean) Whether to issue a warning instead of an error and continue if a resource deletion fails. This can also be set by the `JUJU_SKIP_FAILED_DELETION` environment variable. Defaults to false.
-- `allow_offer_force_deletion` (Boolean) Whether to force-destroy an offer that still has active connections after the timeout period has elapsed, instead of returning an error. This can also be set by the `JUJU_ALLOW_OFFER_FORCE_DELETION` environment variable. Defaults to false.
 - `username` (String) This is the username registered with the controller to be used. This can also be set by the `JUJU_USERNAME` environment variable
 
 <a id="nestedatt--offering_controllers"></a>

--- a/docs/index.md
+++ b/docs/index.md
@@ -285,6 +285,7 @@ resource "juju_integration" "wp_to_percona" {
 - `offering_controllers` (Attributes Map) Additional controller details for cross-model integrations. The map key is the controller name. (see [below for nested schema](#nestedatt--offering_controllers))
 - `password` (String, Sensitive) This is the password of the username to be used. This can also be set by the `JUJU_PASSWORD` environment variable
 - `skip_failed_deletion` (Boolean) Whether to issue a warning instead of an error and continue if a resource deletion fails. This can also be set by the `JUJU_SKIP_FAILED_DELETION` environment variable. Defaults to false.
+- `allow_offer_force_deletion` (Boolean) Whether to force-destroy an offer that still has active connections after the timeout period has elapsed, instead of returning an error. This can also be set by the `JUJU_ALLOW_OFFER_FORCE_DELETION` environment variable. Defaults to false.
 - `username` (String) This is the username registered with the controller to be used. This can also be set by the `JUJU_USERNAME` environment variable
 
 <a id="nestedatt--offering_controllers"></a>

--- a/docs/index.md
+++ b/docs/index.md
@@ -277,6 +277,7 @@ resource "juju_integration" "wp_to_percona" {
 
 ### Optional
 
+- `allow_offer_force_deletion` (Boolean) Whether to force-destroy an offer that still has active connections after the timeout period has elapsed, instead of returning an error. This can also be set by the `JUJU_ALLOW_OFFER_FORCE_DELETION` environment variable. Defaults to false.
 - `ca_certificate` (String) If the controller was deployed with a self-signed certificate: This is the certificate to use for identification. This can also be set by the `JUJU_CA_CERT` environment variable
 - `client_id` (String) If using JAAS: This is the client ID (OAuth2.0, created by the external identity provider) to be used. This can also be set by the `JUJU_CLIENT_ID` environment variable
 - `client_secret` (String, Sensitive) If using JAAS: This is the client secret (OAuth2.0, created by the external identity provider) to be used. This can also be set by the `JUJU_CLIENT_SECRET` environment variable
@@ -285,7 +286,6 @@ resource "juju_integration" "wp_to_percona" {
 - `offering_controllers` (Attributes Map) Additional controller details for cross-model integrations. The map key is the controller name. (see [below for nested schema](#nestedatt--offering_controllers))
 - `password` (String, Sensitive) This is the password of the username to be used. This can also be set by the `JUJU_PASSWORD` environment variable
 - `skip_failed_deletion` (Boolean) Whether to issue a warning instead of an error and continue if a resource deletion fails. This can also be set by the `JUJU_SKIP_FAILED_DELETION` environment variable. Defaults to false.
-- `allow_offer_force_deletion` (Boolean) Whether to force-destroy an offer that still has active connections after the timeout period has elapsed, instead of returning an error. This can also be set by the `JUJU_ALLOW_OFFER_FORCE_DELETION` environment variable. Defaults to false.
 - `username` (String) This is the username registered with the controller to be used. This can also be set by the `JUJU_USERNAME` environment variable
 
 <a id="nestedatt--offering_controllers"></a>

--- a/internal/juju/client.go
+++ b/internal/juju/client.go
@@ -97,6 +97,12 @@ type Config struct {
 	// This avoids making the user manipulate Terraform state manually to get rid of the resource.
 	SkipFailedDeletion bool
 
+	// ForceFailedDeletion indicates whether the provider should force-destroy a resource
+	// when it still has active connections after the timeout period has elapsed.
+	// Defaults to true, which force-destroys instead of returning an error.
+	// Currently, this only applies to deleting offers.
+	ForceFailedDeletion bool
+
 	// ControllerMode indicates whether the provider is operating in controller mode.
 	ControllerMode bool
 }

--- a/internal/juju/client.go
+++ b/internal/juju/client.go
@@ -97,11 +97,11 @@ type Config struct {
 	// This avoids making the user manipulate Terraform state manually to get rid of the resource.
 	SkipFailedDeletion bool
 
-	// ForceFailedDeletion indicates whether the provider should force-destroy a resource
-	// when it still has active connections after the timeout period has elapsed.
-	// Defaults to true, which force-destroys instead of returning an error.
-	// Currently, this only applies to deleting offers.
-	ForceFailedDeletion bool
+	// AllowForceDeleteOffers indicates whether the provider should force-destroy an offer
+	// when it still has active connections, after it has timed out attempting to delete
+	// normally.
+	// Defaults to false, which returns an error on timeout.
+	AllowForceDeleteOffers bool
 
 	// ControllerMode indicates whether the provider is operating in controller mode.
 	ControllerMode bool

--- a/internal/juju/client.go
+++ b/internal/juju/client.go
@@ -97,11 +97,11 @@ type Config struct {
 	// This avoids making the user manipulate Terraform state manually to get rid of the resource.
 	SkipFailedDeletion bool
 
-	// AllowForceDeleteOffers indicates whether the provider should force-destroy an offer
+	// AllowOfferForceDeletion indicates whether the provider should force-destroy an offer
 	// when it still has active connections, after it has timed out attempting to delete
 	// normally.
 	// Defaults to false, which returns an error on timeout.
-	AllowForceDeleteOffers bool
+	AllowOfferForceDeletion bool
 
 	// ControllerMode indicates whether the provider is operating in controller mode.
 	ControllerMode bool

--- a/internal/juju/offers.go
+++ b/internal/juju/offers.go
@@ -285,7 +285,7 @@ func (c *offersClient) DestroyOffer(ctx context.Context, input *DestroyOfferInpu
 		for ok := true; ok; ok = len(offer.Connections) > 0 {
 			if time.Now().After(end) {
 				return fmt.Errorf(
-					"cannot destroy offer %q: it still has %d active connection(s) after waiting 5 minutes; remove all consumers first",
+					"cannot destroy offer %q: it still has %d active connection(s) after waiting; remove all consumers first",
 					input.OfferURL,
 					len(offer.Connections),
 				)

--- a/internal/juju/offers.go
+++ b/internal/juju/offers.go
@@ -278,28 +278,15 @@ func (c *offersClient) DestroyOffer(ctx context.Context, input *DestroyOfferInpu
 	if err != nil {
 		return err
 	}
-
-	forceDestroy := false
-	//This code loops until it detects 0 connections in the offer or 3 minutes elapses
 	if len(offer.Connections) > 0 {
-		end := time.Now().Add(5 * time.Minute)
-		c.Tracef(fmt.Sprintf("offer %q has %d connections, waiting for them to be removed before destroying", offer.OfferURL, len(offer.Connections)))
-		for ok := true; ok; ok = len(offer.Connections) > 0 {
-			//if we have been failing to destroy offer for 5 minutes then force destroy
-			//TODO: investigate cleaner solution (acceptance tests fail even if timeout set to 20m)
-			if time.Now().After(end) {
-				forceDestroy = true
-				break
-			}
-			time.Sleep(10 * time.Second)
-			offer, err = client.ApplicationOffer(ctx, input.OfferURL)
-			if err != nil {
-				return err
-			}
-		}
+		return fmt.Errorf(
+			"cannot destroy offer %q because it still has %d active connection(s); remove the juju_integration resources consuming the offer and apply that change before removing the offer",
+			input.OfferURL,
+			len(offer.Connections),
+		)
 	}
 
-	err = client.DestroyOffers(ctx, forceDestroy, input.OfferURL)
+	err = client.DestroyOffers(ctx, false, input.OfferURL)
 	if err != nil {
 		return err
 	}

--- a/internal/juju/offers.go
+++ b/internal/juju/offers.go
@@ -278,12 +278,24 @@ func (c *offersClient) DestroyOffer(ctx context.Context, input *DestroyOfferInpu
 	if err != nil {
 		return err
 	}
+	// This code loops until it detects 0 connections in the offer or 5 minutes elapses
 	if len(offer.Connections) > 0 {
-		return fmt.Errorf(
-			"cannot destroy offer %q: it still has %d active connection(s); remove all consumers first",
-			input.OfferURL,
-			len(offer.Connections),
-		)
+		end := time.Now().Add(5 * time.Minute)
+		c.Tracef(fmt.Sprintf("offer %q has %d connections, waiting for them to be removed before destroying", offer.OfferURL, len(offer.Connections)))
+		for ok := true; ok; ok = len(offer.Connections) > 0 {
+			if time.Now().After(end) {
+				return fmt.Errorf(
+					"cannot destroy offer %q: it still has %d active connection(s) after waiting 5 minutes; remove all consumers first",
+					input.OfferURL,
+					len(offer.Connections),
+				)
+			}
+			time.Sleep(10 * time.Second)
+			offer, err = client.ApplicationOffer(ctx, input.OfferURL)
+			if err != nil {
+				return err
+			}
+		}
 	}
 
 	err = client.DestroyOffers(ctx, false, input.OfferURL)

--- a/internal/juju/offers.go
+++ b/internal/juju/offers.go
@@ -77,8 +77,8 @@ type ReadOfferResponse struct {
 
 // DestroyOfferInput represents input for destroying an offer.
 type DestroyOfferInput struct {
-	OfferURL               string
-	AllowForceDeleteOffers bool
+	OfferURL                string
+	AllowOfferForceDeletion bool
 }
 
 // ConsumeRemoteOfferInput represents input for consuming a remote offer.
@@ -279,13 +279,16 @@ func (c *offersClient) DestroyOffer(ctx context.Context, input *DestroyOfferInpu
 	if err != nil {
 		return err
 	}
+
+	forceDelete := false
 	// Loops until we detect 0 connections in the offer or we time out
 	if len(offer.Connections) > 0 {
 		end := time.Now().Add(5 * time.Minute)
 		c.Tracef(fmt.Sprintf("offer %q has %d connections, waiting for them to be removed before destroying", offer.OfferURL, len(offer.Connections)))
 		for ok := true; ok; ok = len(offer.Connections) > 0 {
 			if time.Now().After(end) {
-				if !input.AllowForceDeleteOffers {
+				if input.AllowOfferForceDeletion {
+					forceDelete = true
 					break
 				}
 				return fmt.Errorf(
@@ -303,7 +306,7 @@ func (c *offersClient) DestroyOffer(ctx context.Context, input *DestroyOfferInpu
 	}
 
 	// Potentially fall back to force deletion
-	err = client.DestroyOffers(ctx, input.AllowForceDeleteOffers, input.OfferURL)
+	err = client.DestroyOffers(ctx, forceDelete, input.OfferURL)
 	if err != nil {
 		return err
 	}

--- a/internal/juju/offers.go
+++ b/internal/juju/offers.go
@@ -77,8 +77,8 @@ type ReadOfferResponse struct {
 
 // DestroyOfferInput represents input for destroying an offer.
 type DestroyOfferInput struct {
-	OfferURL            string
-	ForceFailedDeletion bool
+	OfferURL          string
+	AllowForceDeleteOffers bool
 }
 
 // ConsumeRemoteOfferInput represents input for consuming a remote offer.
@@ -285,7 +285,7 @@ func (c *offersClient) DestroyOffer(ctx context.Context, input *DestroyOfferInpu
 		c.Tracef(fmt.Sprintf("offer %q has %d connections, waiting for them to be removed before destroying", offer.OfferURL, len(offer.Connections)))
 		for ok := true; ok; ok = len(offer.Connections) > 0 {
 			if time.Now().After(end) {
-				if input.ForceFailedDeletion {
+				if !input.AllowForceDeleteOffers {
 					break
 				}
 				return fmt.Errorf(
@@ -302,7 +302,8 @@ func (c *offersClient) DestroyOffer(ctx context.Context, input *DestroyOfferInpu
 		}
 	}
 
-	err = client.DestroyOffers(ctx, input.ForceFailedDeletion, input.OfferURL)
+	// Potentially fall back to force deletion
+	err = client.DestroyOffers(ctx, input.AllowForceDeleteOffers, input.OfferURL)
 	if err != nil {
 		return err
 	}

--- a/internal/juju/offers.go
+++ b/internal/juju/offers.go
@@ -77,7 +77,8 @@ type ReadOfferResponse struct {
 
 // DestroyOfferInput represents input for destroying an offer.
 type DestroyOfferInput struct {
-	OfferURL string
+	OfferURL            string
+	ForceFailedDeletion bool
 }
 
 // ConsumeRemoteOfferInput represents input for consuming a remote offer.
@@ -284,6 +285,9 @@ func (c *offersClient) DestroyOffer(ctx context.Context, input *DestroyOfferInpu
 		c.Tracef(fmt.Sprintf("offer %q has %d connections, waiting for them to be removed before destroying", offer.OfferURL, len(offer.Connections)))
 		for ok := true; ok; ok = len(offer.Connections) > 0 {
 			if time.Now().After(end) {
+				if input.ForceFailedDeletion {
+					break
+				}
 				return fmt.Errorf(
 					"cannot destroy offer %q: it still has %d active connection(s) after waiting; remove all consumers first",
 					input.OfferURL,
@@ -298,7 +302,7 @@ func (c *offersClient) DestroyOffer(ctx context.Context, input *DestroyOfferInpu
 		}
 	}
 
-	err = client.DestroyOffers(ctx, false, input.OfferURL)
+	err = client.DestroyOffers(ctx, input.ForceFailedDeletion, input.OfferURL)
 	if err != nil {
 		return err
 	}

--- a/internal/juju/offers.go
+++ b/internal/juju/offers.go
@@ -77,7 +77,7 @@ type ReadOfferResponse struct {
 
 // DestroyOfferInput represents input for destroying an offer.
 type DestroyOfferInput struct {
-	OfferURL          string
+	OfferURL               string
 	AllowForceDeleteOffers bool
 }
 
@@ -279,7 +279,7 @@ func (c *offersClient) DestroyOffer(ctx context.Context, input *DestroyOfferInpu
 	if err != nil {
 		return err
 	}
-	// This code loops until it detects 0 connections in the offer or 5 minutes elapses
+	// Loops until we detect 0 connections in the offer or we time out
 	if len(offer.Connections) > 0 {
 		end := time.Now().Add(5 * time.Minute)
 		c.Tracef(fmt.Sprintf("offer %q has %d connections, waiting for them to be removed before destroying", offer.OfferURL, len(offer.Connections)))

--- a/internal/juju/offers.go
+++ b/internal/juju/offers.go
@@ -280,7 +280,7 @@ func (c *offersClient) DestroyOffer(ctx context.Context, input *DestroyOfferInpu
 	}
 	if len(offer.Connections) > 0 {
 		return fmt.Errorf(
-			"cannot destroy offer %q because it still has %d active connection(s); remove the juju_integration resources consuming the offer and apply that change before removing the offer",
+			"cannot destroy offer %q: it still has %d active connection(s); remove all consumers first",
 			input.OfferURL,
 			len(offer.Connections),
 		)

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -45,8 +45,8 @@ const (
 	JujuClientSecretEnvKey = "JUJU_CLIENT_SECRET"
 	// SkipFailedDeletionEnvKey is the env var for skip-failed-deletion behavior.
 	SkipFailedDeletionEnvKey = "JUJU_SKIP_FAILED_DELETION"
-	// ForceFailedDeletionEnvKey is the env var for force-failed-deletion behavior.
-	ForceFailedDeletionEnvKey = "JUJU_FORCE_FAILED_DELETION"
+	// AllowOfferForceDeletionEnvKey is the env var for allow-offer-force-deletion behavior.
+	AllowOfferForceDeletionEnvKey = "JUJU_ALLOW_OFFER_FORCE_DELETION"
 
 	// ControllerMode is the provider config key for controller mode.
 	ControllerMode = "controller_mode"
@@ -64,8 +64,8 @@ const (
 	JujuCACert = "ca_certificate"
 	// SkipFailedDeletion is the provider config key for skip-failed-deletion behavior.
 	SkipFailedDeletion = "skip_failed_deletion"
-	// ForceFailedDeletion is the provider config key for force-failed-deletion behavior.
-	ForceFailedDeletion = "force_failed_deletion"
+	// AllowOfferForceDeletion is the provider config key for allow-offer-force-deletion behavior.
+	AllowOfferForceDeletion = "allow_offer_force_deletion"
 	// JujuOfferingControllers is the provider config key for offering controllers.
 	JujuOfferingControllers = "offering_controllers"
 
@@ -84,11 +84,11 @@ func jujuProviderModelEnvVar(diags diag.Diagnostics) jujuProviderModel {
 			fmt.Sprintf("The value %q is not a valid boolean. Defaulting to false.", skipFailedDeletionStrVal))
 	}
 
-	forceFailedDeletionStrVal := os.Getenv(ForceFailedDeletionEnvKey)
-	forceFailedDeletion, err := strconv.ParseBool(forceFailedDeletionStrVal)
+	allowOfferForceDeletionStrVal := os.Getenv(AllowOfferForceDeletionEnvKey)
+	allowOfferForceDeletion, err := strconv.ParseBool(allowOfferForceDeletionStrVal)
 	if err != nil {
-		diags.AddWarning(fmt.Sprintf("Invalid value for %s", ForceFailedDeletion),
-			fmt.Sprintf("The value %q is not a valid boolean. Defaulting to true.", forceFailedDeletionStrVal))
+		diags.AddWarning(fmt.Sprintf("Invalid value for %s", AllowOfferForceDeletion),
+			fmt.Sprintf("The value %q is not a valid boolean. Defaulting to false.", allowOfferForceDeletionStrVal))
 	}
 
 	return jujuProviderModel{
@@ -99,7 +99,7 @@ func jujuProviderModelEnvVar(diags diag.Diagnostics) jujuProviderModel {
 		UserName:               getEnvVar(JujuUsernameEnvKey),
 		Password:               getEnvVar(JujuPasswordEnvKey),
 		SkipFailedDeletion:     types.BoolValue(skipFailedDeletion),
-		AllowForceDeleteOffers: types.BoolValue(forceFailedDeletion),
+		AllowForceDeleteOffers: types.BoolValue(allowOfferForceDeletion),
 	}
 }
 
@@ -185,7 +185,7 @@ type jujuProviderModel struct {
 	ClientSecret    types.String `tfsdk:"client_secret"`
 
 	SkipFailedDeletion     types.Bool `tfsdk:"skip_failed_deletion"`
-	AllowForceDeleteOffers types.Bool `tfsdk:"allow_force_delete_offers"`
+	AllowForceDeleteOffers types.Bool `tfsdk:"allow_offer_force_deletion"`
 
 	OfferingControllers types.Map `tfsdk:"offering_controllers"`
 }
@@ -324,8 +324,8 @@ func (p *jujuProvider) Schema(_ context.Context, _ provider.SchemaRequest, resp 
 				Description: fmt.Sprintf("Whether to issue a warning instead of an error and continue if a resource deletion fails. This can also be set by the `%s` environment variable. Defaults to false.", SkipFailedDeletionEnvKey),
 				Optional:    true,
 			},
-			ForceFailedDeletion: schema.BoolAttribute{
-				Description: fmt.Sprintf("Whether to force-destroy an offer that still has active connections after the timeout period has elapsed, instead of returning an error. This can also be set by the `%s` environment variable. Defaults to true.", ForceFailedDeletionEnvKey),
+			AllowOfferForceDeletion: schema.BoolAttribute{
+				Description: fmt.Sprintf("Whether to force-destroy an offer that still has active connections after the timeout period has elapsed, instead of returning an error. This can also be set by the `%s` environment variable. Defaults to false.", AllowOfferForceDeletionEnvKey),
 				Optional:    true,
 			},
 			JujuOfferingControllers: schema.MapNestedAttribute{

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -45,6 +45,8 @@ const (
 	JujuClientSecretEnvKey = "JUJU_CLIENT_SECRET"
 	// SkipFailedDeletionEnvKey is the env var for skip-failed-deletion behavior.
 	SkipFailedDeletionEnvKey = "JUJU_SKIP_FAILED_DELETION"
+	// ForceFailedDeletionEnvKey is the env var for force-failed-deletion behavior.
+	ForceFailedDeletionEnvKey = "JUJU_FORCE_FAILED_DELETION"
 
 	// ControllerMode is the provider config key for controller mode.
 	ControllerMode = "controller_mode"
@@ -62,6 +64,8 @@ const (
 	JujuCACert = "ca_certificate"
 	// SkipFailedDeletion is the provider config key for skip-failed-deletion behavior.
 	SkipFailedDeletion = "skip_failed_deletion"
+	// ForceFailedDeletion is the provider config key for force-failed-deletion behavior.
+	ForceFailedDeletion = "force_failed_deletion"
 	// JujuOfferingControllers is the provider config key for offering controllers.
 	JujuOfferingControllers = "offering_controllers"
 
@@ -80,14 +84,30 @@ func jujuProviderModelEnvVar(diags diag.Diagnostics) jujuProviderModel {
 			fmt.Sprintf("The value %q is not a valid boolean. Defaulting to false.", skipFailedDeletionStrVal))
 	}
 
+	forceFailedDeletionStrVal := os.Getenv(ForceFailedDeletionEnvKey)
+	var forceFailedDeletion types.Bool
+	if forceFailedDeletionStrVal == "" {
+		forceFailedDeletion = types.BoolNull()
+	} else {
+		parsed, err := strconv.ParseBool(forceFailedDeletionStrVal)
+		if err != nil {
+			diags.AddWarning(fmt.Sprintf("Invalid value for %s", ForceFailedDeletion),
+				fmt.Sprintf("The value %q is not a valid boolean. Defaulting to true.", forceFailedDeletionStrVal))
+			forceFailedDeletion = types.BoolNull()
+		} else {
+			forceFailedDeletion = types.BoolValue(parsed)
+		}
+	}
+
 	return jujuProviderModel{
-		ControllerAddrs:    getEnvVar(JujuControllerEnvKey),
-		CACert:             getEnvVar(JujuCACertEnvKey),
-		ClientID:           getEnvVar(JujuClientIDEnvKey),
-		ClientSecret:       getEnvVar(JujuClientSecretEnvKey),
-		UserName:           getEnvVar(JujuUsernameEnvKey),
-		Password:           getEnvVar(JujuPasswordEnvKey),
-		SkipFailedDeletion: types.BoolValue(skipFailedDeletion),
+		ControllerAddrs:     getEnvVar(JujuControllerEnvKey),
+		CACert:              getEnvVar(JujuCACertEnvKey),
+		ClientID:            getEnvVar(JujuClientIDEnvKey),
+		ClientSecret:        getEnvVar(JujuClientSecretEnvKey),
+		UserName:            getEnvVar(JujuUsernameEnvKey),
+		Password:            getEnvVar(JujuPasswordEnvKey),
+		SkipFailedDeletion:  types.BoolValue(skipFailedDeletion),
+		ForceFailedDeletion: forceFailedDeletion,
 	}
 }
 
@@ -172,7 +192,8 @@ type jujuProviderModel struct {
 	ClientID        types.String `tfsdk:"client_id"`
 	ClientSecret    types.String `tfsdk:"client_secret"`
 
-	SkipFailedDeletion types.Bool `tfsdk:"skip_failed_deletion"`
+	SkipFailedDeletion  types.Bool `tfsdk:"skip_failed_deletion"`
+	ForceFailedDeletion types.Bool `tfsdk:"force_failed_deletion"`
 
 	OfferingControllers types.Map `tfsdk:"offering_controllers"`
 }
@@ -206,6 +227,9 @@ func (j jujuProviderModel) merge(in jujuProviderModel, from string) (jujuProvide
 	mergedModel := j
 	if mergedModel.SkipFailedDeletion.IsNull() {
 		mergedModel.SkipFailedDeletion = in.SkipFailedDeletion
+	}
+	if mergedModel.ForceFailedDeletion.IsNull() {
+		mergedModel.ForceFailedDeletion = in.ForceFailedDeletion
 	}
 	if mergedModel.ControllerAddrs.ValueString() == "" {
 		mergedModel.ControllerAddrs = in.ControllerAddrs
@@ -306,6 +330,10 @@ func (p *jujuProvider) Schema(_ context.Context, _ provider.SchemaRequest, resp 
 			},
 			SkipFailedDeletion: schema.BoolAttribute{
 				Description: fmt.Sprintf("Whether to issue a warning instead of an error and continue if a resource deletion fails. This can also be set by the `%s` environment variable. Defaults to false.", SkipFailedDeletionEnvKey),
+				Optional:    true,
+			},
+			ForceFailedDeletion: schema.BoolAttribute{
+				Description: fmt.Sprintf("Whether to force-destroy an offer that still has active connections after the timeout period has elapsed, instead of returning an error. This can also be set by the `%s` environment variable. Defaults to true.", ForceFailedDeletionEnvKey),
 				Optional:    true,
 			},
 			JujuOfferingControllers: schema.MapNestedAttribute{
@@ -410,8 +438,9 @@ func (p *jujuProvider) Configure(ctx context.Context, req provider.ConfigureRequ
 
 	providerData := juju.ProviderData{
 		Config: juju.Config{
-			ControllerMode:     data.ControllerMode.ValueBool(),
-			SkipFailedDeletion: data.SkipFailedDeletion.ValueBool(),
+			ControllerMode:      data.ControllerMode.ValueBool(),
+			SkipFailedDeletion:  data.SkipFailedDeletion.ValueBool(),
+			ForceFailedDeletion: data.ForceFailedDeletion.IsNull() || data.ForceFailedDeletion.ValueBool(),
 		},
 	}
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -85,18 +85,11 @@ func jujuProviderModelEnvVar(diags diag.Diagnostics) jujuProviderModel {
 	}
 
 	forceFailedDeletionStrVal := os.Getenv(ForceFailedDeletionEnvKey)
-	var forceFailedDeletion types.Bool
-	if forceFailedDeletionStrVal == "" {
-		forceFailedDeletion = types.BoolNull()
-	} else {
-		parsed, err := strconv.ParseBool(forceFailedDeletionStrVal)
-		if err != nil {
-			diags.AddWarning(fmt.Sprintf("Invalid value for %s", ForceFailedDeletion),
-				fmt.Sprintf("The value %q is not a valid boolean. Defaulting to true.", forceFailedDeletionStrVal))
-			forceFailedDeletion = types.BoolNull()
-		} else {
-			forceFailedDeletion = types.BoolValue(parsed)
-		}
+	forceFailedDeletion, err := strconv.ParseBool(forceFailedDeletionStrVal)
+	if err != nil {
+		diags.AddWarning(fmt.Sprintf("Invalid value for %s", ForceFailedDeletion),
+			fmt.Sprintf("The value %q is not a valid boolean. Defaulting to true.", forceFailedDeletionStrVal))
+		forceFailedDeletion = true
 	}
 
 	return jujuProviderModel{
@@ -107,7 +100,7 @@ func jujuProviderModelEnvVar(diags diag.Diagnostics) jujuProviderModel {
 		UserName:            getEnvVar(JujuUsernameEnvKey),
 		Password:            getEnvVar(JujuPasswordEnvKey),
 		SkipFailedDeletion:  types.BoolValue(skipFailedDeletion),
-		ForceFailedDeletion: forceFailedDeletion,
+		ForceFailedDeletion: types.BoolValue(forceFailedDeletion),
 	}
 }
 
@@ -440,7 +433,7 @@ func (p *jujuProvider) Configure(ctx context.Context, req provider.ConfigureRequ
 		Config: juju.Config{
 			ControllerMode:      data.ControllerMode.ValueBool(),
 			SkipFailedDeletion:  data.SkipFailedDeletion.ValueBool(),
-			ForceFailedDeletion: data.ForceFailedDeletion.IsNull() || data.ForceFailedDeletion.ValueBool(),
+			ForceFailedDeletion: data.ForceFailedDeletion.ValueBool(),
 		},
 	}
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -89,18 +89,17 @@ func jujuProviderModelEnvVar(diags diag.Diagnostics) jujuProviderModel {
 	if err != nil {
 		diags.AddWarning(fmt.Sprintf("Invalid value for %s", ForceFailedDeletion),
 			fmt.Sprintf("The value %q is not a valid boolean. Defaulting to true.", forceFailedDeletionStrVal))
-		forceFailedDeletion = true
 	}
 
 	return jujuProviderModel{
-		ControllerAddrs:     getEnvVar(JujuControllerEnvKey),
-		CACert:              getEnvVar(JujuCACertEnvKey),
-		ClientID:            getEnvVar(JujuClientIDEnvKey),
-		ClientSecret:        getEnvVar(JujuClientSecretEnvKey),
-		UserName:            getEnvVar(JujuUsernameEnvKey),
-		Password:            getEnvVar(JujuPasswordEnvKey),
-		SkipFailedDeletion:  types.BoolValue(skipFailedDeletion),
-		ForceFailedDeletion: types.BoolValue(forceFailedDeletion),
+		ControllerAddrs:        getEnvVar(JujuControllerEnvKey),
+		CACert:                 getEnvVar(JujuCACertEnvKey),
+		ClientID:               getEnvVar(JujuClientIDEnvKey),
+		ClientSecret:           getEnvVar(JujuClientSecretEnvKey),
+		UserName:               getEnvVar(JujuUsernameEnvKey),
+		Password:               getEnvVar(JujuPasswordEnvKey),
+		SkipFailedDeletion:     types.BoolValue(skipFailedDeletion),
+		AllowForceDeleteOffers: types.BoolValue(forceFailedDeletion),
 	}
 }
 
@@ -185,8 +184,8 @@ type jujuProviderModel struct {
 	ClientID        types.String `tfsdk:"client_id"`
 	ClientSecret    types.String `tfsdk:"client_secret"`
 
-	SkipFailedDeletion  types.Bool `tfsdk:"skip_failed_deletion"`
-	ForceFailedDeletion types.Bool `tfsdk:"force_failed_deletion"`
+	SkipFailedDeletion     types.Bool `tfsdk:"skip_failed_deletion"`
+	AllowForceDeleteOffers types.Bool `tfsdk:"allow_force_delete_offers"`
 
 	OfferingControllers types.Map `tfsdk:"offering_controllers"`
 }
@@ -221,8 +220,8 @@ func (j jujuProviderModel) merge(in jujuProviderModel, from string) (jujuProvide
 	if mergedModel.SkipFailedDeletion.IsNull() {
 		mergedModel.SkipFailedDeletion = in.SkipFailedDeletion
 	}
-	if mergedModel.ForceFailedDeletion.IsNull() {
-		mergedModel.ForceFailedDeletion = in.ForceFailedDeletion
+	if mergedModel.AllowForceDeleteOffers.IsNull() {
+		mergedModel.AllowForceDeleteOffers = in.AllowForceDeleteOffers
 	}
 	if mergedModel.ControllerAddrs.ValueString() == "" {
 		mergedModel.ControllerAddrs = in.ControllerAddrs
@@ -431,9 +430,9 @@ func (p *jujuProvider) Configure(ctx context.Context, req provider.ConfigureRequ
 
 	providerData := juju.ProviderData{
 		Config: juju.Config{
-			ControllerMode:      data.ControllerMode.ValueBool(),
-			SkipFailedDeletion:  data.SkipFailedDeletion.ValueBool(),
-			ForceFailedDeletion: data.ForceFailedDeletion.ValueBool(),
+			ControllerMode:         data.ControllerMode.ValueBool(),
+			SkipFailedDeletion:     data.SkipFailedDeletion.ValueBool(),
+			AllowForceDeleteOffers: data.AllowForceDeleteOffers.ValueBool(),
 		},
 	}
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -92,14 +92,14 @@ func jujuProviderModelEnvVar(diags diag.Diagnostics) jujuProviderModel {
 	}
 
 	return jujuProviderModel{
-		ControllerAddrs:        getEnvVar(JujuControllerEnvKey),
-		CACert:                 getEnvVar(JujuCACertEnvKey),
-		ClientID:               getEnvVar(JujuClientIDEnvKey),
-		ClientSecret:           getEnvVar(JujuClientSecretEnvKey),
-		UserName:               getEnvVar(JujuUsernameEnvKey),
-		Password:               getEnvVar(JujuPasswordEnvKey),
-		SkipFailedDeletion:     types.BoolValue(skipFailedDeletion),
-		AllowForceDeleteOffers: types.BoolValue(allowOfferForceDeletion),
+		ControllerAddrs:         getEnvVar(JujuControllerEnvKey),
+		CACert:                  getEnvVar(JujuCACertEnvKey),
+		ClientID:                getEnvVar(JujuClientIDEnvKey),
+		ClientSecret:            getEnvVar(JujuClientSecretEnvKey),
+		UserName:                getEnvVar(JujuUsernameEnvKey),
+		Password:                getEnvVar(JujuPasswordEnvKey),
+		SkipFailedDeletion:      types.BoolValue(skipFailedDeletion),
+		AllowOfferForceDeletion: types.BoolValue(allowOfferForceDeletion),
 	}
 }
 
@@ -184,8 +184,8 @@ type jujuProviderModel struct {
 	ClientID        types.String `tfsdk:"client_id"`
 	ClientSecret    types.String `tfsdk:"client_secret"`
 
-	SkipFailedDeletion     types.Bool `tfsdk:"skip_failed_deletion"`
-	AllowForceDeleteOffers types.Bool `tfsdk:"allow_offer_force_deletion"`
+	SkipFailedDeletion      types.Bool `tfsdk:"skip_failed_deletion"`
+	AllowOfferForceDeletion types.Bool `tfsdk:"allow_offer_force_deletion"`
 
 	OfferingControllers types.Map `tfsdk:"offering_controllers"`
 }
@@ -220,8 +220,8 @@ func (j jujuProviderModel) merge(in jujuProviderModel, from string) (jujuProvide
 	if mergedModel.SkipFailedDeletion.IsNull() {
 		mergedModel.SkipFailedDeletion = in.SkipFailedDeletion
 	}
-	if mergedModel.AllowForceDeleteOffers.IsNull() {
-		mergedModel.AllowForceDeleteOffers = in.AllowForceDeleteOffers
+	if mergedModel.AllowOfferForceDeletion.IsNull() {
+		mergedModel.AllowOfferForceDeletion = in.AllowOfferForceDeletion
 	}
 	if mergedModel.ControllerAddrs.ValueString() == "" {
 		mergedModel.ControllerAddrs = in.ControllerAddrs
@@ -430,9 +430,9 @@ func (p *jujuProvider) Configure(ctx context.Context, req provider.ConfigureRequ
 
 	providerData := juju.ProviderData{
 		Config: juju.Config{
-			ControllerMode:         data.ControllerMode.ValueBool(),
-			SkipFailedDeletion:     data.SkipFailedDeletion.ValueBool(),
-			AllowForceDeleteOffers: data.AllowForceDeleteOffers.ValueBool(),
+			ControllerMode:          data.ControllerMode.ValueBool(),
+			SkipFailedDeletion:      data.SkipFailedDeletion.ValueBool(),
+			AllowOfferForceDeletion: data.AllowOfferForceDeletion.ValueBool(),
 		},
 	}
 

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -506,6 +506,7 @@ func newConfigureRequest(t *testing.T, conf jujuProviderModel) provider.Configur
 		JujuClientID:            types.StringType,
 		JujuClientSecret:        types.StringType,
 		SkipFailedDeletion:      types.BoolType,
+		AllowOfferForceDeletion: types.BoolType,
 		JujuOfferingControllers: offeringControllersMapType,
 	}
 
@@ -526,7 +527,7 @@ func TestFrameworkProviderSchema(t *testing.T) {
 	resp := provider.SchemaResponse{}
 	jujuProvider.Schema(context.Background(), req, &resp)
 	assert.Equal(t, resp.Diagnostics.HasError(), false)
-	assert.Len(t, resp.Schema.Attributes, 9)
+	assert.Len(t, resp.Schema.Attributes, 10)
 }
 
 func createOfferingControllerMap(t *testing.T, extControllers map[string]map[string]attr.Value) types.Map {

--- a/internal/provider/resource_integration_test.go
+++ b/internal/provider/resource_integration_test.go
@@ -571,6 +571,10 @@ variable "enable-b2-consumer" {
 
 func testAccResourceIntegrationMultipleIntegrationsSameEndpoint(srcModelName string, dstModelName string) string {
 	return fmt.Sprintf(`
+provider "juju" {
+  allow_offer_force_deletion = true
+}
+
 resource "juju_model" "offering" {
   name = %q
 }

--- a/internal/provider/resource_integration_test.go
+++ b/internal/provider/resource_integration_test.go
@@ -346,6 +346,10 @@ resource "juju_integration" "this" {
 // and offer of pgbouncer.
 func testAccResourceIntegrationWithVia(srcModelName, aOS, dstModelName, bOS, viaCIDRs string) string {
 	return fmt.Sprintf(`
+provider "juju" {
+  allow_offer_force_deletion = true
+}
+
 resource "juju_model" "a" {
 	name = %q
 }
@@ -488,6 +492,10 @@ func TestAcc_ResourceIntegrationWithMultipleIntegrationsSameEndpoint(t *testing.
 // two juju-qa-dummy-source applications relates to source offer.
 func testAccResourceIntegrationMultipleConsumers(srcModelName string, dstModelName string) string {
 	return fmt.Sprintf(`
+provider "juju" {
+  allow_offer_force_deletion = true
+}
+
 resource "juju_model" "a" {
         name = %q
 }

--- a/internal/provider/resource_offer.go
+++ b/internal/provider/resource_offer.go
@@ -38,6 +38,7 @@ func NewOfferResource() resource.Resource {
 
 type offerResource struct {
 	client *juju.Client
+	config juju.Config
 
 	// subCtx is the context created with the new tflog subsystem for applications.
 	subCtx context.Context
@@ -275,7 +276,8 @@ func (o *offerResource) Delete(ctx context.Context, req resource.DeleteRequest, 
 	}
 
 	err := o.client.Offers.DestroyOffer(ctx, &juju.DestroyOfferInput{
-		OfferURL: plan.URL.ValueString(),
+		OfferURL:            plan.URL.ValueString(),
+		ForceFailedDeletion: o.config.ForceFailedDeletion,
 	})
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete offer, got error: %s", err))
@@ -297,6 +299,7 @@ func (o *offerResource) Configure(ctx context.Context, req resource.ConfigureReq
 	}
 
 	o.client = provider.Client
+	o.config = provider.Config
 	// Create the local logging subsystem here, using the TF context when creating it.
 	o.subCtx = tflog.NewSubsystem(ctx, LogResourceOffer)
 }

--- a/internal/provider/resource_offer.go
+++ b/internal/provider/resource_offer.go
@@ -276,8 +276,8 @@ func (o *offerResource) Delete(ctx context.Context, req resource.DeleteRequest, 
 	}
 
 	err := o.client.Offers.DestroyOffer(ctx, &juju.DestroyOfferInput{
-		OfferURL:            plan.URL.ValueString(),
-		ForceFailedDeletion: o.config.ForceFailedDeletion,
+		OfferURL:               plan.URL.ValueString(),
+		AllowForceDeleteOffers: o.config.AllowForceDeleteOffers,
 	})
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete offer, got error: %s", err))

--- a/internal/provider/resource_offer.go
+++ b/internal/provider/resource_offer.go
@@ -276,8 +276,8 @@ func (o *offerResource) Delete(ctx context.Context, req resource.DeleteRequest, 
 	}
 
 	err := o.client.Offers.DestroyOffer(ctx, &juju.DestroyOfferInput{
-		OfferURL:               plan.URL.ValueString(),
-		AllowForceDeleteOffers: o.config.AllowForceDeleteOffers,
+		OfferURL:                plan.URL.ValueString(),
+		AllowOfferForceDeletion: o.config.AllowOfferForceDeletion,
 	})
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete offer, got error: %s", err))

--- a/internal/provider/resource_offer_test.go
+++ b/internal/provider/resource_offer_test.go
@@ -53,6 +53,9 @@ func TestAcc_ResourceOffer(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccResourceOfferWithoutIntegration(modelName2, destModelName),
+			},
+			{
 				Destroy:           true,
 				ImportStateVerify: true,
 				ImportState:       true,
@@ -108,6 +111,44 @@ resource "juju_integration" "int" {
 
 	application {
 		offer_url = juju_offer.offerone.url
+	}
+}
+`, srcModelName, destModelName)
+}
+
+func testAccResourceOfferWithoutIntegration(srcModelName string, destModelName string) string {
+	return fmt.Sprintf(`
+resource "juju_model" "modelone" {
+	name = %q
+}
+
+resource "juju_application" "appone" {
+	model_uuid = juju_model.modelone.uuid
+	name  = "appone"
+
+	charm {
+		name = "juju-qa-dummy-source"
+		base = "ubuntu@22.04"
+	}
+}
+
+resource "juju_offer" "offerone" {
+	model_uuid = juju_model.modelone.uuid
+	application_name = juju_application.appone.name
+	endpoints         = ["sink"]
+}
+
+resource "juju_model" "modeldest" {
+	name = %q
+}
+
+resource "juju_application" "apptwo" {
+	model_uuid = juju_model.modeldest.uuid
+	name = "apptwo"
+
+	charm {
+		name = "juju-qa-dummy-sink"
+		base = "ubuntu@22.04"
 	}
 }
 `, srcModelName, destModelName)

--- a/internal/provider/resource_offer_test.go
+++ b/internal/provider/resource_offer_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	internaltesting "github.com/juju/terraform-provider-juju/internal/testing"
 )
 
 func TestAcc_ResourceOffer(t *testing.T) {
@@ -40,7 +41,7 @@ func TestAcc_ResourceOffer(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccResourceOfferXIntegration(modelName2, destModelName),
+				Config: testAccResourceOfferWithIntegrationTemplate(modelName2, destModelName, true),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair("juju_model.modeldest", "uuid", "juju_integration.int", "model_uuid"),
 
@@ -53,7 +54,7 @@ func TestAcc_ResourceOffer(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccResourceOfferWithoutIntegration(modelName2, destModelName),
+				Config: testAccResourceOfferWithIntegrationTemplate(modelName2, destModelName, false),
 			},
 			{
 				Destroy:           true,
@@ -65,10 +66,12 @@ func TestAcc_ResourceOffer(t *testing.T) {
 	})
 }
 
-func testAccResourceOfferXIntegration(srcModelName string, destModelName string) string {
-	return fmt.Sprintf(`
+func testAccResourceOfferWithIntegrationTemplate(srcModelName string, destModelName string, includeIntegration bool) string {
+	return internaltesting.GetStringFromTemplateWithData(
+		"testAccResourceOfferWithIntegration",
+		`
 resource "juju_model" "modelone" {
-	name = %q
+	name = "{{.SrcModelName}}"
 }
 
 resource "juju_application" "appone" {
@@ -88,7 +91,7 @@ resource "juju_offer" "offerone" {
 }
 
 resource "juju_model" "modeldest" {
-	name = %q
+	name = "{{.DestModelName}}"
 }
 
 resource "juju_application" "apptwo" {
@@ -100,7 +103,7 @@ resource "juju_application" "apptwo" {
 		base = "ubuntu@22.04"
 	}
 }
-
+{{ if .IncludeIntegration }}
 resource "juju_integration" "int" {
 	model_uuid = juju_model.modeldest.uuid
 
@@ -113,45 +116,14 @@ resource "juju_integration" "int" {
 		offer_url = juju_offer.offerone.url
 	}
 }
-`, srcModelName, destModelName)
-}
-
-func testAccResourceOfferWithoutIntegration(srcModelName string, destModelName string) string {
-	return fmt.Sprintf(`
-resource "juju_model" "modelone" {
-	name = %q
-}
-
-resource "juju_application" "appone" {
-	model_uuid = juju_model.modelone.uuid
-	name  = "appone"
-
-	charm {
-		name = "juju-qa-dummy-source"
-		base = "ubuntu@22.04"
-	}
-}
-
-resource "juju_offer" "offerone" {
-	model_uuid = juju_model.modelone.uuid
-	application_name = juju_application.appone.name
-	endpoints         = ["sink"]
-}
-
-resource "juju_model" "modeldest" {
-	name = %q
-}
-
-resource "juju_application" "apptwo" {
-	model_uuid = juju_model.modeldest.uuid
-	name = "apptwo"
-
-	charm {
-		name = "juju-qa-dummy-sink"
-		base = "ubuntu@22.04"
-	}
-}
-`, srcModelName, destModelName)
+{{ end }}
+`,
+		internaltesting.TemplateData{
+			"SrcModelName":       srcModelName,
+			"DestModelName":      destModelName,
+			"IncludeIntegration": includeIntegration,
+		},
+	)
 }
 
 func TestAcc_ResourceOffer_UpgradeProvider(t *testing.T) {


### PR DESCRIPTION
## Description

Stop implicitly using force destroy on offers and instead bubble the error up to the user.

Add provider config to let user opt into previous behaviour.

Update documentation to explain what to do.

## Type of change

- Change existing resource
- Logic changes in resources (the API interaction with Juju has been changed)
- Change in tests (one or several tests have been changed)
- Bug fix (non-breaking change which fixes an issue)
- Requires a documentation update

## QA steps

Manual QA steps should be done to test this PR.

### Setup

1. Create the following Terraform plan:

```tf
terraform {
  required_providers {
    juju = {
      source  = "juju/juju"
      version = "1.3.1"
    }
  }
}

provider "juju" {}

resource "juju_model" "source" {
  name = "qa-offer-source"
}

resource "juju_application" "source" {
  model_uuid = juju_model.source.uuid
  charm {
    name = "juju-qa-dummy-source"
  }
  config = {
    token = "abc"
  }
}

resource "juju_offer" "offer" {
  model_uuid       = juju_model.source.uuid
  application_name = juju_application.source.name
  endpoints        = ["sink"]
}

resource "juju_model" "sink" {
  name = "qa-offer-sink"
}

resource "juju_application" "sink" {
  model_uuid = juju_model.sink.uuid
  charm {
    name = "juju-qa-dummy-sink"
  }
}

resource "juju_integration" "integration" {
  model_uuid = juju_model.sink.uuid

  application {
    name     = juju_application.sink.name
    endpoint = "source"
  }

  application {
    offer_url = juju_offer.offer.url
    endpoint  = "sink"
  }
}
```

2. Run `terraform apply`

3. Run `juju status` on both models and wait for everything to be active.

4. Run `terraform state rm juju_integration.integration` 

5. Run `terraform destroy -target juju_offer.offer`, which errors out after 5 minutes:
```
juju_offer.offer: Destroying... [id=admin/qa-offer-source.juju-qa-dummy-source]
juju_offer.offer: Still destroying... [id=admin/qa-offer-source.juju-qa-dummy-source, 00m10s elapsed]
juju_offer.offer: Still destroying... [id=admin/qa-offer-source.juju-qa-dummy-source, 00m20s elapsed]
...
juju_offer.offer: Still destroying... [id=admin/qa-offer-source.juju-qa-dummy-source, 04m50s elapsed]
juju_offer.offer: Still destroying... [id=admin/qa-offer-source.juju-qa-dummy-source, 05m00s elapsed]
...
│ Error: Client Error
│ 
│ Unable to delete offer, got error: cannot destroy offer "admin/qa-offer-source.juju-qa-dummy-source": it still has 1 active connection(s) after waiting; remove all consumers first
```
