### PR TITLE
feat: explicit force destroy of offers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,8 @@ modules-dev/
 .vscode
 .envrc
 vendor/
-__debug_bin
+__debug_bin*
 test.env
 /tmp
 modules/
+qa/

--- a/docs-rtd/howto/manage-offers.md
+++ b/docs-rtd/howto/manage-offers.md
@@ -37,6 +37,27 @@ resource "juju_offer" "percona-cluster" {
 }
 ```
 
+You can optionally configure behaviour:
+
+- `timeouts` — A block to configure custom timeouts for create and delete operations.
+- `allow_force_destroy` (default: `false`) — Allows the offer to be force-destroyed even if it has active connections. Force destroy may not actually be used if not necessary.
+
+Use of `allow_force_destroy` is potentially dangerous and should be avoided if at all possible. Note that changing it to `true` first requires applying the plan, so it is updated on the resource.
+
+```terraform
+resource "juju_offer" "percona-cluster" {
+  model_uuid       = juju_model.development.uuid
+  application_name = juju_application.percona-cluster.name
+  endpoints         = ["server"]
+  allow_force_destroy = true
+
+  timeouts {
+    create = "2m"
+    delete = "10m"
+  }
+}
+```
+
 > See more: [`juju_offer` (resource)](../reference/terraform-provider/resources/offer)
 
 

--- a/docs-rtd/reference/terraform-provider/resources/offer.md
+++ b/docs-rtd/reference/terraform-provider/resources/offer.md
@@ -44,12 +44,22 @@ resource "juju_integration" "myintegration" {
 
 ### Optional
 
+- `allow_force_destroy` (Boolean) Allows the offer to be force-destroyed if it has active connections. Force destroy may not actually be used if not necessary.
 - `name` (String) The name of the offer. Changing this value will cause the offer to be destroyed and recreated by terraform.
+- `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only
 
 - `id` (String) The ID of this resource.
 - `url` (String) The offer URL.
+
+<a id="nestedblock--timeouts"></a>
+### Nested Schema for `timeouts`
+
+Optional:
+
+- `create` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).
+- `delete` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Setting a timeout for a Delete operation is only applicable if changes are saved into state before the destroy operation occurs.
 
 ## Import
 

