### PR TITLE
Implement list spaces

### DIFF
--- a/examples/list-resources/juju_space/list-resource.tfquery.hcl
+++ b/examples/list-resources/juju_space/list-resource.tfquery.hcl
@@ -1,0 +1,11 @@
+list "juju_space" "this" {
+  provider         = juju
+  include_resource = true
+
+  config {
+    model_uuid = "<model-uuid>"
+
+    # Optional: filter by space name
+    # name = "my-space"
+  }
+}

--- a/internal/provider/list_spaces.go
+++ b/internal/provider/list_spaces.go
@@ -1,0 +1,151 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	listschema "github.com/hashicorp/terraform-plugin-framework/list/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/juju/names/v5"
+
+	"github.com/juju/terraform-provider-juju/internal/juju"
+)
+
+type listSpaceRequest struct {
+	ModelUUID types.String `tfsdk:"model_uuid"`
+	Name      types.String `tfsdk:"name"`
+}
+
+type spaceLister struct {
+	client *juju.Client
+	config juju.Config
+
+	// context for the logging subsystem.
+	subCtx context.Context
+}
+
+// NewSpaceLister returns a new instance of the space lister.
+func NewSpaceLister() list.ListResourceWithConfigure {
+	return &spaceLister{}
+}
+
+// Configure implements [list.ListResourceWithConfigure].
+func (r *spaceLister) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	provider, ok := req.ProviderData.(juju.ProviderData)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected juju.ProviderData, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	r.client = provider.Client
+	r.config = provider.Config
+	r.subCtx = tflog.NewSubsystem(ctx, LogResourceSpace)
+}
+
+// Metadata implements [list.ListResourceWithConfigure].
+func (r *spaceLister) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_space"
+}
+
+// ListResourceConfigSchema implements [list.ListResourceWithConfigure].
+func (r *spaceLister) ListResourceConfigSchema(_ context.Context, _ list.ListResourceSchemaRequest, resp *list.ListResourceSchemaResponse) {
+	resp.Schema = listschema.Schema{
+		Attributes: map[string]listschema.Attribute{
+			"model_uuid": schema.StringAttribute{
+				Description: "The Juju model UUID.",
+				Required:    true,
+				Validators: []validator.String{
+					ValidatorMatchString(names.IsValidModel, "must be a valid UUID"),
+				},
+			},
+			"name": schema.StringAttribute{
+				Description: "Filter by space name.",
+				Optional:    true,
+			},
+		},
+	}
+}
+
+// List implements [list.ListResourceWithConfigure].
+func (r *spaceLister) List(ctx context.Context, req list.ListRequest, stream *list.ListResultsStream) {
+	var listRequest listSpaceRequest
+
+	diags := req.Config.Get(ctx, &listRequest)
+	if diags.HasError() {
+		stream.Results = list.ListResultsStreamDiagnostics(diags)
+		return
+	}
+
+	modelUUID := listRequest.ModelUUID.ValueString()
+	spaces, err := r.client.Spaces.ListSpaces(ctx, &juju.ListSpacesInput{ModelUUID: modelUUID})
+	if err != nil {
+		stream.Results = list.ListResultsStreamDiagnostics(
+			diag.Diagnostics{
+				diag.NewErrorDiagnostic(
+					"Client Error",
+					fmt.Sprintf("Unable to list spaces in model %s, got error: %s", modelUUID, err),
+				),
+			},
+		)
+		return
+	}
+
+	filterByName := ""
+	if !listRequest.Name.IsNull() && !listRequest.Name.IsUnknown() {
+		filterByName = listRequest.Name.ValueString()
+	}
+
+	stream.Results = func(push func(list.ListResult) bool) {
+		for _, space := range spaces {
+			if filterByName != "" && space.Name != filterByName {
+				continue
+			}
+
+			result := req.NewListResult(ctx)
+			result.DisplayName = space.Name
+
+			identity := spaceResourceIdentityModel{
+				ID: types.StringValue(newSpaceResourceID(modelUUID, space.Name)),
+			}
+			result.Diagnostics.Append(result.Identity.Set(ctx, identity)...)
+			if result.Diagnostics.HasError() {
+				push(result)
+				return
+			}
+
+			if req.IncludeResource {
+				spaceResource := spaceResourceModel{
+					ID:        identity.ID,
+					ModelUUID: types.StringValue(modelUUID),
+					Name:      types.StringValue(space.Name),
+				}
+
+				result.Diagnostics.Append(result.Resource.Set(ctx, spaceResource)...)
+				if result.Diagnostics.HasError() {
+					push(result)
+					return
+				}
+			}
+
+			if !push(result) {
+				return
+			}
+		}
+	}
+}

