### PR TITLE
fix: correctly handle charm updates when changing channel

### DIFF
--- a/internal/provider/modifier_revision_invalidate.go
+++ b/internal/provider/modifier_revision_invalidate.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-// InvalidateRevisionIfChannelChanges returns a plan modifier that set the
+// InvalidateRevisionIfChannelChanges returns a plan modifier that sets the
 // revision to Unknown if the channel has changed.
 func InvalidateRevisionIfChannelChanges() planmodifier.Int64 {
 	return &invalidateRevisionModifier{}
@@ -37,8 +37,16 @@ func (m *invalidateRevisionModifier) PlanModifyInt64(ctx context.Context, req pl
 	channelPath := req.Path.ParentPath().AtName("channel")
 
 	var stateChannel, planChannel types.String
-	req.State.GetAttribute(ctx, channelPath, &stateChannel)
-	req.Plan.GetAttribute(ctx, channelPath, &planChannel)
+	diags := req.State.GetAttribute(ctx, channelPath, &stateChannel)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	diags = req.Plan.GetAttribute(ctx, channelPath, &planChannel)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	// If the channel is changing, mark the revision as Unknown (Known After Apply)
 	if !planChannel.Equal(stateChannel) {

--- a/internal/provider/modifier_revision_invalidate.go
+++ b/internal/provider/modifier_revision_invalidate.go
@@ -1,0 +1,47 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the Apache License, Version 2.0, see LICENCE file for details.
+
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// InvalidateRevisionIfChannelChanges returns a plan modifier that set the
+// revision to Unknown if the channel has changed.
+func InvalidateRevisionIfChannelChanges() planmodifier.Int64 {
+	return &invalidateRevisionModifier{}
+}
+
+type invalidateRevisionModifier struct{}
+
+func (m *invalidateRevisionModifier) Description(_ context.Context) string {
+	return "If the channel changes, the revision must be recalculated unless pinned."
+}
+
+func (m *invalidateRevisionModifier) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (m *invalidateRevisionModifier) PlanModifyInt64(ctx context.Context, req planmodifier.Int64Request, resp *planmodifier.Int64Response) {
+	// If the user provided an explicit revision in the config, don't override it.
+	if !req.ConfigValue.IsNull() && !req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	// We need to check if the channel (a sibling attribute) is changing.
+	// Because 'charm' is a ListNestedBlock, we look at the first element [0].
+	channelPath := req.Path.ParentPath().AtName("channel")
+
+	var stateChannel, planChannel types.String
+	req.State.GetAttribute(ctx, channelPath, &stateChannel)
+	req.Plan.GetAttribute(ctx, channelPath, &planChannel)
+
+	// If the channel is changing, mark the revision as Unknown (Known After Apply)
+	if !planChannel.Equal(stateChannel) {
+		resp.PlanValue = types.Int64Unknown()
+	}
+}

--- a/internal/provider/resource_application.go
+++ b/internal/provider/resource_application.go
@@ -398,9 +398,6 @@ func (r *applicationResource) Schema(_ context.Context, _ resource.SchemaRequest
 							Description: "The revision of the charm to deploy. During the update phase, the charm revision should be update before config update, to avoid issues with config parameters parsing.",
 							Optional:    true,
 							Computed:    true,
-							PlanModifiers: []planmodifier.Int64{
-								int64planmodifier.UseStateForUnknown(),
-							},
 						},
 						BaseKey: schema.StringAttribute{
 							Description: "The operating system on which to deploy. E.g. ubuntu@22.04. Changing this value for machine charms will trigger a replace by terraform.",
@@ -1099,10 +1096,12 @@ func (r *applicationResource) Update(ctx context.Context, req resource.UpdateReq
 			updateApplicationInput.Channel = stateCharm.Channel.ValueString()
 		}
 
-		if !planCharm.Revision.Equal(stateCharm.Revision) {
-			updateApplicationInput.Revision = intPtr(planCharm.Revision)
-		} else {
-			updateApplicationInput.Revision = intPtr(stateCharm.Revision)
+		if !planCharm.Revision.IsNull() && !planCharm.Revision.IsUnknown() {
+			if !planCharm.Revision.Equal(stateCharm.Revision) {
+				updateApplicationInput.Revision = intPtr(planCharm.Revision)
+			} else {
+				updateApplicationInput.Revision = intPtr(stateCharm.Revision)
+			}
 		}
 
 		if !planCharm.Base.Equal(stateCharm.Base) {
@@ -1278,6 +1277,19 @@ func (r *applicationResource) Update(ctx context.Context, req resource.UpdateReq
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read application resource after update, got error: %s", err))
 		return
 	}
+
+	charmType := req.Config.Schema.GetBlocks()[CharmKey].(schema.ListNestedBlock).NestedObject.Type()
+	updatedCharm, charmDiags := types.ListValueFrom(ctx, charmType, []nestedCharm{{
+		Name:     types.StringValue(readResp.Name),
+		Channel:  types.StringValue(readResp.Channel),
+		Revision: types.Int64Value(int64(readResp.Revision)),
+		Base:     types.StringValue(readResp.Base),
+	}})
+	if charmDiags.HasError() {
+		resp.Diagnostics.Append(charmDiags...)
+		return
+	}
+	plan.Charm = updatedCharm
 
 	// If the plan has refreshed the charm, changed the unit count,
 	// or changed placement, wait for the changes to be seen in

--- a/internal/provider/resource_application.go
+++ b/internal/provider/resource_application.go
@@ -398,6 +398,10 @@ func (r *applicationResource) Schema(_ context.Context, _ resource.SchemaRequest
 							Description: "The revision of the charm to deploy. During the update phase, the charm revision should be update before config update, to avoid issues with config parameters parsing.",
 							Optional:    true,
 							Computed:    true,
+							PlanModifiers: []planmodifier.Int64{
+								int64planmodifier.UseStateForUnknown(),
+								InvalidateRevisionIfChannelChanges(),
+							},
 						},
 						BaseKey: schema.StringAttribute{
 							Description: "The operating system on which to deploy. E.g. ubuntu@22.04. Changing this value for machine charms will trigger a replace by terraform.",
@@ -1082,30 +1086,21 @@ func (r *applicationResource) Update(ctx context.Context, req resource.UpdateReq
 	}
 
 	if !plan.Charm.Equal(state.Charm) {
-		var planCharms, stateCharms []nestedCharm
+		var planCharms []nestedCharm
 		resp.Diagnostics.Append(plan.Charm.ElementsAs(ctx, &planCharms, false)...)
-		resp.Diagnostics.Append(state.Charm.ElementsAs(ctx, &stateCharms, false)...)
 		if resp.Diagnostics.HasError() {
 			return
 		}
 		planCharm := planCharms[0]
-		stateCharm := stateCharms[0]
-		if !planCharm.Channel.Equal(stateCharm.Channel) {
-			updateApplicationInput.Channel = planCharm.Channel.ValueString()
+		updateApplicationInput.Channel = planCharm.Channel.ValueString()
+		updateApplicationInput.Base = planCharm.Base.ValueString()
+
+		// If the revision was left empty in the plan, leave it empty here
+		// to ensure we use the latest from the channel, otherwise keep it pinned.
+		if planCharm.Revision.IsUnknown() || planCharm.Revision.IsNull() {
+			updateApplicationInput.Revision = nil
 		} else {
-			updateApplicationInput.Channel = stateCharm.Channel.ValueString()
-		}
-
-		if !planCharm.Revision.IsNull() && !planCharm.Revision.IsUnknown() {
-			if !planCharm.Revision.Equal(stateCharm.Revision) {
-				updateApplicationInput.Revision = intPtr(planCharm.Revision)
-			} else {
-				updateApplicationInput.Revision = intPtr(stateCharm.Revision)
-			}
-		}
-
-		if !planCharm.Base.Equal(stateCharm.Base) {
-			updateApplicationInput.Base = planCharm.Base.ValueString()
+			updateApplicationInput.Revision = intPtr(planCharm.Revision)
 		}
 	}
 

--- a/internal/provider/resource_application_test.go
+++ b/internal/provider/resource_application_test.go
@@ -621,12 +621,12 @@ func TestAcc_ConfigChangeKeepsCharm(t *testing.T) {
 						}
 						currentVersionStr := rs.Primary.Attributes["charm.0.revision"]
 						var err error
-						currrentVersion, err := strconv.Atoi(currentVersionStr)
+						currentVersion, err := strconv.Atoi(currentVersionStr)
 						if err != nil {
 							return fmt.Errorf("error converting revision to int: %v", err)
 						}
-						if currrentVersion != initialVersion {
-							return fmt.Errorf("expected charm revision to remain the same, but it changed from %d to %d", initialVersion, currrentVersion)
+						if currentVersion != initialVersion {
+							return fmt.Errorf("expected charm revision to remain the same, but it changed from %d to %d", initialVersion, currentVersion)
 						}
 						return nil
 					},

--- a/internal/provider/resource_application_test.go
+++ b/internal/provider/resource_application_test.go
@@ -480,31 +480,83 @@ func TestAcc_ResourceApplication_UpdatesRevisionConfig(t *testing.T) {
 	})
 }
 
-func TestAcc_CharmUpdates(t *testing.T) {
+func TestAcc_CharmUpdatesNoRevision(t *testing.T) {
 	modelName := acctest.RandomWithPrefix("tf-test-charmupdates")
+	initialVersion := 0
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceApplicationUpdatesCharm(modelName, "latest/stable"),
+				Config: testAccResourceApplicationUpdatesCharm(modelName, "1.33/stable"),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("juju_application.this", "charm.0.channel", "latest/stable"),
+					resource.TestCheckResourceAttr("juju_application.this", "charm.0.channel", "1.33/stable"),
+					func(s *terraform.State) error {
+						// Use a check to grab the application revision and set it to initialVersion variable to be used in the next step.
+						rs, ok := s.RootModule().Resources["juju_application.this"]
+						if !ok {
+							return fmt.Errorf("not found: juju_application.this")
+						}
+						initialVersionStr := rs.Primary.Attributes["charm.0.revision"]
+						var err error
+						initialVersion, err = strconv.Atoi(initialVersionStr)
+						if err != nil {
+							return fmt.Errorf("error converting revision to int: %v", err)
+						}
+						if initialVersion == 0 {
+							return fmt.Errorf("expected initial charm revision to be non-zero, got %d", initialVersion)
+						}
+						return nil
+					},
 				),
 			},
 			{
-				// move to latest/edge
-				Config: testAccResourceApplicationUpdatesCharm(modelName, "latest/edge"),
+				// move to 1.34/stable
+				Config: testAccResourceApplicationUpdatesCharm(modelName, "1.34/stable"),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("juju_application.this", "charm.0.channel", "latest/edge"),
+					resource.TestCheckResourceAttr("juju_application.this", "charm.0.channel", "1.34/stable"),
+					func(s *terraform.State) error {
+						// Check that the charm revision has been updated to a new revision different from the initialVersion.
+						rs, ok := s.RootModule().Resources["juju_application.this"]
+						if !ok {
+							return fmt.Errorf("not found: juju_application.this")
+						}
+						newVersionStr := rs.Primary.Attributes["charm.0.revision"]
+						var err error
+						newVersion, err := strconv.Atoi(newVersionStr)
+						if err != nil {
+							return fmt.Errorf("error converting revision to int: %v", err)
+						}
+						if newVersion == initialVersion {
+							return fmt.Errorf("expected charm revision to be updated from %d, but it is still %d", initialVersion, newVersion)
+						}
+						return nil
+					},
 				),
 			},
 			{
-				// move back to latest/stable
-				Config: testAccResourceApplicationUpdatesCharm(modelName, "latest/stable"),
+				// move back to 1.33/stable
+				Config: testAccResourceApplicationUpdatesCharm(modelName, "1.33/stable"),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("juju_application.this", "charm.0.channel", "latest/stable"),
+					resource.TestCheckResourceAttr("juju_application.this", "charm.0.channel", "1.33/stable"),
+					func(s *terraform.State) error {
+						// Check that the charm revision has been updated back to the initialVersion.
+						rs, ok := s.RootModule().Resources["juju_application.this"]
+						if !ok {
+							return fmt.Errorf("not found: juju_application.this")
+						}
+						revisionStr := rs.Primary.Attributes["charm.0.revision"]
+						var err error
+						revision, err := strconv.Atoi(revisionStr)
+						if err != nil {
+							return fmt.Errorf("error converting revision to int: %v", err)
+						}
+						if revision != initialVersion {
+							return fmt.Errorf("expected charm revision to be updated back to initial version %d, but it is %d", initialVersion, revision)
+						}
+						return nil
+					},
 				),
 			},
 		},
@@ -2063,7 +2115,7 @@ func testAccResourceApplicationUpdatesCharm(modelName string, channel string) st
 		  model_uuid = juju_model.this.uuid
 		  name = "test-app"
 		  charm {
-			name     = "ubuntu"
+			name     = "k8s-worker"
 			channel = %q
 		  }
 		}

--- a/internal/provider/resource_application_test.go
+++ b/internal/provider/resource_application_test.go
@@ -483,16 +483,21 @@ func TestAcc_ResourceApplication_UpdatesRevisionConfig(t *testing.T) {
 func TestAcc_CharmUpdatesNoRevision(t *testing.T) {
 	modelName := acctest.RandomWithPrefix("tf-test-charmupdates")
 	initialVersion := 0
-	skipTestIfJujuAgentVersionBelow(t, "3.3.0")
+	channelOne := "latest/stable"
+	channelTwo := "2.0/stable"
+	if testingCloud == MicroK8sTesting {
+		channelOne = "1.34/stable"
+		channelTwo = "1.35/stable"
+	}
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceApplicationUpdatesCharm(modelName, "1.33/stable"),
+				Config: testAccResourceApplicationUpdatesCharm(modelName, channelOne),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("juju_application.this", "charm.0.channel", "1.33/stable"),
+					resource.TestCheckResourceAttr("juju_application.this", "charm.0.channel", channelOne),
 					func(s *terraform.State) error {
 						// Use a check to grab the application revision and set it to initialVersion variable to be used in the next step.
 						rs, ok := s.RootModule().Resources["juju_application.this"]
@@ -513,7 +518,7 @@ func TestAcc_CharmUpdatesNoRevision(t *testing.T) {
 				),
 			},
 			{
-				// move to 1.34/stable
+				// move to a new channel
 				PreConfig: func() {
 					// This sleep is necessary because without it, Juju does not update the charm revision and the test fails.
 					// It is unclear where exactly the problem is, but it is almost certainly in the computeCharmID logic,
@@ -521,9 +526,9 @@ func TestAcc_CharmUpdatesNoRevision(t *testing.T) {
 					// (likely) a race condition/timing issue on the controller side.
 					time.Sleep(15 * time.Second)
 				},
-				Config: testAccResourceApplicationUpdatesCharm(modelName, "1.34/stable"),
+				Config: testAccResourceApplicationUpdatesCharm(modelName, channelTwo),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("juju_application.this", "charm.0.channel", "1.34/stable"),
+					resource.TestCheckResourceAttr("juju_application.this", "charm.0.channel", channelTwo),
 					func(s *terraform.State) error {
 						// Check that the charm revision has been updated to a new revision different from the initialVersion.
 						rs, ok := s.RootModule().Resources["juju_application.this"]
@@ -538,6 +543,90 @@ func TestAcc_CharmUpdatesNoRevision(t *testing.T) {
 						}
 						if newVersion == initialVersion {
 							return fmt.Errorf("expected charm revision to be updated from %d, but it is still %d", initialVersion, newVersion)
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+// TestAcc_ConfigChangeKeepsCharm tests that when a field on a juju_application resource
+// is changed, that is not related to the charm, it does not trigger a charm refresh.
+func TestAcc_ConfigChangeKeepsCharm(t *testing.T) {
+	modelName := acctest.RandomWithPrefix("tf-test-charmupdates")
+	initialVersion := 0
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: frameworkProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceApplicationCharmWithRevisionAndConfig(modelName, "latest/stable", "20", nil),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("juju_application.this", "charm.0.channel", "latest/stable"),
+					func(s *terraform.State) error {
+						// Use a check to grab the application revision and set it to initialVersion variable to be used in the next step.
+						rs, ok := s.RootModule().Resources["juju_application.this"]
+						if !ok {
+							return fmt.Errorf("not found: juju_application.this")
+						}
+						initialVersionStr := rs.Primary.Attributes["charm.0.revision"]
+						var err error
+						initialVersion, err = strconv.Atoi(initialVersionStr)
+						if err != nil {
+							return fmt.Errorf("error converting revision to int: %v", err)
+						}
+						if initialVersion == 0 {
+							return fmt.Errorf("expected initial charm revision to be non-zero, got %d", initialVersion)
+						}
+						return nil
+					},
+				),
+			},
+			{
+				// Remove the revision from the plan.
+				Config: testAccResourceApplicationCharmWithRevisionAndConfig(modelName, "latest/stable", "", nil),
+				PreConfig: func() {
+					// This sleep is necessary because without it, Juju does not update the charm revision and the test fails.
+					// It is unclear where exactly the problem is, but it is almost certainly in the computeCharmID logic,
+					// specifically the resolveCharm function, which calls charmsAPIClient.ResolveCharms so possibly
+					// (likely) a race condition/timing issue on the controller side.
+					time.Sleep(15 * time.Second)
+				},
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			{
+				// Add a config key the plan.
+				Config: testAccResourceApplicationCharmWithRevisionAndConfig(modelName, "latest/stable", "", map[string]string{"thing": "foo"}),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectNonEmptyPlan(),
+					},
+				},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("juju_application.this", "charm.0.channel", "latest/stable"),
+					// Check that the config change is in the state.
+					resource.TestCheckResourceAttr("juju_application.this", "config.thing", "foo"),
+					func(s *terraform.State) error {
+						// Check that the charm revision remains the same.
+						rs, ok := s.RootModule().Resources["juju_application.this"]
+						if !ok {
+							return fmt.Errorf("not found: juju_application.this")
+						}
+						currentVersionStr := rs.Primary.Attributes["charm.0.revision"]
+						var err error
+						currrentVersion, err := strconv.Atoi(currentVersionStr)
+						if err != nil {
+							return fmt.Errorf("error converting revision to int: %v", err)
+						}
+						if currrentVersion != initialVersion {
+							return fmt.Errorf("expected charm revision to remain the same, but it changed from %d to %d", initialVersion, currrentVersion)
 						}
 						return nil
 					},
@@ -2099,7 +2188,7 @@ func testAccResourceApplicationUpdatesCharm(modelName string, channel string) st
 		  model_uuid = juju_model.this.uuid
 		  name = "test-app"
 		  charm {
-			name     = "k8s-worker"
+			name     = "juju-qa-test"
 			channel = %q
 		  }
 		}
@@ -2120,6 +2209,38 @@ func testAccResourceApplicationUpdatesCharm(modelName string, channel string) st
 		}
 		`, modelName, channel)
 	}
+}
+
+func testAccResourceApplicationCharmWithRevisionAndConfig(modelName, channel, revision string, config map[string]string) string {
+	return internaltesting.GetStringFromTemplateWithData("testAccResourceApplicationUpdatesCharm", `
+		resource "juju_model" "this" {
+		  name = "{{.ModelName}}"
+		}
+
+		resource "juju_application" "this" {
+		  model_uuid = juju_model.this.uuid
+		  name       = "test-app"
+		  charm {
+			name    = "juju-qa-test"
+			channel = "{{.Channel}}"
+			{{- if .Revision }}
+			revision = "{{.Revision}}"
+			{{- end }}
+		  }
+		  {{- if .Config }}
+		  config = {
+			{{- range $key, $value := .Config }}
+			{{$key}} = "{{$value}}"
+			{{- end }}
+		  }
+		  {{- end }}
+		}
+		`, internaltesting.TemplateData{
+		"ModelName": modelName,
+		"Channel":   channel,
+		"Revision":  revision,
+		"Config":    config,
+	})
 }
 
 func testAccResourceApplicationUpdatesCharmWithRevision(modelName string, channel string, revision string) string {

--- a/internal/provider/resource_application_test.go
+++ b/internal/provider/resource_application_test.go
@@ -483,6 +483,7 @@ func TestAcc_ResourceApplication_UpdatesRevisionConfig(t *testing.T) {
 func TestAcc_CharmUpdatesNoRevision(t *testing.T) {
 	modelName := acctest.RandomWithPrefix("tf-test-charmupdates")
 	initialVersion := 0
+	skipTestIfJujuAgentVersionBelow(t, "3.3.0")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -513,6 +514,13 @@ func TestAcc_CharmUpdatesNoRevision(t *testing.T) {
 			},
 			{
 				// move to 1.34/stable
+				PreConfig: func() {
+					// This sleep is necessary because without it, Juju does not update the charm revision and the test fails.
+					// It is unclear where exactly the problem is, but it is almost certainly in the computeCharmID logic,
+					// specifically the resolveCharm function, which calls charmsAPIClient.ResolveCharms so possibly
+					// (likely) a race condition/timing issue on the controller side.
+					time.Sleep(15 * time.Second)
+				},
 				Config: testAccResourceApplicationUpdatesCharm(modelName, "1.34/stable"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("juju_application.this", "charm.0.channel", "1.34/stable"),
@@ -530,30 +538,6 @@ func TestAcc_CharmUpdatesNoRevision(t *testing.T) {
 						}
 						if newVersion == initialVersion {
 							return fmt.Errorf("expected charm revision to be updated from %d, but it is still %d", initialVersion, newVersion)
-						}
-						return nil
-					},
-				),
-			},
-			{
-				// move back to 1.33/stable
-				Config: testAccResourceApplicationUpdatesCharm(modelName, "1.33/stable"),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("juju_application.this", "charm.0.channel", "1.33/stable"),
-					func(s *terraform.State) error {
-						// Check that the charm revision has been updated back to the initialVersion.
-						rs, ok := s.RootModule().Resources["juju_application.this"]
-						if !ok {
-							return fmt.Errorf("not found: juju_application.this")
-						}
-						revisionStr := rs.Primary.Attributes["charm.0.revision"]
-						var err error
-						revision, err := strconv.Atoi(revisionStr)
-						if err != nil {
-							return fmt.Errorf("error converting revision to int: %v", err)
-						}
-						if revision != initialVersion {
-							return fmt.Errorf("expected charm revision to be updated back to initial version %d, but it is %d", initialVersion, revision)
 						}
 						return nil
 					},


### PR DESCRIPTION
## Description

Note: This PR recreates https://github.com/juju/terraform-provider-juju/pull/1213 since the `1.5` branch was closed in favour of `v1.5`.

Reported in https://github.com/juju/terraform-provider-juju/issues/1212, when a `juju_application` resource specifies only a charm channel and no revision, the initial deployment/`terraform apply` works fine and the latest charm in the channel is deployed. If you change the channel however, running `terraform apply ` keeps the revision fixed and only updates the channel. This is problematic because any resources will come from the tip of the channel while the charm is still one from a different channel.

The issue becomes almost certainly a bug when looking at the code. Also described in the issue, the `revision` field is marked with the plan modifier `UseStateForUnknown` so even when the plan omits the revision, the value in state is passed through the client and onto Juju, keeping it fixed.

One solution to this is to take the approach our docs suggest here https://documentation.ubuntu.com/terraform-provider-juju/v1/howto/manage-charms/#compute-a-charm-s-revision-automatically and use the `juju_charm` data source. ~~But the fix for the bug is straightforward - we simply don't use the plan modifier `UseStateForUnknown`~~ One fix for the bug is to add a new plan modifier like `InvalidateRevisionIfChannelChanges()` that invalidates the revision if revision is not pinned and the channel has changed.

Fixes: https://github.com/juju/terraform-provider-juju/issues/1212, [JUJU-9827](https://warthogs.atlassian.net/browse/JUJU-9827)

## Type of change


- Change existing resource

## QA steps

The updated test verifies the fix. With the updated test and the existing logic, the test fails, with the removal of the plan modifier and the supporting changes, the test passes.

[JUJU-9827]: https://warthogs.atlassian.net/browse/JUJU-9827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