--- a/docs/resources/offer.md
+++ b/docs/resources/offer.md
@@ -44,12 +44,22 @@ resource "juju_integration" "myintegration" {
 
 ### Optional
 
+- `allow_force_destroy` (Boolean) Allows the offer to be force-destroyed if it has active connections. Force destroy may not actually be used if not necessary.
 - `name` (String) The name of the offer. Changing this value will cause the offer to be destroyed and recreated by terraform.
+- `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only
 
 - `id` (String) The ID of this resource.
 - `url` (String) The offer URL.
+
+<a id="nestedblock--timeouts"></a>
+### Nested Schema for `timeouts`
+
+Optional:
+
+- `create` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).
+- `delete` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Setting a timeout for a Delete operation is only applicable if changes are saved into state before the destroy operation occurs.
 
 ## Import
 

--- a/internal/juju/offers.go
+++ b/internal/juju/offers.go
@@ -7,11 +7,14 @@ import (
 	"context"
 	stderr "errors"
 	"fmt"
+	"regexp"
 	"slices"
 	"strings"
 	"time"
 
 	"github.com/juju/errors"
+	"github.com/juju/names/v5"
+
 	"github.com/juju/juju/api"
 	apiapplication "github.com/juju/juju/api/client/application"
 	"github.com/juju/juju/api/client/applicationoffers"
@@ -19,13 +22,9 @@ import (
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/rpc/params"
-	"github.com/juju/names/v5"
 )
 
 const (
-	// OfferAppAvailableTimeout is the time to wait for an app to be available
-	// before creating an offer.
-	OfferAppAvailableTimeout = time.Second * 60
 	// OfferApiTickWait is the time to wait between consecutive requests
 	// to the API
 	OfferApiTickWait = time.Second * 5
@@ -34,6 +33,18 @@ const (
 // RemoteAppNotFoundError is returned when a remote app
 // cannot be found when contacting the Juju API.
 var RemoteAppNotFoundError = errors.ConstError("remote-app-not-found")
+
+// OfferHasConnectionsError is returned when a non-forced destroy is attempted
+// while the offer still has active connections.
+var OfferHasConnectionsError = errors.ConstError("offer-has-connections")
+
+// offerHasConnectionsJuju3Re matches error messages returned by Juju 3
+// when attempting to destroy an offer with active connections.
+var offerHasConnectionsJuju3Re = regexp.MustCompile(`cannot delete application offer .+: offer has \d+ relations?`)
+
+// offerHasConnectionsJuju4Re matches error messages returned by Juju 4
+// when attempting to destroy an offer with active connections.
+var offerHasConnectionsJuju4Re = regexp.MustCompile(`cannot delete offer .+, it has \d+ connections?`)
 
 type offersClient struct {
 	SharedClient
@@ -78,6 +89,7 @@ type ReadOfferResponse struct {
 // DestroyOfferInput represents input for destroying an offer.
 type DestroyOfferInput struct {
 	OfferURL string
+	Force    bool
 }
 
 // ConsumeRemoteOfferInput represents input for consuming a remote offer.
@@ -165,9 +177,6 @@ func (c *offersClient) CreateOffer(ctx context.Context, input *CreateOfferInput)
 	applicationClient := apiapplication.NewClient(modelConn)
 
 	// wait for the app to be available
-	ctx, cancel := context.WithTimeout(ctx, OfferAppAvailableTimeout)
-	defer cancel()
-
 	err = WaitForAppsAvailable(ctx, applicationClient, []string{input.ApplicationName}, OfferApiTickWait)
 	if err != nil {
 		return nil, append(errs, errors.New("the application was not available to be offered"))
@@ -265,7 +274,10 @@ func (c *offersClient) ReadOffer(ctx context.Context, input *ReadOfferInput) (*R
 	return &response, nil
 }
 
-// DestroyOffer destroys offer managed by the offer resource.
+// DestroyOffer makes a single attempt to destroy an offer.
+//
+// If the offer still has active connections, OfferHasConnectionsError is
+// returned so the caller can decide whether to retry or force-destroy.
 func (c *offersClient) DestroyOffer(ctx context.Context, input *DestroyOfferInput) error {
 	conn, err := c.GetConnection(ctx, nil)
 	if err != nil {
@@ -274,36 +286,29 @@ func (c *offersClient) DestroyOffer(ctx context.Context, input *DestroyOfferInpu
 	defer func() { _ = conn.Close() }()
 
 	client := applicationoffers.NewClient(conn)
-	offer, err := client.ApplicationOffer(ctx, input.OfferURL)
+
+	if input.Force {
+		// Ignore any possible active connections
+		return client.DestroyOffers(ctx, true, input.OfferURL)
+	}
+
+	// Unfortunate string match because Juju client throws away the error `Code`.
+	// Even more unfortunately, the error message differs between Juju 3 and 4.
+	version, err := c.GetControllerVersion(ctx)
 	if err != nil {
 		return err
 	}
+	hasConnectionsRe := offerHasConnectionsJuju3Re
+	if version.Major >= 4 {
+		hasConnectionsRe = offerHasConnectionsJuju4Re
+	}
 
-	forceDestroy := false
-	//This code loops until it detects 0 connections in the offer or 3 minutes elapses
-	if len(offer.Connections) > 0 {
-		end := time.Now().Add(5 * time.Minute)
-		c.Tracef(fmt.Sprintf("offer %q has %d connections, waiting for them to be removed before destroying", offer.OfferURL, len(offer.Connections)))
-		for ok := true; ok; ok = len(offer.Connections) > 0 {
-			//if we have been failing to destroy offer for 5 minutes then force destroy
-			//TODO: investigate cleaner solution (acceptance tests fail even if timeout set to 20m)
-			if time.Now().After(end) {
-				forceDestroy = true
-				break
-			}
-			time.Sleep(10 * time.Second)
-			offer, err = client.ApplicationOffer(ctx, input.OfferURL)
-			if err != nil {
-				return err
-			}
+	if err := client.DestroyOffers(ctx, false, input.OfferURL); err != nil {
+		if hasConnectionsRe.MatchString(err.Error()) {
+			return OfferHasConnectionsError
 		}
-	}
-
-	err = client.DestroyOffers(ctx, forceDestroy, input.OfferURL)
-	if err != nil {
 		return err
 	}
-
 	return nil
 }
 

--- a/internal/provider/list_offers.go
+++ b/internal/provider/list_offers.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/list"
 	listschema "github.com/hashicorp/terraform-plugin-framework/list/schema"
@@ -155,6 +157,20 @@ func (r *offerLister) getOfferResource(ctx context.Context, offer juju.ListOffer
 		return offerResourceModelV2{}, diags
 	}
 	resource.Endpoints = endpointSet
+
+	resource.AllowForceDestroy = types.BoolValue(false)
+	resource.Timeouts = timeouts.Value{
+		Object: types.ObjectValueMust(
+			map[string]attr.Type{
+				"create": types.StringType,
+				"delete": types.StringType,
+			},
+			map[string]attr.Value{
+				"create": types.StringValue("1m"),
+				"delete": types.StringValue("5m"),
+			},
+		),
+	}
 
 	return resource, diags
 }

--- a/internal/provider/resource_integration_test.go
+++ b/internal/provider/resource_integration_test.go
@@ -378,6 +378,10 @@ resource "juju_offer" "b" {
 	model_uuid       = juju_model.b.uuid
 	application_name = juju_application.b.name
 	endpoints        = ["sink"]
+	allow_force_destroy = true
+	timeouts {
+		delete = "10s"
+	}
 }
 
 resource "juju_integration" "a" {
@@ -505,6 +509,10 @@ resource "juju_offer" "a" {
         model_uuid       = juju_model.a.uuid
         application_name = juju_application.a.name
         endpoints        = ["source"]
+        allow_force_destroy = true
+        timeouts {
+                delete = "10s"
+        }
 }
 
 resource "juju_model" "b" {
@@ -603,12 +611,20 @@ resource "juju_offer" "appzero_endpoint" {
   model_uuid       = juju_model.offering.uuid
   application_name = juju_application.appzero.name
   endpoints        = ["sink"]
+  allow_force_destroy = true
+  timeouts {
+    delete = "10s"
+  }
 }
 
 resource "juju_offer" "appone_endpoint" {
   model_uuid       = juju_model.offering.uuid
   application_name = juju_application.appone.name
   endpoints        = ["sink"]
+  allow_force_destroy = true
+  timeouts {
+    delete = "10s"
+  }
 }
 
 resource "juju_model" "consuming" {

--- a/internal/provider/resource_offer.go
+++ b/internal/provider/resource_offer.go
@@ -359,7 +359,6 @@ func (o *offerResource) Delete(ctx context.Context, req resource.DeleteRequest, 
 			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to force delete offer, got error: %s", err))
 			return
 		}
-		o.trace(fmt.Sprintf("deleted offer resource %q", offerURL))
 	}
 	o.trace(fmt.Sprintf("deleted offer resource %q", offerURL))
 }

--- a/internal/provider/resource_offer.go
+++ b/internal/provider/resource_offer.go
@@ -7,12 +7,15 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/identityschema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -20,9 +23,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-
 	"github.com/juju/names/v5"
 	"github.com/juju/terraform-provider-juju/internal/juju"
+	"github.com/juju/terraform-provider-juju/internal/retry"
+	"github.com/juju/terraform-provider-juju/internal/wait"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -53,8 +57,10 @@ type offerResourceModel struct {
 
 type offerResourceModelV2 struct {
 	offerResourceModel
-	ModelUUID types.String `tfsdk:"model_uuid"`
-	Endpoints types.Set    `tfsdk:"endpoints"`
+	ModelUUID         types.String   `tfsdk:"model_uuid"`
+	Endpoints         types.Set      `tfsdk:"endpoints"`
+	AllowForceDestroy types.Bool     `tfsdk:"allow_force_destroy"`
+	Timeouts          timeouts.Value `tfsdk:"timeouts"`
 }
 
 type offerResourceIdentityModel struct {
@@ -77,8 +83,13 @@ func (o *offerResource) IdentitySchema(_ context.Context, _ resource.IdentitySch
 	}
 }
 
+const (
+	defaultOfferCreateTimeout = 1 * time.Minute
+	defaultOfferDeleteTimeout = 5 * time.Minute
+)
+
 // Schema implements resource.ResourceWithConfigure interface.
-func (o *offerResource) Schema(_ context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+func (o *offerResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Version:     2,
 		Description: "A resource that represent a Juju Offer.",
@@ -135,6 +146,19 @@ func (o *offerResource) Schema(_ context.Context, req resource.SchemaRequest, re
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
+			"allow_force_destroy": schema.BoolAttribute{
+				Description: "Allows the offer to be force-destroyed if it has active connections. " +
+					"Force destroy may not actually be used if not necessary.",
+				Optional: true,
+				Computed: true,
+				Default:  booldefault.StaticBool(false),
+			},
+		},
+		Blocks: map[string]schema.Block{
+			"timeouts": timeouts.Block(ctx, timeouts.Opts{
+				Create: true,
+				Delete: true,
+			}),
 		},
 	}
 }
@@ -153,6 +177,15 @@ func (o *offerResource) Create(ctx context.Context, req resource.CreateRequest, 
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	createTimeout, diags := plan.Timeouts.Create(ctx, defaultOfferCreateTimeout)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, createTimeout)
+	defer cancel()
 
 	modelUUID := plan.ModelUUID.ValueString()
 
@@ -248,7 +281,15 @@ func (o *offerResource) Read(ctx context.Context, req resource.ReadRequest, resp
 }
 
 func (o *offerResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	// Everything is always replaced, so Update should not be called.
+	var plan offerResourceModelV2
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Only allow_force_destroy and timeouts can change without triggering
+	// a replace, so just persist the new plan values to state.
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
 // Delete is called when the provider must delete the resource. Config
@@ -266,22 +307,61 @@ func (o *offerResource) Delete(ctx context.Context, req resource.DeleteRequest, 
 		addClientNotConfiguredError(&resp.Diagnostics, "offer", "delete")
 		return
 	}
-	var plan offerResourceModelV2
+	var state offerResourceModelV2
 
 	// Get the Terraform state from the request into the plan
-	resp.Diagnostics.Append(req.State.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	err := o.client.Offers.DestroyOffer(ctx, &juju.DestroyOfferInput{
-		OfferURL: plan.URL.ValueString(),
-	})
-	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete offer, got error: %s", err))
+	deleteTimeout, diags := state.Timeouts.Delete(ctx, defaultOfferDeleteTimeout)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
-	o.trace(fmt.Sprintf("delete offer resource %q", plan.URL))
+
+	offerURL := state.URL.ValueString()
+
+	_, err := retry.RetryOnErrors(retry.RetryOnErrorsCfg[*juju.DestroyOfferInput, struct{}]{
+		Context: ctx,
+		Input:   &juju.DestroyOfferInput{OfferURL: offerURL},
+		Do: func(ctx context.Context, input *juju.DestroyOfferInput) (struct{}, error) {
+			return struct{}{}, o.client.Offers.DestroyOffer(ctx, input)
+		},
+		RetriableErrors: []error{juju.OfferHasConnectionsError},
+		RetryConf: &wait.RetryConf{
+			Delay:       time.Second,
+			MaxDelay:    juju.OfferApiTickWait,
+			MaxDuration: deleteTimeout,
+		},
+		Logf: o.trace,
+	})
+	if err != nil {
+		if !retry.IsDurationExceeded(err) {
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete offer, got error: %s", retry.LastError(err)))
+			return
+		}
+
+		if !state.AllowForceDestroy.ValueBool() {
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf(
+				"offer %q still has connection(s) after timeout; remove integrations consuming this offer first",
+				offerURL,
+			))
+			return
+		}
+
+		o.trace(fmt.Sprintf("offer %q still has active connections after timeout; force destroying", offerURL))
+		if err := o.client.Offers.DestroyOffer(ctx, &juju.DestroyOfferInput{
+			OfferURL: offerURL,
+			Force:    true,
+		}); err != nil {
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to force delete offer, got error: %s", err))
+			return
+		}
+		o.trace(fmt.Sprintf("deleted offer resource %q", offerURL))
+	}
+	o.trace(fmt.Sprintf("deleted offer resource %q", offerURL))
 }
 
 func (o *offerResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {

--- a/internal/provider/resource_offer_test.go
+++ b/internal/provider/resource_offer_test.go
@@ -5,7 +5,9 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"log"
 	"regexp"
 	"testing"
 	"time"
@@ -640,7 +642,11 @@ func destroyDstModel(modelUUID string) error {
 	timeout := 60 * time.Second
 
 	if err := client.DestroyModel(ctx, tag, &destroyStorage, &forceDestroy, &maxWait, &timeout); err != nil {
-		return fmt.Errorf("force destroying model %s: %w", modelUUID, err)
+		if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+			log.Printf("[WARN] destroyDstModel: ignoring timeout from force-destroy of model %s: %v", modelUUID, err)
+		} else {
+			return fmt.Errorf("force destroying model %s: %w", modelUUID, err)
+		}
 	}
 	return nil
 }

--- a/internal/provider/resource_offer_test.go
+++ b/internal/provider/resource_offer_test.go
@@ -633,7 +633,7 @@ func destroyDstModel(_ *terraform.State, modelUUID string) error {
 	tag := names.NewModelTag(modelUUID)
 	destroyStorage := false
 	forceDestroy := true
-	maxWait := 5 * time.Second
+	maxWait := 1 * time.Second
 	timeout := 60 * time.Second
 
 	if err := client.DestroyModel(ctx, tag, &destroyStorage, &forceDestroy, &maxWait, &timeout); err != nil {

--- a/internal/provider/resource_offer_test.go
+++ b/internal/provider/resource_offer_test.go
@@ -449,6 +449,7 @@ resource "juju_offer" "haproxy_two" {
 // After investigating whether it's appropriate, the practitioner decies to allow
 // force destroy and try again.
 func TestAcc_ResourceOffer_DeleteTimeout(t *testing.T) {
+	SkipAgainstJuju4WithReason(t, "offer force-destroy behaviour differs in Juju 4.x")
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}

--- a/internal/provider/resource_offer_test.go
+++ b/internal/provider/resource_offer_test.go
@@ -462,14 +462,26 @@ func TestAcc_ResourceOffer_DeleteTimeout(t *testing.T) {
 		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				// Setup practitioner's plan
+				// Setup practitioner's src model with offer
 				Config: testAccResourceOfferToDelete(srcModelName, internaltesting.TemplateData{
 					"AllowForceDestroy": false,
 					"IncludeOffer":      true,
 				}),
 				// And rogue dst model with integration
 				Check: func(s *terraform.State) error {
-					return createDstModel(s, dstModelName, &dstModelUUID)
+					offer, ok := s.RootModule().Resources["juju_offer.this"]
+					if !ok {
+						return fmt.Errorf("not found: juju_offer.this")
+					}
+					offerURL := offer.Primary.Attributes["url"]
+					if offerURL == "" {
+						return fmt.Errorf("missing juju_offer.this.url")
+					}
+
+					// Update closure capture and return any error
+					var err error
+					dstModelUUID, err = createDstModel(dstModelName, offerURL)
+					return err
 				},
 			},
 			{
@@ -488,16 +500,16 @@ func TestAcc_ResourceOffer_DeleteTimeout(t *testing.T) {
 				}),
 			},
 			{
-				// Drop the offer. Force destroy should happen on timeout.
+				// Drop the offer. Force destroy should happen on timeout
 				Config: testAccResourceOfferToDelete(srcModelName, internaltesting.TemplateData{
 					"AllowForceDestroy": true,
 					"IncludeOffer":      false,
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckOfferRemoved,
-					// Clean up dst model.
+					// Clean up dst model
 					func(s *terraform.State) error {
-						return destroyDstModel(s, dstModelUUID)
+						return destroyDstModel(dstModelUUID)
 					},
 				),
 			},
@@ -569,59 +581,50 @@ func testAccCheckOfferRemoved(s *terraform.State) error {
 	}
 }
 
-func createDstModel(s *terraform.State, dstModelName string, dstModelUUID *string) error {
+func createDstModel(dstModelName string, offerURL string) (string, error) {
 	ctx := context.Background()
 
 	modelResp, err := TestClient.Models.CreateModel(ctx, juju.CreateModelInput{
 		Name: dstModelName,
 	})
 	if err != nil {
-		return fmt.Errorf("creating dst model: %w", err)
+		return "", fmt.Errorf("creating dst model: %w", err)
 	}
-	*dstModelUUID = modelResp.UUID
+	dstModelUUID := modelResp.UUID
 
 	_, err = TestClient.Applications.CreateApplication(ctx, &juju.CreateApplicationInput{
 		ApplicationName: "dst",
-		ModelUUID:       *dstModelUUID,
+		ModelUUID:       dstModelUUID,
 		CharmName:       "juju-qa-dummy-sink",
 		CharmChannel:    "stable",
 		CharmRevision:   juju.UnspecifiedRevision,
 		CharmBase:       "ubuntu@22.04",
 	})
 	if err != nil {
-		return fmt.Errorf("creating dst application: %w", err)
-	}
-
-	offer, ok := s.RootModule().Resources["juju_offer.this"]
-	if !ok {
-		return fmt.Errorf("not found: juju_offer.this")
-	}
-	offerURL := offer.Primary.Attributes["url"]
-	if offerURL == "" {
-		return fmt.Errorf("missing juju_offer.this.url")
+		return "", fmt.Errorf("creating dst application: %w", err)
 	}
 
 	_, err = TestClient.Offers.ConsumeRemoteOffer(ctx, &juju.ConsumeRemoteOfferInput{
-		ModelUUID: *dstModelUUID,
+		ModelUUID: dstModelUUID,
 		OfferURL:  offerURL,
 	})
 	if err != nil {
-		return fmt.Errorf("consuming remote offer: %w", err)
+		return "", fmt.Errorf("consuming remote offer: %w", err)
 	}
 
 	_, err = TestClient.Integrations.CreateIntegration(ctx, &juju.IntegrationInput{
-		ModelUUID: *dstModelUUID,
+		ModelUUID: dstModelUUID,
 		Apps:      []string{"dst"},
 		Endpoints: []string{"dst:source", "src"},
 	})
 	if err != nil {
-		return fmt.Errorf("creating integration: %w", err)
+		return "", fmt.Errorf("creating integration: %w", err)
 	}
 
-	return nil
+	return dstModelUUID, nil
 }
 
-func destroyDstModel(_ *terraform.State, modelUUID string) error {
+func destroyDstModel(modelUUID string) error {
 	ctx := context.Background()
 	conn, err := TestClient.Models.GetConnection(ctx, nil)
 	if err != nil {

--- a/internal/provider/resource_offer_test.go
+++ b/internal/provider/resource_offer_test.go
@@ -4,11 +4,19 @@
 package provider
 
 import (
+	"context"
 	"fmt"
+	"regexp"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	jujuparams "github.com/juju/juju/rpc/params"
+
+	"github.com/juju/terraform-provider-juju/internal/juju"
+	internaltesting "github.com/juju/terraform-provider-juju/internal/testing"
 )
 
 func TestAcc_ResourceOffer(t *testing.T) {
@@ -431,4 +439,194 @@ resource "juju_offer" "haproxy_two" {
 	endpoints        = ["sink"]
 }
 `, modelName)