--- a/internal/provider/list_spaces_test.go
+++ b/internal/provider/list_spaces_test.go
@@ -1,0 +1,103 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func TestAccListSpaces_Query(t *testing.T) {
+	modelName := acctest.RandomWithPrefix("tf-test-space-list")
+	spaceName := "test-space"
+
+	var expectedID string
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: frameworkProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccListSpacesSetup(modelName, spaceName),
+				Check: func(s *terraform.State) error {
+					rs, ok := s.RootModule().Resources["juju_space.test"]
+					if !ok {
+						return fmt.Errorf("not found: juju_space.test")
+					}
+					expectedID = rs.Primary.ID
+					return nil
+				},
+			},
+			{
+				Config: testAccListSpaces(),
+				Query:  true,
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					querycheck.ExpectIdentity("juju_space.test", map[string]knownvalue.Check{
+						"id": knownvalue.StringFunc(func(actual string) error {
+							return knownvalue.StringExact(expectedID).CheckValue(actual)
+						}),
+					}),
+				},
+			},
+			{
+				Config: testAccListSpaceExact(),
+				Query:  true,
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					querycheck.ExpectLength("juju_space.test", 1),
+					querycheck.ExpectIdentity("juju_space.test", map[string]knownvalue.Check{
+						"id": knownvalue.StringFunc(func(actual string) error {
+							return knownvalue.StringExact(expectedID).CheckValue(actual)
+						}),
+					}),
+				},
+			},
+		},
+	})
+}
+
+func testAccListSpacesSetup(modelName, spaceName string) string {
+	return fmt.Sprintf(`
+resource "juju_model" "test" {
+  name = %q
+}
+
+resource "juju_space" "test" {
+  model_uuid = juju_model.test.uuid
+  name       = %q
+}
+`, modelName, spaceName)
+}
+
+func testAccListSpaces() string {
+	return `
+list "juju_space" "test" {
+  provider         = juju
+  include_resource = true
+
+  config {
+    model_uuid = juju_model.test.uuid
+  }
+}
+`
+}
+
+func testAccListSpaceExact() string {
+	return `
+list "juju_space" "test" {
+  provider         = juju
+  include_resource = true
+
+  config {
+    model_uuid = juju_model.test.uuid
+    name       = juju_space.test.name
+  }
+}
+`
+}

--- a/internal/provider/list_spaces_test.go
+++ b/internal/provider/list_spaces_test.go
@@ -15,6 +15,9 @@ import (
 )
 
 func TestAccListSpaces_Query(t *testing.T) {
+	if testingCloud != LXDCloudTesting {
+		t.Skip(t.Name() + " only runs with LXD")
+	}
 	modelName := acctest.RandomWithPrefix("tf-test-space-list")
 	spaceName := "test-space"
 	spaceTobeIgnored := "space-to-be-ignored"

--- a/internal/provider/list_spaces_test.go
+++ b/internal/provider/list_spaces_test.go
@@ -17,6 +17,7 @@ import (
 func TestAccListSpaces_Query(t *testing.T) {
 	modelName := acctest.RandomWithPrefix("tf-test-space-list")
 	spaceName := "test-space"
+	spaceTobeIgnored := "space-to-be-ignored"
 
 	var expectedID string
 
@@ -25,7 +26,7 @@ func TestAccListSpaces_Query(t *testing.T) {
 		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccListSpacesSetup(modelName, spaceName),
+				Config: testAccListSpacesSetup(modelName, spaceName, spaceTobeIgnored),
 				Check: func(s *terraform.State) error {
 					rs, ok := s.RootModule().Resources["juju_space.test"]
 					if !ok {
@@ -62,7 +63,7 @@ func TestAccListSpaces_Query(t *testing.T) {
 	})
 }
 
-func testAccListSpacesSetup(modelName, spaceName string) string {
+func testAccListSpacesSetup(modelName, spaceName, spaceTobeIgnored string) string {
 	return fmt.Sprintf(`
 resource "juju_model" "test" {
   name = %q
@@ -72,7 +73,12 @@ resource "juju_space" "test" {
   model_uuid = juju_model.test.uuid
   name       = %q
 }
-`, modelName, spaceName)
+
+resource "juju_space" "ignored" {
+  model_uuid = juju_model.test.uuid
+  name       = %q
+}
+`, modelName, spaceName, spaceTobeIgnored)
 }
 
 func testAccListSpaces() string {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -677,6 +677,7 @@ func (p *jujuProvider) ListResources(_ context.Context) []func() list.ListResour
 		func() list.ListResource { return NewOfferLister() },
 		func() list.ListResource { return NewMachineLister() },
 		func() list.ListResource { return NewSSHKeyLister() },
+		func() list.ListResource { return NewSpaceLister() },
 		func() list.ListResource { return NewStoragePoolLister() },
 		func() list.ListResource { return NewSecretLister() },
 	}


### PR DESCRIPTION
## Description

Implements space data source according to #1227

This PR builds on #1236 

Fixes: 

## Type of change
- Add new resource

## Environment

Juju controller version: 4.0

Terraform version:
Terraform v1.15.5
on linux_amd64
provider registry.terraform.io/juju/juju v2.1.0
## QA steps

Manual QA steps should be done to test this PR.

```tf
# # list all spaces in model
# list "juju_space" "all" {
#   provider         = juju
#   include_resource = true

#   config {
#     model_uuid = juju_model.this.uuid
#   }
# }

# list exact space by name filter
list "juju_space" "filtered" {
  provider         = juju
  include_resource = true

  config {
    model_uuid = juju_model.this.uuid
    name       = juju_space.qa_space.name
  }
}
```

