### PR TITLE
ci: run k8s tunnel add machine on 3.6 upwards

### DIFF
--- a/.github/workflows/k8s_tunnel.yml
+++ b/.github/workflows/k8s_tunnel.yml
@@ -68,7 +68,7 @@ jobs:
           provider: ${{ matrix.cloud }}
           channel: "1.36-strict/stable"
           juju-channel: 3.6/stable
-          microk8s-addons: "ingress"
+          microk8s-addons: "ingress storage"
       - run: go mod download
       - name: "Bring up loadbalancer & access via terraform plan"
         run: |

--- a/.github/workflows/k8s_tunnel.yml
+++ b/.github/workflows/k8s_tunnel.yml
@@ -66,7 +66,7 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: ${{ matrix.cloud }}
-          juju-channel: 2.9/stable
+          juju-channel: 3.6/stable
       - run: go mod download
       - name: "Bring up loadbalancer & access via terraform plan"
         run: |

--- a/.github/workflows/k8s_tunnel.yml
+++ b/.github/workflows/k8s_tunnel.yml
@@ -66,7 +66,9 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: ${{ matrix.cloud }}
+          channel: "1.36-strict/stable"
           juju-channel: 3.6/stable
+          microk8s-addons: "ingress"
       - run: go mod download
       - name: "Bring up loadbalancer & access via terraform plan"
         run: |
@@ -80,9 +82,6 @@ jobs:
           # Ensure Juju controller name
           echo "Controller name: $CONTROLLER"
           echo "Juju Username: $JUJU_USERNAME"
-
-          # Enable Ingress in MicroK8s
-          sudo microk8s enable ingress
 
           # Determine a subnet for MetalLB
           subnet="$(ip route get 1 | head -n 1 | awk '{print $7}' | awk -F. '{print $1 "." $2 "." $3 ".240/24"}')"


### PR DESCRIPTION
## Description

The test was failing due to:
```
│ Unable to create application, got error: not supported: juju version does
│ not support DeployFromRepository API
```

On v2.0. (This run [here](https://github.com/juju/terraform-provider-juju/actions/runs/26745140784/job/78822731832?pr=1232))

I'm not sure if that is an issue in and of itself, but noticed the Juju version was 2.9 which isn't supported by our 2.0 branch. So this just updates it to our lowest supported version.

## Type of change

- Maintenance work (repository related, like Github actions, or revving the Go version, etc.)