+}
+
+// TestAcc_ResourceOffer_DeleteTimeout simulates a practitioner deleting an offer.
+// At first they don't realise there is an integration created outside Terraform.
+// After investigating whether it's appropriate, they allow force destroy and
+// try again.
+func TestAcc_ResourceOffer_DeleteTimeout(t *testing.T) {
+	if testingCloud != LXDCloudTesting {
+		t.Skip(t.Name() + " only runs with LXD")
+	}
+
+	srcModelName := acctest.RandomWithPrefix("tf-test-offer-src-delete")
+	dstModelName := acctest.RandomWithPrefix("tf-test-offer-dst-delete")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: frameworkProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceOfferToDelete(srcModelName, dstModelName, internaltesting.TemplateData{
+					"AllowForceDestroy": false,
+					"IncludeOffer":      true,
+				}),
+				Check: testAccCreateIntegration,
+			},
+			{
+				// Drop the offer. Destroy should time out with an active connection error
+				Config: testAccResourceOfferToDelete(srcModelName, dstModelName, internaltesting.TemplateData{
+					"AllowForceDestroy": false,
+					"IncludeOffer":      false,
+				}),
+				ExpectError: regexp.MustCompile(`(?s)still\s+has\s+connection\(s\)\s+after\s+timeout`),
+			},
+			{
+				// Restore the offer and store allow_force_destroy=true in state
+				Config: testAccResourceOfferToDelete(srcModelName, dstModelName, internaltesting.TemplateData{
+					"AllowForceDestroy": true,
+					"IncludeOffer":      true,
+				}),
+			},
+			{
+				// Drop the offer. Force destroy should happen on timeout.
+				// Clean up integration.
+				Config: testAccResourceOfferToDelete(srcModelName, dstModelName, internaltesting.TemplateData{
+					"AllowForceDestroy": true,
+					"IncludeOffer":      false,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOfferRemoved,
+					testAccRemoveIntegration,
+				),
+			},
+		},
+	})
+}
+
+func testAccResourceOfferToDelete(srcModelName, dstModelName string, data internaltesting.TemplateData) string {
+	data["SrcModelName"] = srcModelName
+	data["DstModelName"] = dstModelName
+	return internaltesting.GetStringFromTemplateWithData(
+		"testAccResourceOfferToDelete",
+		`
+resource "juju_model" "src" {
+  name = "{{.SrcModelName}}"
+}
+
+resource "juju_application" "src" {
+  model_uuid = juju_model.src.uuid
+  name       = "src"
+  charm {
+    name = "juju-qa-dummy-source"
+    base = "ubuntu@22.04"
+  }
+  config = {
+    token = "abc"
+  }
+}
+
+resource "juju_model" "dst" {
+  name = "{{.DstModelName}}"
+}
+
+resource "juju_application" "dst" {
+  model_uuid = juju_model.dst.uuid
+  name       = "dst"
+  charm {
+    name = "juju-qa-dummy-sink"
+    base = "ubuntu@22.04"
+  }
+}
+
+{{ if .IncludeOffer }}
+resource "juju_offer" "this" {
+  model_uuid          = juju_model.src.uuid
+  application_name    = juju_application.src.name
+  endpoints           = ["sink"]
+  allow_force_destroy = {{.AllowForceDestroy}}
+  timeouts {
+    delete = "10s"
+  }
+}
+{{ end }}
+`,
+		data,
+	)
+}
+
+func testAccCreateIntegration(s *terraform.State) error {
+	rs, ok := s.RootModule().Resources["juju_model.dst"]
+	if !ok {
+		return fmt.Errorf("not found: juju_model.dst")
+	}
+	modelUUID := rs.Primary.Attributes["uuid"]
+
+	offer, ok := s.RootModule().Resources["juju_offer.this"]
+	if !ok {
+		return fmt.Errorf("not found: juju_offer.this")
+	}
+	offerURL := offer.Primary.Attributes["url"]
+	if offerURL == "" {
+		return fmt.Errorf("missing juju_offer.this.url")
+	}
+
+	_, err := TestClient.Offers.ConsumeRemoteOffer(context.Background(), &juju.ConsumeRemoteOfferInput{
+		ModelUUID: modelUUID,
+		OfferURL:  offerURL,
+	})
+	if err != nil {
+		return fmt.Errorf("creating integration: %w", err)
+	}
+
+	_, err = TestClient.Integrations.CreateIntegration(context.Background(), &juju.IntegrationInput{
+		ModelUUID: modelUUID,
+		Apps:      []string{"dst"},
+		Endpoints: []string{"dst:source", "src"},
+	})
+	if err != nil {
+		return fmt.Errorf("creating integration: %w", err)
+	}
+
+	return nil
+}
+
+func testAccCheckOfferRemoved(s *terraform.State) error {
+	// juju_offer.this has already been destroyed so it is absent from state.
+	// Derive the offer URL from the src model that is still present.
+	srcModel, ok := s.RootModule().Resources["juju_model.src"]
+	if !ok {
+		return fmt.Errorf("not found: juju_model.src")
+	}
+	offerURL := fmt.Sprintf("%s/%s.src", expectedResourceOwner(), srcModel.Primary.Attributes["name"])
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	defer cancel()
+
+	for {
+		_, err := TestClient.Offers.ReadOffer(ctx, &juju.ReadOfferInput{
+			OfferURL: offerURL,
+		})
+		if err != nil {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("offer %q still exists after force destroy and timeout", offerURL)
+		case <-time.After(1 * time.Second):
+		}
+	}
+}
+
+func testAccRemoveIntegration(s *terraform.State) error {
+	rs, ok := s.RootModule().Resources["juju_model.dst"]
+	if !ok {
+		return fmt.Errorf("not found: juju_model.dst")
+	}
+	modelUUID := rs.Primary.Attributes["uuid"]
+
+	err := TestClient.Integrations.DestroyIntegration(context.Background(), &juju.IntegrationInput{
+		ModelUUID: modelUUID,
+		Endpoints: []string{"dst:source", "src"},
+	})
+	if err != nil {
+		// We sometimes lose this race
+		if jujuparams.IsCodeNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("destroying integration: %w", err)
+	}
+
+	return nil
 }

