### PR TITLE
feat: allow controller patch upgrades

### DIFF
--- a/.github/workflows/test_integration.yml
+++ b/.github/workflows/test_integration.yml
@@ -155,6 +155,23 @@ jobs:
           TEST_CLOUD: ${{ matrix.action-operator.cloud }}
         run: go test -parallel 4 -timeout 90m -v -cover ./internal/provider/
         timeout-minutes: 90
+      - name: Dump Juju bootstrap logs on failure
+        if: failure()
+        run: |
+          log_files=(/tmp/juju-bootstrap-log-*.txt)
+          if [ ${#log_files[@]} -eq 0 ]; then
+            echo "No Juju bootstrap logs found in /tmp."
+            exit 0
+          fi
+
+          echo "Found ${#log_files[@]} Juju bootstrap log file(s):"
+          printf ' - %s\n' "${log_files[@]}"
+
+          for log_file in "${log_files[@]}"; do
+            echo "::group::${log_file}"
+            cat "${log_file}"
+            echo "::endgroup::"
+          done
 
   # Run acceptance tests in a matrix with Terraform CLI versions
   add-machine-test:

--- a/docs-rtd/reference/terraform-provider/resources/controller.md
+++ b/docs-rtd/reference/terraform-provider/resources/controller.md
@@ -91,7 +91,7 @@ resource "juju_controller" "this" {
 
 ### Optional
 
-- `agent_version` (String) Specifies a controller version to bootstrap. If not specified, the latest stable agent version will be used. Updating this value only supports in-place upgrades to higher patch versions within the same major.minor series.
+- `agent_version` (String) Specifies a controller version to bootstrap. If not specified, the latest stable agent version will be used. Updating this value only supports in-place upgrades to higher patch versions within the same major.minor series. The provider does not wait for the upgrade to complete, so we recommend waiting for the upgrade to finish before applying further changes.
 - `bootstrap_base` (String) The base for the bootstrap machine.
 - `bootstrap_config` (Map of String) Configuration options that apply during the bootstrap process.
 - `bootstrap_constraints` (Map of String) Constraints for the bootstrap machine.

--- a/docs-rtd/reference/terraform-provider/resources/controller.md
+++ b/docs-rtd/reference/terraform-provider/resources/controller.md
@@ -91,7 +91,7 @@ resource "juju_controller" "this" {
 
 ### Optional
 
-- `agent_version` (String) Specifies a controller version to bootstrap. If not specified, the latest stable agent version will be used.
+- `agent_version` (String) Specifies a controller version to bootstrap. If not specified, the latest stable agent version will be used. Updating this value only supports in-place upgrades to higher patch versions within the same major.minor series.
 - `bootstrap_base` (String) The base for the bootstrap machine.
 - `bootstrap_config` (Map of String) Configuration options that apply during the bootstrap process.
 - `bootstrap_constraints` (Map of String) Constraints for the bootstrap machine.

--- a/docs/resources/controller.md
+++ b/docs/resources/controller.md
@@ -91,7 +91,7 @@ resource "juju_controller" "this" {
 
 ### Optional
 
-- `agent_version` (String) Specifies a controller version to bootstrap. If not specified, the latest stable agent version will be used. Updating this value only supports in-place upgrades to higher patch versions within the same major.minor series.
+- `agent_version` (String) Specifies a controller version to bootstrap. If not specified, the latest stable agent version will be used. Updating this value only supports in-place upgrades to higher patch versions within the same major.minor series. The provider does not wait for the upgrade to complete, so we recommend waiting for the upgrade to finish before applying further changes.
 - `bootstrap_base` (String) The base for the bootstrap machine.
 - `bootstrap_config` (Map of String) Configuration options that apply during the bootstrap process.
 - `bootstrap_constraints` (Map of String) Constraints for the bootstrap machine.

--- a/docs/resources/controller.md
+++ b/docs/resources/controller.md
@@ -91,7 +91,7 @@ resource "juju_controller" "this" {
 
 ### Optional
 
-- `agent_version` (String) Specifies a controller version to bootstrap. If not specified, the latest stable agent version will be used.
+- `agent_version` (String) Specifies a controller version to bootstrap. If not specified, the latest stable agent version will be used. Updating this value only supports in-place upgrades to higher patch versions within the same major.minor series.
 - `bootstrap_base` (String) The base for the bootstrap machine.
 - `bootstrap_config` (Map of String) Configuration options that apply during the bootstrap process.
 - `bootstrap_constraints` (Map of String) Constraints for the bootstrap machine.

--- a/go.sum
+++ b/go.sum
@@ -40,8 +40,6 @@ github.com/Masterminds/sprig/v3 v3.2.3 h1:eL2fZNezLomi0uOLqjQoN6BfsDD+fyLtgbJMAj
 github.com/Masterminds/sprig/v3 v3.2.3/go.mod h1:rXcFaZ2zZbLRJv/xSysmlgIM1u11eBaRMhvYXJNkGuM=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
-github.com/ProtonMail/go-crypto v1.1.6 h1:ZcV+Ropw6Qn0AX9brlQLAUXfqLBc7Bl+f/DmNxpLfdw=
-github.com/ProtonMail/go-crypto v1.1.6/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
 github.com/ProtonMail/go-crypto v1.3.0 h1:ILq8+Sf5If5DCpHQp4PbZdS1J7HDFRXz/+xKBiRGFrw=
 github.com/ProtonMail/go-crypto v1.3.0/go.mod h1:9whxjD8Rbs29b4XWbB8irEcE8KHMqaR2e7GWU1R+/PE=
 github.com/Rican7/retry v0.3.1 h1:scY4IbO8swckzoA/11HgBwaZRJEyY9vaNJshcdhp1Mc=
@@ -160,9 +158,8 @@ github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 h1:+zs/tPmkDkHx3U66D
 github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376/go.mod h1:an3vInlBmSxCcxctByoQdvwPiA7DTK7jaaFDBTtu0ic=
 github.com/go-git/go-billy/v5 v5.6.2 h1:6Q86EsPXMa7c3YZ3aLAQsMA0VlWmy43r6FHqa/UNbRM=
 github.com/go-git/go-billy/v5 v5.6.2/go.mod h1:rcFC2rAsp/erv7CMz9GczHcuD0D32fWzH+MJAU+jaUU=
-github.com/go-git/go-git/v5 v5.14.0 h1:/MD3lCrGjCen5WfEAzKg00MJJffKhC8gzS80ycmCi60=
-github.com/go-git/go-git/v5 v5.14.0/go.mod h1:Z5Xhoia5PcWA3NF8vRLURn9E5FRhSl7dGj9ItW3Wk5k=
 github.com/go-git/go-git/v5 v5.16.5 h1:mdkuqblwr57kVfXri5TTH+nMFLNUxIj9Z7F5ykFbw5s=
+github.com/go-git/go-git/v5 v5.16.5/go.mod h1:QOMLpNf1qxuSY4StA/ArOdfFR2TrKEjJiye2kel2m+M=
 github.com/go-jose/go-jose/v3 v3.0.4 h1:Wp5HA7bLQcKnf6YYao/4kpRpVMp/yf6+pJKV8WFSaNY=
 github.com/go-jose/go-jose/v3 v3.0.4/go.mod h1:5b+7YgP7ZICgJDBdfjZaIt+H/9L9T/YQrVfLAMboGkQ=
 github.com/go-jose/go-jose/v4 v4.1.3 h1:CVLmWDhDVRa6Mi/IgCgaopNosCaHz7zrMeF9MlZRkrs=
@@ -261,8 +258,6 @@ github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+l
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-plugin v1.7.0 h1:YghfQH/0QmPNc/AZMTFE3ac8fipZyZECHdDPshfk+mA=
 github.com/hashicorp/go-plugin v1.7.0/go.mod h1:BExt6KEaIYx804z8k4gRzRLEvxKVb+kn0NMcihqOqb8=
-github.com/hashicorp/go-retryablehttp v0.7.7 h1:C8hUCYzor8PIfXHa4UrZkU4VvK8o9ISHxT2Q8+VepXU=
-github.com/hashicorp/go-retryablehttp v0.7.7/go.mod h1:pkQpWZeYWskR+D1tR2O5OcBFOxfA7DoAO6xtkuQnHTk=
 github.com/hashicorp/go-retryablehttp v0.7.8 h1:ylXZWnqa7Lhqpk0L1P1LzDtGcCR0rPVUrx/c8Unxc48=
 github.com/hashicorp/go-retryablehttp v0.7.8/go.mod h1:rjiScheydd+CxvumBsIrFKlx3iS0jrZ7LvzFGFmuKbw=
 github.com/hashicorp/go-rootcerts v1.0.2 h1:jzhAVGtqPKbwpyCPELlgNWhE1znq+qwJtW5Oi2viEzc=
@@ -276,12 +271,8 @@ github.com/hashicorp/go-sockaddr v1.0.2/go.mod h1:rB4wwRAUzs07qva3c5SdrY/NEtAUjG
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
 github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
-github.com/hashicorp/go-version v1.7.0 h1:5tqGy27NaOTB8yJKUZELlFAS/LTKJkrmONwQKeRZfjY=
-github.com/hashicorp/go-version v1.7.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.8.0 h1:KAkNb1HAiZd1ukkxDFGmokVZe1Xy9HG6NUp+bPle2i4=
 github.com/hashicorp/go-version v1.8.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
-github.com/hashicorp/hc-install v0.9.2 h1:v80EtNX4fCVHqzL9Lg/2xkp62bbvQMnvPQ0G+OmtO24=
-github.com/hashicorp/hc-install v0.9.2/go.mod h1:XUqBQNnuT4RsxoxiM9ZaUk0NX8hi2h+Lb6/c0OZnC/I=
 github.com/hashicorp/hc-install v0.9.3 h1:1H4dgmgzxEVwT6E/d/vIL5ORGVKz9twRwDw+qA5Hyho=
 github.com/hashicorp/hc-install v0.9.3/go.mod h1:FQlQ5I3I/X409N/J1U4pPeQQz1R3BoV0IysB7aiaQE0=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
@@ -290,8 +281,6 @@ github.com/hashicorp/hcl/v2 v2.24.0 h1:2QJdZ454DSsYGoaE6QheQZjtKZSUs9Nh2izTWiwQx
 github.com/hashicorp/hcl/v2 v2.24.0/go.mod h1:oGoO1FIQYfn/AgyOhlg9qLC6/nOJPX3qGbkZpYAcqfM=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
-github.com/hashicorp/terraform-exec v0.24.0 h1:mL0xlk9H5g2bn0pPF6JQZk5YlByqSqrO5VoaNtAf8OE=
-github.com/hashicorp/terraform-exec v0.24.0/go.mod h1:lluc/rDYfAhYdslLJQg3J0oDqo88oGQAdHR+wDqFvo4=
 github.com/hashicorp/terraform-exec v0.25.0 h1:Bkt6m3VkJqYh+laFMrWIpy9KHYFITpOyzRMNI35rNaY=
 github.com/hashicorp/terraform-exec v0.25.0/go.mod h1:dl9IwsCfklDU6I4wq9/StFDp7dNbH/h5AnfS1RmiUl8=
 github.com/hashicorp/terraform-json v0.27.2 h1:BwGuzM6iUPqf9JYM/Z4AF1OJ5VVJEEzoKST/tRDBJKU=
@@ -308,8 +297,6 @@ github.com/hashicorp/terraform-plugin-go v0.31.0 h1:0Fz2r9DQ+kNNl6bx8HRxFd1TfMKU
 github.com/hashicorp/terraform-plugin-go v0.31.0/go.mod h1:A88bDhd/cW7FnwqxQRz3slT+QY6yzbHKc6AOTtmdeS8=
 github.com/hashicorp/terraform-plugin-log v0.10.0 h1:eu2kW6/QBVdN4P3Ju2WiB2W3ObjkAsyfBsL3Wh1fj3g=
 github.com/hashicorp/terraform-plugin-log v0.10.0/go.mod h1:/9RR5Cv2aAbrqcTSdNmY1NRHP4E3ekrXRGjqORpXyB0=
-github.com/hashicorp/terraform-plugin-sdk/v2 v2.38.1 h1:mlAq/OrMlg04IuJT7NpefI1wwtdpWudnEmjuQs04t/4=
-github.com/hashicorp/terraform-plugin-sdk/v2 v2.38.1/go.mod h1:GQhpKVvvuwzD79e8/NZ+xzj+ZpWovdPAe8nfV/skwNU=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.0 h1:MKS/2URqeJRwJdbOfcbdsZCq/IRrNkqJNN0GtVIsuGs=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.0/go.mod h1:PuG4P97Ju3QXW6c6vRkRadWJbvnEu2Xh+oOuqcYOqX4=
 github.com/hashicorp/terraform-plugin-testing v1.14.0 h1:5t4VKrjOJ0rg0sVuSJ86dz5K7PHsMO6OKrHFzDBerWA=

--- a/internal/juju/controllers.go
+++ b/internal/juju/controllers.go
@@ -19,6 +19,7 @@ import (
 	"github.com/juju/juju/api/client/cloud"
 	"github.com/juju/juju/api/client/modelconfig"
 	"github.com/juju/juju/api/client/modelmanager"
+	"github.com/juju/juju/api/client/modelupgrader"
 	"github.com/juju/juju/api/connector"
 	controllerapi "github.com/juju/juju/api/controller/controller"
 	jujucloud "github.com/juju/juju/cloud"
@@ -390,6 +391,98 @@ func (d *DefaultJujuCommand) UpdateConfig(
 	}
 
 	return nil
+}
+
+// UpgradeController upgrades a controller in place to a higher patch version.
+func (d *DefaultJujuCommand) ControllerVersion(
+	ctx context.Context,
+	connInfo *ControllerConnectionInformation,
+) (version.Number, error) {
+	// Connect to the controller
+	connr, err := connector.NewSimple(connector.SimpleConfig{
+		ControllerAddresses: connInfo.Addresses,
+		CACert:              connInfo.CACert,
+		Username:            connInfo.Username,
+		Password:            connInfo.Password,
+	})
+	if err != nil {
+		return version.Number{}, err
+	}
+
+	conn, err := connr.Connect()
+	if err != nil {
+		return version.Number{}, err
+	}
+
+	// Fetch controller model config
+	modelCfgClient := modelconfig.NewClient(conn)
+	defer modelCfgClient.Close()
+
+	modelAttrs, err := modelCfgClient.ModelGet()
+	if err != nil {
+		return version.Number{}, err
+	}
+
+	cfg, err := config.New(config.NoDefaults, modelAttrs)
+	if err != nil {
+		return version.Number{}, err
+	}
+
+	agentVersion, ok := cfg.AgentVersion()
+	if !ok {
+		return version.Number{}, fmt.Errorf("agent version not found in controller model config")
+	}
+
+	return agentVersion, nil
+}
+
+// UpgradeController upgrades a controller in place to a higher patch version.
+func (d *DefaultJujuCommand) UpgradeController(
+	ctx context.Context,
+	connInfo *ControllerConnectionInformation,
+	targetVersion version.Number,
+) (version.Number, error) {
+	connr, err := connector.NewSimple(connector.SimpleConfig{
+		ControllerAddresses: connInfo.Addresses,
+		CACert:              connInfo.CACert,
+		Username:            connInfo.Username,
+		Password:            connInfo.Password,
+	})
+	if err != nil {
+		return version.Number{}, err
+	}
+
+	conn, err := connr.Connect()
+	if err != nil {
+		return version.Number{}, err
+	}
+	defer conn.Close()
+
+	// We need to fetch the controller model's UUID.
+	modelCfgClient := modelconfig.NewClient(conn)
+	defer modelCfgClient.Close()
+
+	modelAttrs, err := modelCfgClient.ModelGet()
+	if err != nil {
+		return version.Number{}, err
+	}
+
+	cfg, err := config.New(config.NoDefaults, modelAttrs)
+	if err != nil {
+		return version.Number{}, err
+	}
+
+	controllerModelUUID := cfg.UUID()
+
+	modelUpgraderClient := modelupgrader.NewClient(conn)
+	defer modelUpgraderClient.Close()
+
+	chosenVersion, err := modelUpgraderClient.UpgradeModel(controllerModelUUID, targetVersion, "", false, false)
+	if err != nil {
+		return version.Number{}, fmt.Errorf("failed to upgrade controller: %w", err)
+	}
+
+	return chosenVersion, nil
 }
 
 // Config retrieves controller configuration and controller-model configuration settings.

--- a/internal/juju/controllers.go
+++ b/internal/juju/controllers.go
@@ -393,12 +393,11 @@ func (d *DefaultJujuCommand) UpdateConfig(
 	return nil
 }
 
-// UpgradeController upgrades a controller in place to a higher patch version.
+// ControllerVersion retrieves the controller's agent version.
 func (d *DefaultJujuCommand) ControllerVersion(
 	ctx context.Context,
 	connInfo *ControllerConnectionInformation,
 ) (version.Number, error) {
-	// Connect to the controller
 	connr, err := connector.NewSimple(connector.SimpleConfig{
 		ControllerAddresses: connInfo.Addresses,
 		CACert:              connInfo.CACert,
@@ -414,7 +413,6 @@ func (d *DefaultJujuCommand) ControllerVersion(
 		return version.Number{}, err
 	}
 
-	// Fetch controller model config
 	modelCfgClient := modelconfig.NewClient(conn)
 	defer modelCfgClient.Close()
 

--- a/internal/juju/controllers.go
+++ b/internal/juju/controllers.go
@@ -456,7 +456,6 @@ func (d *DefaultJujuCommand) UpgradeController(
 	}
 	defer conn.Close()
 
-	// We need to fetch the controller model's UUID.
 	modelCfgClient := modelconfig.NewClient(conn)
 	defer modelCfgClient.Close()
 

--- a/internal/provider/mock_test.go
+++ b/internal/provider/mock_test.go
@@ -14,6 +14,7 @@ import (
 	reflect "reflect"
 
 	juju "github.com/juju/terraform-provider-juju/internal/juju"
+	version "github.com/juju/version/v2"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -120,6 +121,45 @@ func (c *MockJujuCommandConfigCall) DoAndReturn(f func(context.Context, *juju.Co
 	return c
 }
 
+// ControllerVersion mocks base method.
+func (m *MockJujuCommand) ControllerVersion(ctx context.Context, connInfo *juju.ControllerConnectionInformation) (version.Number, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ControllerVersion", ctx, connInfo)
+	ret0, _ := ret[0].(version.Number)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ControllerVersion indicates an expected call of ControllerVersion.
+func (mr *MockJujuCommandMockRecorder) ControllerVersion(ctx, connInfo any) *MockJujuCommandControllerVersionCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ControllerVersion", reflect.TypeOf((*MockJujuCommand)(nil).ControllerVersion), ctx, connInfo)
+	return &MockJujuCommandControllerVersionCall{Call: call}
+}
+
+// MockJujuCommandControllerVersionCall wrap *gomock.Call
+type MockJujuCommandControllerVersionCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockJujuCommandControllerVersionCall) Return(arg0 version.Number, arg1 error) *MockJujuCommandControllerVersionCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockJujuCommandControllerVersionCall) Do(f func(context.Context, *juju.ControllerConnectionInformation) (version.Number, error)) *MockJujuCommandControllerVersionCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockJujuCommandControllerVersionCall) DoAndReturn(f func(context.Context, *juju.ControllerConnectionInformation) (version.Number, error)) *MockJujuCommandControllerVersionCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // Destroy mocks base method.
 func (m *MockJujuCommand) Destroy(ctx context.Context, args juju.DestroyArguments) error {
 	m.ctrl.T.Helper()
@@ -192,6 +232,45 @@ func (c *MockJujuCommandUpdateConfigCall) Do(f func(context.Context, *juju.Contr
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockJujuCommandUpdateConfigCall) DoAndReturn(f func(context.Context, *juju.ControllerConnectionInformation, map[string]string, map[string]string, []string) error) *MockJujuCommandUpdateConfigCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// UpgradeController mocks base method.
+func (m *MockJujuCommand) UpgradeController(ctx context.Context, connInfo *juju.ControllerConnectionInformation, targetVersion version.Number) (version.Number, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpgradeController", ctx, connInfo, targetVersion)
+	ret0, _ := ret[0].(version.Number)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpgradeController indicates an expected call of UpgradeController.
+func (mr *MockJujuCommandMockRecorder) UpgradeController(ctx, connInfo, targetVersion any) *MockJujuCommandUpgradeControllerCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpgradeController", reflect.TypeOf((*MockJujuCommand)(nil).UpgradeController), ctx, connInfo, targetVersion)
+	return &MockJujuCommandUpgradeControllerCall{Call: call}
+}
+
+// MockJujuCommandUpgradeControllerCall wrap *gomock.Call
+type MockJujuCommandUpgradeControllerCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockJujuCommandUpgradeControllerCall) Return(arg0 version.Number, arg1 error) *MockJujuCommandUpgradeControllerCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockJujuCommandUpgradeControllerCall) Do(f func(context.Context, *juju.ControllerConnectionInformation, version.Number) (version.Number, error)) *MockJujuCommandUpgradeControllerCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockJujuCommandUpgradeControllerCall) DoAndReturn(f func(context.Context, *juju.ControllerConnectionInformation, version.Number) (version.Number, error)) *MockJujuCommandUpgradeControllerCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/provider/resource_controller.go
+++ b/internal/provider/resource_controller.go
@@ -194,6 +194,11 @@ func (r *controllerResource) Schema(_ context.Context, _ resource.SchemaRequest,
 				Optional:    true,
 				Computed:    true,
 				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplaceIf(
+						controllerAgentVersionRequiresReplaceIf,
+						"Changing the controller agent version major.minor series or lowering the patch version requires replacement.",
+						"Changing the controller agent version major.minor series or lowering the patch version requires replacement.",
+					),
 					stringplanmodifier.UseStateForUnknown(),
 				},
 				Validators: []validator.String{
@@ -1075,7 +1080,7 @@ func (r *controllerResource) Update(ctx context.Context, req resource.UpdateRequ
 	}
 
 	if targetAgentVersion != "" && targetAgentVersion != currentAgentVersion {
-		validatedTargetVersion, err := validateControllerPatchUpgrade(currentAgentVersion, targetAgentVersion)
+		validatedTargetVersion, err := version.Parse(targetAgentVersion)
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Controller Version Update Error",
@@ -1214,26 +1219,38 @@ func controllerVersionShim(ctx context.Context, command JujuCommand) func(connIn
 	}
 }
 
-func validateControllerPatchUpgrade(currentVersion, targetVersion string) (version.Number, error) {
-	currentPatchVersion, err := version.Parse(currentVersion)
+func controllerAgentVersionRequiresReplaceIf(_ context.Context, req planmodifier.StringRequest, resp *stringplanmodifier.RequiresReplaceIfFuncResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+	if req.StateValue.IsNull() || req.StateValue.IsUnknown() {
+		return
+	}
+
+	requiresReplace, err := controllerAgentVersionSeriesChanged(req.StateValue.ValueString(), req.ConfigValue.ValueString())
 	if err != nil {
-		return version.Number{}, fmt.Errorf("invalid current controller version %q: %w", currentVersion, err)
+		resp.Diagnostics.AddError("Invalid controller version", err.Error())
+		return
 	}
 
-	targetPatchVersion, err := version.Parse(targetVersion)
+	resp.RequiresReplace = requiresReplace
+}
+
+// controllerAgentVersionSeriesChanged determines if the major or minor version has changed,
+// or if the patch version has been upgraded, between the current and target controller agent versions.
+// If the target version is invalid, an error is returned.
+func controllerAgentVersionSeriesChanged(currentVersion, targetVersion string) (bool, error) {
+	current, err := version.Parse(currentVersion)
 	if err != nil {
-		return version.Number{}, fmt.Errorf("invalid requested controller version %q: %w", targetVersion, err)
+		return false, fmt.Errorf("invalid current controller version %q: %w", currentVersion, err)
 	}
 
-	if currentPatchVersion.Major != targetPatchVersion.Major || currentPatchVersion.Minor != targetPatchVersion.Minor || targetPatchVersion.Patch <= currentPatchVersion.Patch {
-		return version.Number{}, fmt.Errorf(
-			"only upgrades to a higher patch version within the same major.minor series are supported (current %s, requested %s)",
-			currentPatchVersion,
-			targetPatchVersion,
-		)
+	target, err := version.Parse(targetVersion)
+	if err != nil {
+		return false, fmt.Errorf("invalid requested controller version %q: %w", targetVersion, err)
 	}
 
-	return targetPatchVersion, nil
+	return current.Major != target.Major || current.Minor != target.Minor || current.Patch >= target.Patch, nil
 }
 
 // buildStringListFromMap converts a map to a list of key=value strings.

--- a/internal/provider/resource_controller.go
+++ b/internal/provider/resource_controller.go
@@ -27,12 +27,18 @@ import (
 
 	"github.com/juju/names/v5"
 	"github.com/juju/terraform-provider-juju/internal/juju"
+	"github.com/juju/terraform-provider-juju/internal/wait"
+	"github.com/juju/version/v2"
 )
 
 // JujuCommand defines the interface for interacting with Juju controllers.
 type JujuCommand interface {
 	// Bootstrap creates a new controller and returns connection information.
 	Bootstrap(ctx context.Context, model juju.BootstrapArguments) (*juju.ControllerConnectionInformation, error)
+	// ControllerVersion retrieves the agent version of the controller.
+	ControllerVersion(ctx context.Context, connInfo *juju.ControllerConnectionInformation) (version.Number, error)
+	// UpgradeController upgrades an existing controller to the requested target version.
+	UpgradeController(ctx context.Context, connInfo *juju.ControllerConnectionInformation, targetVersion version.Number) (version.Number, error)
 	// UpdateConfig updates controller and controller-model configuration.
 	UpdateConfig(ctx context.Context, connInfo *juju.ControllerConnectionInformation,
 		controllerConfig, controllerModelConfig map[string]string,
@@ -184,12 +190,17 @@ func (r *controllerResource) Schema(_ context.Context, _ resource.SchemaRequest,
 		Description: "A resource that represents a Juju Controller.",
 		Attributes: map[string]schema.Attribute{
 			"agent_version": schema.StringAttribute{
-				Description: "Specifies a controller version to bootstrap. If not specified, the latest stable agent version will be used.",
+				Description: "Specifies a controller version to bootstrap. If not specified, the latest stable agent version will be used. Updating this value only supports in-place upgrades to higher patch versions within the same major.minor series.",
 				Optional:    true,
 				Computed:    true,
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
 					stringplanmodifier.UseStateForUnknown(),
+				},
+				Validators: []validator.String{
+					ValidatorMatchString(func(s string) bool {
+						_, err := version.Parse(s)
+						return err == nil
+					}, "invalid version format"),
 				},
 			},
 			"api_addresses": schema.ListAttribute{
@@ -926,6 +937,16 @@ func (r *controllerResource) Read(ctx context.Context, req resource.ReadRequest,
 		return
 	}
 
+	agentVersion, err := command.ControllerVersion(ctx, connInfo)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Controller Version Read Error",
+			fmt.Sprintf("Unable to determine controller %q version: %s", state.Name.ValueString(), err),
+		)
+		return
+	}
+	state.AgentVersion = types.StringValue(agentVersion.String())
+
 	cfg, diags := newConfigFromModelConfigAPI(ctx, controllerConfig, state.ControllerConfig)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -1047,6 +1068,54 @@ func (r *controllerResource) Update(ctx context.Context, req resource.UpdateRequ
 		return
 	}
 
+	currentAgentVersion := state.AgentVersion.ValueString()
+	targetAgentVersion := ""
+	if !plan.AgentVersion.IsNull() && !plan.AgentVersion.IsUnknown() {
+		targetAgentVersion = plan.AgentVersion.ValueString()
+	}
+
+	if targetAgentVersion != "" && targetAgentVersion != currentAgentVersion {
+		validatedTargetVersion, err := validateControllerPatchUpgrade(currentAgentVersion, targetAgentVersion)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Controller Version Update Error",
+				fmt.Sprintf("Unable to update controller %q version: %s", state.Name.ValueString(), err),
+			)
+			return
+		}
+
+		upgradedVersion, err := command.UpgradeController(ctx, connInfo, validatedTargetVersion)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Controller Upgrade Error",
+				fmt.Sprintf("Unable to upgrade controller %q from %s to %s: %s", state.Name.ValueString(), currentAgentVersion, targetAgentVersion, err),
+			)
+			return
+		}
+
+		if _, err := wait.WaitFor(
+			wait.WaitForCfg[*juju.ControllerConnectionInformation, version.Number]{
+				Context: ctx,
+				GetData: controllerVersionShim(ctx, command),
+				Input:   connInfo,
+				DataAssertions: []wait.Assert[version.Number]{
+					func(data version.Number) error {
+						if data != upgradedVersion {
+							return juju.NewRetryReadError("waiting for controller version to change")
+						}
+						return nil
+					},
+				},
+				Logf: r.trace,
+			},
+		); err != nil {
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed waiting for new controller version, got error: %s", err))
+			return
+		}
+
+		plan.AgentVersion = types.StringValue(upgradedVersion.String())
+	}
+
 	r.trace(fmt.Sprintf("controller updated: %q", plan.Name.ValueString()))
 
 	// Write the updated state
@@ -1136,6 +1205,35 @@ func (r *controllerResource) Delete(ctx context.Context, req resource.DeleteRequ
 		}
 		return
 	}
+}
+
+// controllerVersionShim is a helper function to adapt the ControllerVersion method to the signature required by wait.WaitFor.
+func controllerVersionShim(ctx context.Context, command JujuCommand) func(connInfo *juju.ControllerConnectionInformation) (version.Number, error) {
+	return func(connInfo *juju.ControllerConnectionInformation) (version.Number, error) {
+		return command.ControllerVersion(ctx, connInfo)
+	}
+}
+
+func validateControllerPatchUpgrade(currentVersion, targetVersion string) (version.Number, error) {
+	currentPatchVersion, err := version.Parse(currentVersion)
+	if err != nil {
+		return version.Number{}, fmt.Errorf("invalid current controller version %q: %w", currentVersion, err)
+	}
+
+	targetPatchVersion, err := version.Parse(targetVersion)
+	if err != nil {
+		return version.Number{}, fmt.Errorf("invalid requested controller version %q: %w", targetVersion, err)
+	}
+
+	if currentPatchVersion.Major != targetPatchVersion.Major || currentPatchVersion.Minor != targetPatchVersion.Minor || targetPatchVersion.Patch <= currentPatchVersion.Patch {
+		return version.Number{}, fmt.Errorf(
+			"only upgrades to a higher patch version within the same major.minor series are supported (current %s, requested %s)",
+			currentPatchVersion,
+			targetPatchVersion,
+		)
+	}
+
+	return targetPatchVersion, nil
 }
 
 // buildStringListFromMap converts a map to a list of key=value strings.

--- a/internal/provider/resource_controller.go
+++ b/internal/provider/resource_controller.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/juju/names/v5"
 	"github.com/juju/terraform-provider-juju/internal/juju"
-	"github.com/juju/terraform-provider-juju/internal/wait"
 	"github.com/juju/version/v2"
 )
 
@@ -190,9 +189,11 @@ func (r *controllerResource) Schema(_ context.Context, _ resource.SchemaRequest,
 		Description: "A resource that represents a Juju Controller.",
 		Attributes: map[string]schema.Attribute{
 			"agent_version": schema.StringAttribute{
-				Description: "Specifies a controller version to bootstrap. If not specified, the latest stable agent version will be used. Updating this value only supports in-place upgrades to higher patch versions within the same major.minor series.",
-				Optional:    true,
-				Computed:    true,
+				Description: "Specifies a controller version to bootstrap. If not specified, the latest stable agent version will be used." +
+					" Updating this value only supports in-place upgrades to higher patch versions within the same major.minor series." +
+					" The provider does not wait for the upgrade to complete, so we recommend waiting for the upgrade to finish before applying further changes.",
+				Optional: true,
+				Computed: true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplaceIf(
 						controllerAgentVersionRequiresReplaceIf,
@@ -1100,25 +1101,17 @@ func (r *controllerResource) Update(ctx context.Context, req resource.UpdateRequ
 			return
 		}
 
-		if _, err := wait.WaitFor(
-			wait.WaitForCfg[*juju.ControllerConnectionInformation, version.Number]{
-				Context: ctx,
-				GetData: controllerVersionShim(ctx, command),
-				Input:   connInfo,
-				DataAssertions: []wait.Assert[version.Number]{
-					func(data version.Number) error {
-						if data != upgradedVersion {
-							return juju.NewRetryReadError("waiting for controller version to change")
-						}
-						return nil
-					},
-				},
-				Logf: r.trace,
-			},
-		); err != nil {
-			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed waiting for new controller version, got error: %s", err))
-			return
-		}
+		// Waiting for the upgrade to complete is not currently possible
+		// as the controller starts returning an "upgrade in progress" error
+		// at some point after the upgrade process has started, which prevents
+		// us from accurately polling for the controller version.
+
+		resp.Diagnostics.AddWarning(
+			"Controller Upgrade Warning",
+			fmt.Sprintf("The controller %q is being upgraded to version %s. "+
+				"Please wait for the upgrade to complete before applying further changes to avoid 'upgrade-in-progress' errors.",
+				state.Name.ValueString(), upgradedVersion.String()),
+		)
 
 		plan.AgentVersion = types.StringValue(upgradedVersion.String())
 	}
@@ -1211,13 +1204,6 @@ func (r *controllerResource) Delete(ctx context.Context, req resource.DeleteRequ
 			)
 		}
 		return
-	}
-}
-
-// controllerVersionShim is a helper function to adapt the ControllerVersion method to the signature required by wait.WaitFor.
-func controllerVersionShim(ctx context.Context, command JujuCommand) func(connInfo *juju.ControllerConnectionInformation) (version.Number, error) {
-	return func(connInfo *juju.ControllerConnectionInformation) (version.Number, error) {
-		return command.ControllerVersion(ctx, connInfo)
 	}
 }
 

--- a/internal/provider/resource_controller.go
+++ b/internal/provider/resource_controller.go
@@ -942,6 +942,8 @@ func (r *controllerResource) Read(ctx context.Context, req resource.ReadRequest,
 		return
 	}
 
+	// Controller version is also available inside of controllerModelConfig
+	// but we make an extra call here to decouple the separate use cases.
 	agentVersion, err := command.ControllerVersion(ctx, connInfo)
 	if err != nil {
 		resp.Diagnostics.AddError(

--- a/internal/provider/resource_controller_test.go
+++ b/internal/provider/resource_controller_test.go
@@ -266,49 +266,55 @@ resource "juju_controller" "controller" {
 `, agentVersion, controllerName, cloudName)
 }
 
-func TestValidateControllerPatchUpgrade(t *testing.T) {
+func TestControllerAgentVersionSeriesChanged(t *testing.T) {
 	tests := []struct {
-		name           string
-		currentVersion string
-		targetVersion  string
-		expected       version.Number
-		errSubstring   string
+		name            string
+		currentVersion  string
+		targetVersion   string
+		requiresReplace bool
+		errSubstring    string
 	}{
 		{
-			name:           "higher patch allowed",
-			currentVersion: "3.6.12",
+			name:            "higher patch does not replace",
+			currentVersion:  "3.6.12",
+			targetVersion:   "3.6.13",
+			requiresReplace: false,
+		},
+		{
+			name:            "lower patch replaces",
+			currentVersion:  "3.6.12",
+			targetVersion:   "3.6.11",
+			requiresReplace: true,
+		},
+		{
+			name:            "minor upgrade replaces",
+			currentVersion:  "3.6.12",
+			targetVersion:   "3.7.0",
+			requiresReplace: true,
+		},
+		{
+			name:            "major upgrade replaces",
+			currentVersion:  "3.6.12",
+			targetVersion:   "4.0.0",
+			requiresReplace: true,
+		},
+		{
+			name:           "invalid current version",
+			currentVersion: "bad-version",
 			targetVersion:  "3.6.13",
-			expected:       version.MustParse("3.6.13"),
+			errSubstring:   "invalid current controller version",
 		},
 		{
-			name:           "same patch rejected",
+			name:           "invalid target version",
 			currentVersion: "3.6.12",
-			targetVersion:  "3.6.12",
-			errSubstring:   "only upgrades to a higher patch version",
-		},
-		{
-			name:           "lower patch rejected",
-			currentVersion: "3.6.12",
-			targetVersion:  "3.6.11",
-			errSubstring:   "only upgrades to a higher patch version",
-		},
-		{
-			name:           "minor upgrade rejected",
-			currentVersion: "3.6.12",
-			targetVersion:  "3.7.0",
-			errSubstring:   "only upgrades to a higher patch version",
-		},
-		{
-			name:           "major upgrade rejected",
-			currentVersion: "3.6.12",
-			targetVersion:  "4.0.0",
-			errSubstring:   "only upgrades to a higher patch version",
+			targetVersion:  "bad-version",
+			errSubstring:   "invalid requested controller version",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := validateControllerPatchUpgrade(tt.currentVersion, tt.targetVersion)
+			got, err := controllerAgentVersionSeriesChanged(tt.currentVersion, tt.targetVersion)
 			if tt.errSubstring != "" {
 				require.Error(t, err)
 				require.ErrorContains(t, err, tt.errSubstring)
@@ -316,7 +322,7 @@ func TestValidateControllerPatchUpgrade(t *testing.T) {
 			}
 
 			require.NoError(t, err)
-			require.Equal(t, tt.expected, got)
+			require.Equal(t, tt.requiresReplace, got)
 		})
 	}
 }

--- a/internal/provider/resource_controller_test.go
+++ b/internal/provider/resource_controller_test.go
@@ -540,6 +540,10 @@ func TestAcc_ResourceControllerWithJujuBinary(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "agent_version", updatedAgentVersion),
 					resource.TestCheckResourceAttr(resourceName, "controller_model_config.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "controller_config.%", "0"),
+					func(s *terraform.State) error {
+						time.Sleep(30 * time.Second) // Sleep to wait for the upgrade to complete.
+						return nil
+					},
 				),
 			},
 			{
@@ -615,7 +619,7 @@ func TestAcc_ResourceControllerWithJujuBinary(t *testing.T) {
 				return nil
 			}
 
-			// Retry for up to 60s to allow the controller to finish shutting down.
+			// Retry for up to 30s to allow the controller to finish shutting down.
 			_, err = wait.WaitFor(wait.WaitForCfg[*terraform.State, struct{}]{
 				Context: t.Context(),
 				GetData: func(state *terraform.State) (struct{}, error) {
@@ -632,7 +636,7 @@ func TestAcc_ResourceControllerWithJujuBinary(t *testing.T) {
 				Input:          s,
 				NonFatalErrors: []error{juju.RetryReadError},
 				RetryConf: &wait.RetryConf{
-					MaxDuration: 60 * time.Second,
+					MaxDuration: 30 * time.Second,
 					Delay:       time.Second,
 					MaxDelay:    time.Second,
 				},

--- a/internal/provider/resource_controller_test.go
+++ b/internal/provider/resource_controller_test.go
@@ -365,6 +365,23 @@ func TestBuildStringListFromMap(t *testing.T) {
 func TestAcc_ResourceControllerWithJujuBinary(t *testing.T) {
 	controllerName := acctest.RandomWithPrefix("tf-test-controller")
 	resourceName := "juju_controller.controller"
+	var initialAgentVersion, updatedAgentVersion string
+	agentVersion := os.Getenv(TestJujuAgentVersion)
+	if agentVersion == "" {
+		t.Error("environment variable JUJU_AGENT_VERSION must be set for this test")
+		return
+	}
+	jujuMajor := version.MustParse(agentVersion).Major
+	switch jujuMajor {
+	case 2:
+		initialAgentVersion = "2.9.58"
+		updatedAgentVersion = "2.9.59"
+	case 3:
+		initialAgentVersion = "3.6.21"
+		updatedAgentVersion = "3.6.23"
+	default:
+		t.Errorf("unsupported Juju agent version %q for this test", agentVersion)
+	}
 
 	// bootstrap config
 	baseBootstrapConfig := map[string]string{
@@ -411,9 +428,10 @@ func TestAcc_ResourceControllerWithJujuBinary(t *testing.T) {
 		Steps: append([]resource.TestStep{
 			{
 				// Create the controller
-				Config: testAccResourceControllerWithJujuBinary(controllerName, baseBootstrapConfig, baseControllerConfig, baseControllerModelConfig),
+				Config: testAccResourceControllerWithJujuBinary(controllerName, initialAgentVersion, baseBootstrapConfig, baseControllerConfig, baseControllerModelConfig),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", controllerName),
+					resource.TestCheckResourceAttr(resourceName, "agent_version", initialAgentVersion),
 					resource.TestCheckResourceAttr(resourceName, "bootstrap_config.admin-secret", "my-favorite-admin-password"),
 					resource.TestCheckResourceAttr(resourceName, "controller_config.agent-logfile-max-backups", "3"),
 					resource.TestCheckResourceAttr(resourceName, "controller_model_config.disable-telemetry", "true"),
@@ -423,7 +441,7 @@ func TestAcc_ResourceControllerWithJujuBinary(t *testing.T) {
 			},
 			{
 				// Verify changing controller config works
-				Config: testAccResourceControllerWithJujuBinary(controllerName, baseBootstrapConfig, updatedControllerConfig, baseControllerModelConfig),
+				Config: testAccResourceControllerWithJujuBinary(controllerName, initialAgentVersion, baseBootstrapConfig, updatedControllerConfig, baseControllerModelConfig),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "controller_config.agent-logfile-max-backups", "4"),
 					resource.TestCheckResourceAttr(resourceName, "controller_model_config.%", "1"),
@@ -447,7 +465,7 @@ func TestAcc_ResourceControllerWithJujuBinary(t *testing.T) {
 			},
 			{
 				// Verify unsetting a controller config value behaves as expected.
-				Config: testAccResourceControllerWithJujuBinary(controllerName, baseBootstrapConfig, unsetControllerConfig, baseControllerModelConfig),
+				Config: testAccResourceControllerWithJujuBinary(controllerName, initialAgentVersion, baseBootstrapConfig, unsetControllerConfig, baseControllerModelConfig),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "controller_model_config.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "controller_config.%", "0"),
@@ -474,7 +492,7 @@ func TestAcc_ResourceControllerWithJujuBinary(t *testing.T) {
 			},
 			{
 				// Verify changing controller model config works
-				Config: testAccResourceControllerWithJujuBinary(controllerName, baseBootstrapConfig, unsetControllerConfig, updatedControllerModelConfig),
+				Config: testAccResourceControllerWithJujuBinary(controllerName, initialAgentVersion, baseBootstrapConfig, unsetControllerConfig, updatedControllerModelConfig),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "controller_model_config.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "controller_config.%", "0"),
@@ -484,7 +502,7 @@ func TestAcc_ResourceControllerWithJujuBinary(t *testing.T) {
 			},
 			{
 				// Verify unsetting controller model config works
-				Config: testAccResourceControllerWithJujuBinary(controllerName, baseBootstrapConfig, unsetControllerConfig, unsetControllerModelConfig),
+				Config: testAccResourceControllerWithJujuBinary(controllerName, initialAgentVersion, baseBootstrapConfig, unsetControllerConfig, unsetControllerModelConfig),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "controller_model_config.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "controller_config.%", "0"),
@@ -508,10 +526,19 @@ func TestAcc_ResourceControllerWithJujuBinary(t *testing.T) {
 				),
 			},
 			{
+				// Verify changing controller agent version works
+				Config: testAccResourceControllerWithJujuBinary(controllerName, updatedAgentVersion, baseBootstrapConfig, unsetControllerConfig, unsetControllerModelConfig),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "agent_version", updatedAgentVersion),
+					resource.TestCheckResourceAttr(resourceName, "controller_model_config.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "controller_config.%", "0"),
+				),
+			},
+			{
 				SkipFunc: func() (bool, error) {
 					return testingCloud != LXDCloudTesting, nil
 				},
-				Config: testAccResourceControllerWithEnableHA(controllerName, baseBootstrapConfig, unsetControllerConfig, unsetControllerModelConfig),
+				Config: testAccResourceControllerWithEnableHA(controllerName, updatedAgentVersion, baseBootstrapConfig, unsetControllerConfig, unsetControllerModelConfig),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", controllerName),
 					func(s *terraform.State) error {
@@ -560,10 +587,10 @@ func TestAcc_ResourceControllerWithJujuBinary(t *testing.T) {
 			},
 			{
 				// Verify that invalid controller config fails
-				Config:      testAccResourceControllerWithJujuBinary(controllerName, baseBootstrapConfig, invalidControllerConfig, unsetControllerModelConfig),
+				Config:      testAccResourceControllerWithJujuBinary(controllerName, updatedAgentVersion, baseBootstrapConfig, invalidControllerConfig, unsetControllerModelConfig),
 				ExpectError: regexp.MustCompile("failed to update controller config: unknown controller config"),
 			},
-		}, testJAASControllerResourceSteps(t, resourceName, controllerName, baseBootstrapConfig)...),
+		}, testJAASControllerResourceSteps(t, resourceName, controllerName, updatedAgentVersion, baseBootstrapConfig)...),
 		CheckDestroy: func(s *terraform.State) error {
 			if isJAAS() {
 				if err := testAccCheckJaasControllerRegistered(t, controllerName, false)(s); err != nil {
@@ -752,7 +779,7 @@ resource "juju_controller" "controller" {
 	return ""
 }
 
-func testAccResourceControllerWithJujuBinary(controllerName string, bootstrapConfig, controllerConfig, modelConfig map[string]string) string {
+func testAccResourceControllerWithJujuBinary(controllerName, agentVersion string, bootstrapConfig, controllerConfig, modelConfig map[string]string) string {
 	if isJAAS() {
 		// If JAAS, set the controller's login-token-refresh-url to JAAS.
 		addrs := os.Getenv(JujuControllerEnvKey)
@@ -795,6 +822,7 @@ locals {
 
 resource "juju_controller" "controller" {
   name          = %q
+  agent_version = %q
 
   juju_binary     = "/snap/juju/current/bin/juju"
 
@@ -831,7 +859,7 @@ resource "juju_controller" "controller" {
     }
   }  
 }
-`, controllerName, bootstrapConfigHCL, controllerConfigHCL, modelConfigHCL)
+`, controllerName, agentVersion, bootstrapConfigHCL, controllerConfigHCL, modelConfigHCL)
 	case MicroK8sTesting:
 		return fmt.Sprintf(`
 provider "juju" {
@@ -844,6 +872,7 @@ locals {
 
 resource "juju_controller" "controller" {
   name          = %q
+  agent_version = %q
 
   juju_binary     = "/snap/juju/current/bin/juju"
 
@@ -876,15 +905,15 @@ resource "juju_controller" "controller" {
 	}
   }
 }
-`, controllerName, bootstrapConfigHCL, controllerConfigHCL, modelConfigHCL)
+`, controllerName, agentVersion, bootstrapConfigHCL, controllerConfigHCL, modelConfigHCL)
 	}
 	return ""
 }
 
 // testAccResourceControllerWithEnableHA returns HCL that bootstraps a controller
 // and runs the juju_enable_ha action with 3 units.
-func testAccResourceControllerWithEnableHA(controllerName string, bootstrapConfig, controllerConfig, modelConfig map[string]string) string {
-	base := testAccResourceControllerWithJujuBinary(controllerName, bootstrapConfig, controllerConfig, modelConfig)
+func testAccResourceControllerWithEnableHA(controllerName, agentVersion string, bootstrapConfig, controllerConfig, modelConfig map[string]string) string {
+	base := testAccResourceControllerWithJujuBinary(controllerName, agentVersion, bootstrapConfig, controllerConfig, modelConfig)
 	return base + `
 resource "terraform_data" "test" {
   lifecycle {

--- a/internal/provider/resource_controller_test.go
+++ b/internal/provider/resource_controller_test.go
@@ -4,6 +4,7 @@
 package provider
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"os"
@@ -37,6 +38,8 @@ import (
 func TestAcc_ResourceController(t *testing.T) {
 	SkipJAAS(t)
 	controllerName := acctest.RandomWithPrefix("tf-test-controller")
+	currentAgentVersion := "3.6.12"
+	targetAgentVersion := "3.6.13"
 
 	mockCtrl := gomock.NewController(t)
 	mockJujuCommand := NewMockJujuCommand(mockCtrl)
@@ -88,7 +91,7 @@ func TestAcc_ResourceController(t *testing.T) {
 			},
 		},
 		Flags: juju.BootstrapFlags{
-			AgentVersion:  "3.6.12",
+			AgentVersion:  currentAgentVersion,
 			BootstrapBase: "test-base",
 		},
 	}).Return(&juju.ControllerConnectionInformation{
@@ -96,7 +99,7 @@ func TestAcc_ResourceController(t *testing.T) {
 		CACert:       "test controller CA cert",
 		Username:     "admin",
 		Password:     "password",
-		AgentVersion: "3.6.12",
+		AgentVersion: currentAgentVersion,
 	}, nil).AnyTimes()
 
 	mockJujuCommand.EXPECT().Config(
@@ -107,30 +110,60 @@ func TestAcc_ResourceController(t *testing.T) {
 			Username:  "admin",
 			Password:  "password",
 		},
-	).Return(map[string]any{
-		"agent-logfile-max-backups": "3",
-		"audit-log-capture-args":    "true",
-		"autocert-dns-name":         "test-external-name",
-	}, map[string]any{
-		"enable-os-refresh-update": "false",
-		"http-proxy":               "fake-proxy",
-	}, nil).AnyTimes()
+	).DoAndReturn(func(context.Context, *juju.ControllerConnectionInformation) (map[string]any, map[string]any, error) {
+		return map[string]any{
+				"agent-logfile-max-backups": "3",
+				"audit-log-capture-args":    "true",
+				"autocert-dns-name":         "test-external-name",
+			}, map[string]any{
+				"agent-version":            currentAgentVersion,
+				"enable-os-refresh-update": "false",
+				"http-proxy":               "fake-proxy",
+			}, nil
+	}).AnyTimes()
+
+	mockJujuCommand.EXPECT().ControllerVersion(
+		gomock.Any(),
+		&juju.ControllerConnectionInformation{
+			Addresses: []string{"127.0.0.1:17070"},
+			CACert:    "test controller CA cert",
+			Username:  "admin",
+			Password:  "password",
+		},
+	).DoAndReturn(func(ctx context.Context, cci *juju.ControllerConnectionInformation) (version.Number, error) {
+		return version.MustParse(currentAgentVersion), nil
+	}).AnyTimes()
+
+	mockJujuCommand.EXPECT().UpgradeController(
+		gomock.Any(),
+		&juju.ControllerConnectionInformation{
+			Addresses: []string{"127.0.0.1:17070"},
+			CACert:    "test controller CA cert",
+			Username:  "admin",
+			Password:  "password",
+		},
+		version.MustParse(targetAgentVersion),
+	).DoAndReturn(func(_ context.Context, _ *juju.ControllerConnectionInformation, targetVersion version.Number) (version.Number, error) {
+		currentAgentVersion = targetVersion.String()
+		return targetVersion, nil
+	})
+
+	mockJujuCommand.EXPECT().UpdateConfig(
+		gomock.Any(),
+		&juju.ControllerConnectionInformation{
+			Addresses: []string{"127.0.0.1:17070"},
+			CACert:    "test controller CA cert",
+			Username:  "admin",
+			Password:  "password",
+		},
+		map[string]string{},
+		map[string]string{},
+		[]string{},
+	).Return(nil)
 
 	mockJujuCommand.EXPECT().Destroy(
 		gomock.Any(),
-		juju.DestroyArguments{
-			Name:        controllerName,
-			JujuBinary:  "/snap/bin/juju",
-			CloudName:   testingCloud.CloudName(),
-			CloudRegion: "local",
-			ConnectionInfo: juju.ControllerConnectionInformation{
-				Addresses:    []string{"127.0.0.1:17070"},
-				CACert:       "test controller CA cert",
-				Username:     "admin",
-				Password:     "password",
-				AgentVersion: "3.6.12",
-			},
-		},
+		gomock.Any(),
 	).Return(nil).AnyTimes()
 
 	frameworkProviderFactoriesWithMockJujuCommand := map[string]func() (tfprotov6.ProviderServer, error){
@@ -145,23 +178,37 @@ func TestAcc_ResourceController(t *testing.T) {
 	resourceName := "juju_controller.controller"
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: frameworkProviderFactoriesWithMockJujuCommand,
-		Steps: []resource.TestStep{{
-			Config: testAccResourceController(controllerName, testingCloud.CloudName()),
-			Check: resource.ComposeTestCheckFunc(
-				resource.TestCheckResourceAttr(resourceName, "name", controllerName),
-			),
-		}},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceController(controllerName, testingCloud.CloudName(), currentAgentVersion),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", controllerName),
+					resource.TestCheckResourceAttr(resourceName, "agent_version", currentAgentVersion),
+				),
+			},
+			{
+				Config: testAccResourceController(controllerName, testingCloud.CloudName(), targetAgentVersion),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "agent_version", targetAgentVersion),
+				),
+			},
+		},
 	})
 }
 
-func testAccResourceController(controllerName, cloudName string) string {
+func testAccResourceController(controllerName, cloudName, agentVersion string) string {
 	return fmt.Sprintf(`
 provider "juju" {
   controller_mode = true
 }
 
 resource "juju_controller" "controller" {
-  agent_version = "3.6.12"
+  agent_version = %q
   name          = %q
 
   juju_binary     = "/snap/bin/juju"
@@ -216,7 +263,62 @@ resource "juju_controller" "controller" {
 	}
   }
 }
-`, controllerName, cloudName)
+`, agentVersion, controllerName, cloudName)
+}
+
+func TestValidateControllerPatchUpgrade(t *testing.T) {
+	tests := []struct {
+		name           string
+		currentVersion string
+		targetVersion  string
+		expected       version.Number
+		errSubstring   string
+	}{
+		{
+			name:           "higher patch allowed",
+			currentVersion: "3.6.12",
+			targetVersion:  "3.6.13",
+			expected:       version.MustParse("3.6.13"),
+		},
+		{
+			name:           "same patch rejected",
+			currentVersion: "3.6.12",
+			targetVersion:  "3.6.12",
+			errSubstring:   "only upgrades to a higher patch version",
+		},
+		{
+			name:           "lower patch rejected",
+			currentVersion: "3.6.12",
+			targetVersion:  "3.6.11",
+			errSubstring:   "only upgrades to a higher patch version",
+		},
+		{
+			name:           "minor upgrade rejected",
+			currentVersion: "3.6.12",
+			targetVersion:  "3.7.0",
+			errSubstring:   "only upgrades to a higher patch version",
+		},
+		{
+			name:           "major upgrade rejected",
+			currentVersion: "3.6.12",
+			targetVersion:  "4.0.0",
+			errSubstring:   "only upgrades to a higher patch version",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := validateControllerPatchUpgrade(tt.currentVersion, tt.targetVersion)
+			if tt.errSubstring != "" {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tt.errSubstring)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, got)
+		})
+	}
 }
 
 func TestBuildStringListFromMap(t *testing.T) {

--- a/internal/provider/resource_controller_test.go
+++ b/internal/provider/resource_controller_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 	gomock "go.uber.org/mock/gomock"
 
+	jujuerrors "github.com/juju/errors"
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/client/modelconfig"
 	"github.com/juju/juju/api/client/modelmanager"
@@ -32,6 +33,7 @@ import (
 	controllerapi "github.com/juju/juju/api/controller/controller"
 	"github.com/juju/names/v5"
 	"github.com/juju/terraform-provider-juju/internal/juju"
+	"github.com/juju/terraform-provider-juju/internal/wait"
 	"github.com/juju/version/v2"
 )
 
@@ -613,17 +615,35 @@ func TestAcc_ResourceControllerWithJujuBinary(t *testing.T) {
 				return nil
 			}
 
-			// Attempt to connect and expect a timeout after 10s
-			// This doesn't definitely prove the controller is destroyed, but is a good heuristic.
-			_, err = newBootstrappedControllerClient(s, api.WithDialOpts(api.DialOpts{Timeout: 10 * time.Second}))
+			// Retry for up to 10s to allow the controller to finish shutting down.
+			_, err = wait.WaitFor(wait.WaitForCfg[*terraform.State, struct{}]{
+				Context: t.Context(),
+				GetData: func(state *terraform.State) (struct{}, error) {
+					conn, err := newBootstrappedControllerClient(state, api.WithDialOpts(api.DialOpts{Timeout: time.Second}))
+					if err != nil {
+						if ok, matchErr := regexp.MatchString("failed to connect to controller: .*", err.Error()); matchErr == nil && ok {
+							return struct{}{}, nil
+						}
+						return struct{}{}, fmt.Errorf("unexpected error when connecting to destroyed controller: %w", err)
+					}
+					defer conn.Close()
+					return struct{}{}, juju.NewRetryReadError("controller is still reachable")
+				},
+				Input:          s,
+				NonFatalErrors: []error{juju.RetryReadError},
+				RetryConf: &wait.RetryConf{
+					MaxDuration: 10 * time.Second,
+					Delay:       time.Second,
+					MaxDelay:    time.Second,
+				},
+			})
 			if err != nil {
-				if strings.Contains(err.Error(), "failed to connect to controller: api connection open timed out") {
-					return nil
+				if jujuerrors.Is(err, juju.RetryReadError) {
+					return fmt.Errorf("controller remained reachable for 10s after destroy: %w", err)
 				}
-				return fmt.Errorf("unexpected error when connecting to detroyed controller: %w", err)
-			} else {
-				return fmt.Errorf("unexpectedly managed to connect to controller")
+				return err
 			}
+			return nil
 		},
 	})
 }

