### PR TITLE
fix: unitcounts bug when machines is unknown

### DIFF
--- a/internal/provider/modifier_units.go
+++ b/internal/provider/modifier_units.go
@@ -44,6 +44,14 @@ func (m unitCountModifier) PlanModifyInt64(ctx context.Context, req planmodifier
 		return
 	}
 
+	// If machines is unknown, units cannot be determined yet.
+	// Setting unknown here prevents the plan from committing to a concrete
+	// value that will differ from the actual count once machines are resolved.
+	if machines.IsUnknown() {
+		resp.PlanValue = types.Int64Unknown()
+		return
+	}
+
 	if len(machines.Elements()) > 0 {
 		resp.PlanValue = types.Int64Value(int64(len(machines.Elements())))
 		return

--- a/internal/provider/resource_application.go
+++ b/internal/provider/resource_application.go
@@ -633,7 +633,13 @@ func (r *applicationResource) Create(ctx context.Context, req resource.CreateReq
 		}
 	}
 
-	unitCount := int(plan.UnitCount.ValueInt64())
+	// When machines is unknown at plan time, UnitCount will be unknown too.
+	// Default to 1 so we don't accidentally deploy 0 units; the machines block
+	// below will override this once machines are resolved.
+	unitCount := 1
+	if !plan.UnitCount.IsUnknown() {
+		unitCount = int(plan.UnitCount.ValueInt64())
+	}
 	machines := []string{}
 	if !plan.Machines.IsUnknown() {
 		resp.Diagnostics.Append(plan.Machines.ElementsAs(ctx, &machines, false)...)

--- a/internal/provider/resource_application_test.go
+++ b/internal/provider/resource_application_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	apiapplication "github.com/juju/juju/api/client/application"
 	apiclient "github.com/juju/juju/api/client/client"
 	"github.com/juju/juju/api/client/resources"
@@ -1227,7 +1228,7 @@ func TestAcc_ResourceApplication_MachinesWithSubordinates(t *testing.T) {
 	charmName := "juju-qa-test"
 
 	resourceName := "juju_application.testapp"
-	numberOfMachines := 10
+	numberOfMachines := 3
 
 	checkResourceAttrMachines := func(numberOfMachines int) []resource.TestCheckFunc {
 		return []resource.TestCheckFunc{
@@ -1259,11 +1260,11 @@ func TestAcc_ResourceApplication_MachinesWithSubordinates(t *testing.T) {
 				checkResourceAttrMachines(numberOfMachines - 1)...),
 		}, {
 			ConfigVariables: config.Variables{
-				"machines": config.IntegerVariable(2),
+				"machines": config.IntegerVariable(1),
 			},
 			Config: testAccResourceApplicationBasic_MachinesWithSubordinates(modelName, charmName),
 			Check: resource.ComposeTestCheckFunc(
-				checkResourceAttrMachines(2)...),
+				checkResourceAttrMachines(1)...),
 		}, {
 			ImportStateVerify: true,
 			ImportState:       true,
@@ -3094,4 +3095,76 @@ resource "juju_application" "test_app" {
 			"Revision":  revision,
 			"ConfigNew": configNew,
 		})
+}
+
+// TestAcc_ResourceApplication_UnknownMachinesUnitsDeferred verifies that when
+// the machines set is unknown at plan time (simulated via terraform_data whose
+// output is not yet known), the units attribute is also marked unknown rather
+// than incorrectly defaulting to 1.
+func TestAcc_ResourceApplication_UnknownMachinesUnitsDeferred(t *testing.T) {
+	if testingCloud != LXDCloudTesting {
+		t.Skip(t.Name() + " only runs with LXD")
+	}
+	modelName := acctest.RandomWithPrefix("tf-test-application-unknown-machines")
+	resourceName := "juju_application.testapp"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: frameworkProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				// On the first plan the terraform_data output is unknown, so
+				// toset(...) produces an unknown set — exactly what happens when
+				// machine IDs come from a not-yet-applied juju_machine inside a
+				// module. The modifier must defer units (mark it unknown) rather
+				// than falling through to the default of 1.
+				Config: testAccResourceApplicationUnknownMachines(modelName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("units")),
+					},
+				},
+			},
+			{
+				// After apply the machines are known; units must equal the
+				// number of machines (2) and the plan must be stable — i.e.
+				// the modifier must NOT drift units back to 1 from the state
+				// value of 2.
+				Config: testAccResourceApplicationUnknownMachines(modelName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "units", "2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccResourceApplicationUnknownMachines(modelName string) string {
+	return fmt.Sprintf(`
+		resource "juju_model" "model" {
+		  name = %q
+		}
+		resource "juju_machine" "machine1" {
+		  model_uuid = juju_model.model.uuid
+		  base       = "ubuntu@22.04"
+		}
+		resource "juju_machine" "machine2" {
+		  model_uuid = juju_model.model.uuid
+		  base       = "ubuntu@22.04"
+		}
+		# terraform_data.output is unknown on the first plan because it mirrors
+		# its input, which depends on juju_machine.machine.machine_id that has
+		# not been applied yet. This produces an unknown set for machines.
+		resource "terraform_data" "machine_ids" {
+		  input = [juju_machine.machine1.machine_id, juju_machine.machine2.machine_id]
+		}
+		resource "juju_application" "testapp" {
+		  model_uuid = juju_model.model.uuid
+		  machines   = toset(terraform_data.machine_ids.output)
+		  charm {
+			name = "juju-qa-test"
+			base = "ubuntu@22.04"
+		  }
+		}
+		`, modelName)
 }


### PR DESCRIPTION
# Description

Following a reported issue, we weren't setting unknown number of units when the machine array was unknown. This was causing a provider error, because we were defaulting to 1, and then when machines was known an other number, resulting in an error "produced an invalid new value for .units:"

Fix #1168 

The solution was to:
- set the unit count to unknown if machines is unknown
- set the unit count to 1 if machines and units are unknown at creation time