--- a/internal/provider/resource_offer_test.go
+++ b/internal/provider/resource_offer_test.go
@@ -5,7 +5,6 @@ package provider
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log"
 	"regexp"
@@ -639,14 +638,10 @@ func destroyDstModel(modelUUID string) error {
 	destroyStorage := false
 	forceDestroy := true
 	maxWait := 1 * time.Second
-	timeout := 60 * time.Second
+	timeout := 10 * time.Second
 
 	if err := client.DestroyModel(ctx, tag, &destroyStorage, &forceDestroy, &maxWait, &timeout); err != nil {
-		if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
-			log.Printf("[WARN] destroyDstModel: ignoring timeout from force-destroy of model %s: %v", modelUUID, err)
-		} else {
-			return fmt.Errorf("force destroying model %s: %w", modelUUID, err)
-		}
+		log.Printf("[WARN] destroyDstModel: ignoring failure from force-destroy of model %s: %v", modelUUID, err)
 	}
 	return nil
 }

--- a/internal/provider/resource_offer_test.go
+++ b/internal/provider/resource_offer_test.go
@@ -13,7 +13,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	jujuparams "github.com/juju/juju/rpc/params"
+	"github.com/juju/juju/api/client/modelmanager"
+	"github.com/juju/names/v6"
 
 	"github.com/juju/terraform-provider-juju/internal/juju"
 	internaltesting "github.com/juju/terraform-provider-juju/internal/testing"