--- a/internal/provider/resource_controller_test.go
+++ b/internal/provider/resource_controller_test.go
@@ -536,6 +536,12 @@ func TestAcc_ResourceControllerWithJujuBinary(t *testing.T) {
 			{
 				// Verify changing controller agent version works
 				Config: testAccResourceControllerWithJujuBinary(controllerName, updatedAgentVersion, baseBootstrapConfig, unsetControllerConfig, unsetControllerModelConfig),
+				PreConfig: func() {
+					// If microk8s, sleep for 30s to avoid an error "modeloperator" deployment not found.
+					if testingCloud == MicroK8sTesting {
+						time.Sleep(15 * time.Second)
+					}
+				},
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "agent_version", updatedAgentVersion),
 					resource.TestCheckResourceAttr(resourceName, "controller_model_config.%", "1"),

--- a/internal/provider/resource_controller_test.go
+++ b/internal/provider/resource_controller_test.go
@@ -615,11 +615,11 @@ func TestAcc_ResourceControllerWithJujuBinary(t *testing.T) {
 				return nil
 			}
 
-			// Retry for up to 10s to allow the controller to finish shutting down.
+			// Retry for up to 60s to allow the controller to finish shutting down.
 			_, err = wait.WaitFor(wait.WaitForCfg[*terraform.State, struct{}]{
 				Context: t.Context(),
 				GetData: func(state *terraform.State) (struct{}, error) {
-					conn, err := newBootstrappedControllerClient(state, api.WithDialOpts(api.DialOpts{Timeout: time.Second}))
+					conn, err := newBootstrappedControllerClient(state, api.WithDialOpts(api.DialOpts{Timeout: 5 * time.Second}))
 					if err != nil {
 						if ok, matchErr := regexp.MatchString("failed to connect to controller: .*", err.Error()); matchErr == nil && ok {
 							return struct{}{}, nil
@@ -632,7 +632,7 @@ func TestAcc_ResourceControllerWithJujuBinary(t *testing.T) {
 				Input:          s,
 				NonFatalErrors: []error{juju.RetryReadError},
 				RetryConf: &wait.RetryConf{
-					MaxDuration: 10 * time.Second,
+					MaxDuration: 60 * time.Second,
 					Delay:       time.Second,
 					MaxDelay:    time.Second,
 				},

--- a/internal/provider/resource_jaas_controller_test.go
+++ b/internal/provider/resource_jaas_controller_test.go
@@ -14,7 +14,7 @@ import (
 // and used in the tests where we bootstrap a controller to
 // avoid bootstrapping twice in multiple tests.
 
-func testJAASControllerResourceSteps(t *testing.T, resourceName, controllerName string, bootstrapConfig map[string]string) []resource.TestStep {
+func testJAASControllerResourceSteps(t *testing.T, resourceName, controllerName, agentVersion string, bootstrapConfig map[string]string) []resource.TestStep {
 	return []resource.TestStep{{
 		SkipFunc: func() (bool, error) {
 			// Skip if not JAAS
@@ -25,6 +25,7 @@ func testJAASControllerResourceSteps(t *testing.T, resourceName, controllerName 
 		},
 		Config: testAccResourceControllerAndJAASRegistration(
 			controllerName,
+			agentVersion,
 			bootstrapConfig,
 			nil,
 			nil,
@@ -47,6 +48,7 @@ func testJAASControllerResourceSteps(t *testing.T, resourceName, controllerName 
 			},
 			Config: testAccResourceControllerAndJAASRegistration(
 				controllerName,
+				agentVersion,
 				bootstrapConfig,
 				nil,
 				nil,
@@ -58,8 +60,8 @@ func testJAASControllerResourceSteps(t *testing.T, resourceName, controllerName 
 	}
 }
 
-func testAccResourceControllerAndJAASRegistration(controllerName string, bootstrapConfig, controllerConfig, modelConfig map[string]string) string {
-	base := testAccResourceControllerWithJujuBinary(controllerName, bootstrapConfig, controllerConfig, modelConfig)
+func testAccResourceControllerAndJAASRegistration(controllerName, agentVersion string, bootstrapConfig, controllerConfig, modelConfig map[string]string) string {
+	base := testAccResourceControllerWithJujuBinary(controllerName, agentVersion, bootstrapConfig, controllerConfig, modelConfig)
 	return base + `
 resource "juju_jaas_controller" "jaas" {
   name = juju_controller.controller.name


### PR DESCRIPTION
## Description

This change adjusts the `juju_controller` resource to allow for in-place patch upgrades.

Fixes: [JUJU-9853](https://warthogs.atlassian.net/browse/JUJU-9853)

## Type of change

- Change existing resource

## QA steps

Manual QA steps should be done to test this PR.
Use `juju show-credentials localhost localhost --client --show-secrets` to get the credentials.

```tf
provider "juju" {
  controller_mode = true
}

resource "juju_controller" "controller" {
  name                = "foo"
  agent_version = "3.6.23"

  juju_binary   = "/snap/juju/current/bin/juju"

  cloud = {
    name   = "localhost"
	  auth_types = ["certificate"]
	  type = "lxd"
  }

  cloud_credential = {
    name = "test-credential"
    auth_type = "certificate"
    
    attributes = {
        client-cert = <<EOF
<client-cert>
EOF
         client-key = <<EOF
<private-key>
EOF
         server-cert = <<EOF
<server-cert>
EOF
      }
  }  
}
```


[JUJU-9853]: https://warthogs.atlassian.net/browse/JUJU-9853?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