@@ -442,9 +443,10 @@ resource "juju_offer" "haproxy_two" {
 }
 
 // TestAcc_ResourceOffer_DeleteTimeout simulates a practitioner deleting an offer.
-// At first they don't realise there is an integration created outside Terraform.
-// After investigating whether it's appropriate, they allow force destroy and
-// try again.
+// Unbeknownst to them, someone else has created an integration consuming this offer
+// out of band with Terraform.
+// After investigating whether it's appropriate, the practitioner decies to allow
+// force destroy and try again.
 func TestAcc_ResourceOffer_DeleteTimeout(t *testing.T) {
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
@@ -453,20 +455,26 @@ func TestAcc_ResourceOffer_DeleteTimeout(t *testing.T) {
 	srcModelName := acctest.RandomWithPrefix("tf-test-offer-src-delete")
 	dstModelName := acctest.RandomWithPrefix("tf-test-offer-dst-delete")
 
+	var dstModelUUID string
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceOfferToDelete(srcModelName, dstModelName, internaltesting.TemplateData{
+				// Setup practitioner's plan
+				Config: testAccResourceOfferToDelete(srcModelName, internaltesting.TemplateData{
 					"AllowForceDestroy": false,
 					"IncludeOffer":      true,
 				}),
-				Check: testAccCreateIntegration,
+				// And rogue dst model with integration
+				Check: func(s *terraform.State) error {
+					return createDstModel(s, dstModelName, &dstModelUUID)
+				},
 			},
 			{
 				// Drop the offer. Destroy should time out with an active connection error
-				Config: testAccResourceOfferToDelete(srcModelName, dstModelName, internaltesting.TemplateData{
+				Config: testAccResourceOfferToDelete(srcModelName, internaltesting.TemplateData{
 					"AllowForceDestroy": false,
 					"IncludeOffer":      false,
 				}),
@@ -474,30 +482,31 @@ func TestAcc_ResourceOffer_DeleteTimeout(t *testing.T) {
 			},
 			{
 				// Restore the offer and store allow_force_destroy=true in state
-				Config: testAccResourceOfferToDelete(srcModelName, dstModelName, internaltesting.TemplateData{
+				Config: testAccResourceOfferToDelete(srcModelName, internaltesting.TemplateData{
 					"AllowForceDestroy": true,
 					"IncludeOffer":      true,
 				}),
 			},
 			{
 				// Drop the offer. Force destroy should happen on timeout.
-				// Clean up integration.
-				Config: testAccResourceOfferToDelete(srcModelName, dstModelName, internaltesting.TemplateData{
+				Config: testAccResourceOfferToDelete(srcModelName, internaltesting.TemplateData{
 					"AllowForceDestroy": true,
 					"IncludeOffer":      false,
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckOfferRemoved,
-					testAccRemoveIntegration,
+					// Clean up dst model.
+					func(s *terraform.State) error {
+						return destroyDstModel(s, dstModelUUID)
+					},
 				),
 			},
 		},
 	})
 }
 
-func testAccResourceOfferToDelete(srcModelName, dstModelName string, data internaltesting.TemplateData) string {
+func testAccResourceOfferToDelete(srcModelName string, data internaltesting.TemplateData) string {
 	data["SrcModelName"] = srcModelName
-	data["DstModelName"] = dstModelName
 	return internaltesting.GetStringFromTemplateWithData(
 		"testAccResourceOfferToDelete",
 		`
@@ -517,19 +526,6 @@ resource "juju_application" "src" {
   }
 }
 
-resource "juju_model" "dst" {
-  name = "{{.DstModelName}}"
-}
-
-resource "juju_application" "dst" {
-  model_uuid = juju_model.dst.uuid
-  name       = "dst"
-  charm {
-    name = "juju-qa-dummy-sink"
-    base = "ubuntu@22.04"
-  }
-}
-
 {{ if .IncludeOffer }}
 resource "juju_offer" "this" {
   model_uuid          = juju_model.src.uuid
@@ -544,42 +540,6 @@ resource "juju_offer" "this" {
 `,
 		data,
 	)
-}
-
-func testAccCreateIntegration(s *terraform.State) error {
-	rs, ok := s.RootModule().Resources["juju_model.dst"]
-	if !ok {
-		return fmt.Errorf("not found: juju_model.dst")
-	}
-	modelUUID := rs.Primary.Attributes["uuid"]
-
-	offer, ok := s.RootModule().Resources["juju_offer.this"]
-	if !ok {
-		return fmt.Errorf("not found: juju_offer.this")
-	}
-	offerURL := offer.Primary.Attributes["url"]
-	if offerURL == "" {
-		return fmt.Errorf("missing juju_offer.this.url")
-	}
-
-	_, err := TestClient.Offers.ConsumeRemoteOffer(context.Background(), &juju.ConsumeRemoteOfferInput{
-		ModelUUID: modelUUID,
-		OfferURL:  offerURL,
-	})
-	if err != nil {
-		return fmt.Errorf("creating integration: %w", err)
-	}
-
-	_, err = TestClient.Integrations.CreateIntegration(context.Background(), &juju.IntegrationInput{
-		ModelUUID: modelUUID,
-		Apps:      []string{"dst"},
-		Endpoints: []string{"dst:source", "src"},
-	})
-	if err != nil {
-		return fmt.Errorf("creating integration: %w", err)
-	}
-
-	return nil
 }
 
 func testAccCheckOfferRemoved(s *terraform.State) error {
@@ -609,24 +569,75 @@ func testAccCheckOfferRemoved(s *terraform.State) error {
 	}
 }
 
-func testAccRemoveIntegration(s *terraform.State) error {
-	rs, ok := s.RootModule().Resources["juju_model.dst"]
-	if !ok {
-		return fmt.Errorf("not found: juju_model.dst")
-	}
-	modelUUID := rs.Primary.Attributes["uuid"]
+func createDstModel(s *terraform.State, dstModelName string, dstModelUUID *string) error {
+	ctx := context.Background()
 
-	err := TestClient.Integrations.DestroyIntegration(context.Background(), &juju.IntegrationInput{
-		ModelUUID: modelUUID,
+	modelResp, err := TestClient.Models.CreateModel(ctx, juju.CreateModelInput{
+		Name: dstModelName,
+	})
+	if err != nil {
+		return fmt.Errorf("creating dst model: %w", err)
+	}
+	*dstModelUUID = modelResp.UUID
+
+	_, err = TestClient.Applications.CreateApplication(ctx, &juju.CreateApplicationInput{
+		ApplicationName: "dst",
+		ModelUUID:       *dstModelUUID,
+		CharmName:       "juju-qa-dummy-sink",
+		CharmChannel:    "stable",
+		CharmRevision:   juju.UnspecifiedRevision,
+		CharmBase:       "ubuntu@22.04",
+	})
+	if err != nil {
+		return fmt.Errorf("creating dst application: %w", err)
+	}
+
+	offer, ok := s.RootModule().Resources["juju_offer.this"]
+	if !ok {
+		return fmt.Errorf("not found: juju_offer.this")
+	}
+	offerURL := offer.Primary.Attributes["url"]
+	if offerURL == "" {
+		return fmt.Errorf("missing juju_offer.this.url")
+	}
+
+	_, err = TestClient.Offers.ConsumeRemoteOffer(ctx, &juju.ConsumeRemoteOfferInput{
+		ModelUUID: *dstModelUUID,
+		OfferURL:  offerURL,
+	})
+	if err != nil {
+		return fmt.Errorf("consuming remote offer: %w", err)
+	}
+
+	_, err = TestClient.Integrations.CreateIntegration(ctx, &juju.IntegrationInput{
+		ModelUUID: *dstModelUUID,
+		Apps:      []string{"dst"},
 		Endpoints: []string{"dst:source", "src"},
 	})
 	if err != nil {
-		// We sometimes lose this race
-		if jujuparams.IsCodeNotFound(err) {
-			return nil
-		}
-		return fmt.Errorf("destroying integration: %w", err)
+		return fmt.Errorf("creating integration: %w", err)
 	}
 
+	return nil
+}
+
+func destroyDstModel(_ *terraform.State, modelUUID string) error {
+	ctx := context.Background()
+	conn, err := TestClient.Models.GetConnection(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("getting connection: %w", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	client := modelmanager.NewClient(conn)
+	tag := names.NewModelTag(modelUUID)
+	destroyStorage := false
+	forceDestroy := true
+	maxWait := 5 * time.Second
+	timeout := 60 * time.Second
+
+	if err := client.DestroyModel(ctx, tag, &destroyStorage, &forceDestroy, &maxWait, &timeout); err != nil {
+		return fmt.Errorf("force destroying model %s: %w", modelUUID, err)
+	}
 	return nil
 }

--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -6,6 +6,7 @@ package retry
 import (
 	"context"
 
+	jujuretry "github.com/juju/retry"
 	"github.com/juju/terraform-provider-juju/internal/wait"
 )
 
@@ -37,6 +38,22 @@ type RetryOnErrorsCfg[I any, D any] struct {
 	// RetryConf is a configuration for retrying the operation.
 	// If not provided, default values will be used.
 	RetryConf *RetryConf
+}
+
+// IsDurationExceeded returns true if the retry operation was stopped because
+// the maximum duration was exceeded.
+func IsDurationExceeded(err error) bool {
+	return jujuretry.IsDurationExceeded(err)
+}
+
+// LastError returns the underlying error from a retry operation, unwrapping
+// the retry library's envelope types (duration exceeded, attempts exceeded,
+// retry stopped).
+func LastError(err error) error {
+	if err == nil {
+		return nil
+	}
+	return jujuretry.LastError(err)
 }
 
 // RetryOnErrors waits for a condition to be met, retrying every second, by default, until the condition is met or the context is cancelled.


### PR DESCRIPTION
## Description

Stop implicitly using force destroy on offers and instead bubble the error up to the user after a timeout.
Add resource option to set the timeout.
Add resource option to let user opt into force destroy.
Update documentation to explain what to do.

## Type of change

- Change existing resource
- Logic changes in resources (the API interaction with Juju has been changed)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Requires a documentation update

## QA steps

Manual QA steps should be done to test this PR.

### Setup

1. Create the following Terraform plan:

```tf
terraform {
  required_providers {
    juju = {
      source  = "juju/juju"
      version = "..."
    }
  }
}

provider "juju" {}

resource "juju_model" "source" {
  name = "qa-offer-source"
}

resource "juju_application" "source" {
  model_uuid = juju_model.source.uuid
  charm {
    name = "juju-qa-dummy-source"
  }
  config = {
    token = "abc"
  }
}

resource "juju_offer" "offer" {
  model_uuid       = juju_model.source.uuid
  application_name = juju_application.source.name
  endpoints        = ["sink"]

  timeouts {
    delete = "1m"
  }
}

resource "juju_model" "sink" {
  name = "qa-offer-sink"
}

resource "juju_application" "sink" {
  model_uuid = juju_model.sink.uuid
  charm {
    name = "juju-qa-dummy-sink"
  }
}

resource "juju_integration" "integration" {
  model_uuid = juju_model.sink.uuid

  application {
    name     = juju_application.sink.name
    endpoint = "source"
  }

  application {
    offer_url = juju_offer.offer.url
    endpoint  = "sink"
  }
}
```

2. Run `terraform init` and `terraform apply`

3. Run `juju status` on both models and wait for everything to be active.

4. Run `terraform state rm juju_integration.integration` to forget the integration

5. Run `terraform destroy -target juju_offer.offer`, which errors out after 1 minute:
```
juju_offer.offer: Destroying... [id=admin/qa-offer-source.juju-qa-dummy-source]
juju_offer.offer: Still destroying... [id=admin/qa-offer-source.juju-qa-dummy-source, 00m10s elapsed]
juju_offer.offer: Still destroying... [id=admin/qa-offer-source.juju-qa-dummy-source, 00m20s elapsed]
...
juju_offer.offer: Still destroying... [id=admin/qa-offer-source.juju-qa-dummy-source, 01m00s elapsed]
...
│ Error: Client Error
│ 
│ Unable to delete offer, got error: cannot destroy offer "admin/qa-offer-source.juju-qa-dummy-source": it still has 1 active connection(s) after waiting; remove all consumers first
```
