### PR TITLE
fix(resource_machine): addresses machine placement on import

### DIFF
--- a/docs/resources/machine.md
+++ b/docs/resources/machine.md
@@ -43,7 +43,7 @@ resource "juju_machine" "this_machine" {
 - `constraints` (String) Machine constraints that overwrite those available from 'juju get-model-constraints' and provider's defaults. Changing this value will cause the application to be destroyed and recreated by terraform.
 - `disks` (String) Storage constraints for disks to attach to the machine(s). Changing this value will cause the machine to be destroyed and recreated by terraform.
 - `name` (String) A name for the machine resource in Terraform.
-- `placement` (String) Additional information about how to allocate the machine in the cloud. Changing this value will cause the application to be destroyed and recreated by terraform.
+- `placement` (String) Additional information about how to allocate the machine in the cloud. Changing this value on a machine that already tracks a placement directive will cause the machine to be destroyed and recreated by terraform. Note that Juju does not expose the placement directive, so it cannot be read back: an imported machine has an empty placement in state and will not be recreated when a placement is set in configuration.
 - `private_key_file` (String) The file path to read the private key from.
 - `public_key_file` (String) The file path to read the public key from.
 - `ssh_address` (String) The user@host directive for manual provisioning an existing machine via ssh. Requires public_key_file & private_key_file arguments. Changing this value will cause the machine to be destroyed and recreated by terraform.

--- a/internal/provider/resource_machine.go
+++ b/internal/provider/resource_machine.go
@@ -206,10 +206,15 @@ func (r *machineResource) Schema(ctx context.Context, req resource.SchemaRequest
 			},
 			PlacementKey: schema.StringAttribute{
 				Description: "Additional information about how to allocate the machine in the cloud. Changing" +
-					" this value will cause the application to be destroyed and recreated by terraform.",
+					" this value on a machine that already tracks a placement directive will cause the machine to" +
+					" be destroyed and recreated by terraform. Note that Juju does not expose the placement" +
+					" directive, so it cannot be read back: an imported machine has an empty placement in state" +
+					" and will not be recreated when a placement is set in configuration.",
 				Optional: true,
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplaceIfConfigured(),
+					stringplanmodifier.RequiresReplaceIf(placementRequiresReplacefunc,
+						"If the placement directive changes on a machine that already tracks one, the machine is replaced.",
+						"If the placement directive changes on a machine that already tracks one, the machine is replaced."),
 					stringplanmodifier.UseStateForUnknown(),
 				},
 				Validators: []validator.String{
@@ -542,8 +547,12 @@ func (r *machineResource) Update(ctx context.Context, req resource.UpdateRequest
 		}
 	}
 
-	// Only the name or annotations can be updated in the terraform data.
-	if plan.Name.Equal(state.Name) && state.Annotations.Equal(plan.Annotations) && plan.Timeouts.Equal(state.Timeouts) {
+	// Only the name, annotations, timeouts or placement can change in the
+	// terraform data without forcing a replacement. Placement is never applied
+	// back to Juju (it is a deployment-time directive), but it must be
+	// persisted so an imported machine - whose placement is null in state -
+	// converges to the configured value instead of showing a perpetual diff.
+	if plan.Name.Equal(state.Name) && state.Annotations.Equal(plan.Annotations) && plan.Timeouts.Equal(state.Timeouts) && plan.Placement.Equal(state.Placement) {
 		return
 	}
 	state.Name = plan.Name
@@ -551,6 +560,7 @@ func (r *machineResource) Update(ctx context.Context, req resource.UpdateRequest
 	state.ID = types.StringValue(id)
 	state.Annotations = plan.Annotations
 	state.Timeouts = plan.Timeouts
+	state.Placement = plan.Placement
 	r.trace(fmt.Sprintf("update machine resource %q", plan.MachineID.ValueString()))
 
 	// Save updated data into Terraform state
@@ -674,6 +684,34 @@ func (r *machineResource) trace(msg string, additionalFields ...map[string]inter
 
 func newMachineID(model_uuid, machine_id, machine_name string) string {
 	return fmt.Sprintf("%s:%s:%s", model_uuid, machine_id, machine_name)
+}
+
+// placementRequiresReplacefunc decides whether a change to the placement
+// directive should force the machine to be replaced.
+//
+// Placement is a deployment-time directive that Juju does not expose through
+// its status API, so it cannot be read back during Read/Import. As a result an
+// imported (or otherwise previously untracked) machine has a null placement in
+// state. In that case we must not force replacement, otherwise importing a
+// machine that was created with a placement directive would always propose
+// destroying and recreating it (see issue #1149).
+//
+// The framework only calls this function on update, when the plan and state
+// values differ (creation, destruction and no-op changes are filtered out
+// beforehand). We therefore only need to suppress replacement when the prior
+// state has no placement value to compare against.
+func placementRequiresReplacefunc(_ context.Context, req planmodifier.StringRequest, resp *stringplanmodifier.RequiresReplaceIfFuncResponse) {
+	// Imported or previously untracked machines have no placement recorded in
+	// state. We cannot read the directive back from Juju to compare, so do not
+	// force replacement.
+	if req.StateValue.IsNull() {
+		return
+	}
+	// Placement removed from the configuration: nothing to replace for.
+	if req.ConfigValue.IsNull() {
+		return
+	}
+	resp.RequiresReplace = true
 }
 
 // Machines can be imported using the format: `model_uuid:machine_id:machine_name`.

--- a/internal/provider/resource_machine_internal_test.go
+++ b/internal/provider/resource_machine_internal_test.go
@@ -1,0 +1,64 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the Apache License, Version 2.0, see LICENCE file for details.
+
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// TestPlacementRequiresReplacefunc verifies that a change to the placement
+// directive only forces replacement when the prior state already tracks a
+// placement value. An imported machine has a null placement in state (Juju
+// does not expose the directive), so it must not be replaced - see issue #1149.
+func TestPlacementRequiresReplacefunc(t *testing.T) {
+	tests := []struct {
+		name        string
+		stateValue  types.String
+		configValue types.String
+		planValue   types.String
+		wantReplace bool
+	}{
+		{
+			name:        "imported machine (null state) gaining a placement is not replaced",
+			stateValue:  types.StringNull(),
+			configValue: types.StringValue("zone=ThinkPad-X1"),
+			planValue:   types.StringValue("zone=ThinkPad-X1"),
+			wantReplace: false,
+		},
+		{
+			name:        "placement removed from configuration is not replaced",
+			stateValue:  types.StringValue("zone=ThinkPad-X1"),
+			configValue: types.StringNull(),
+			planValue:   types.StringNull(),
+			wantReplace: false,
+		},
+		{
+			name:        "placement changed on a tracked machine forces replacement",
+			stateValue:  types.StringValue("zone=old"),
+			configValue: types.StringValue("zone=new"),
+			planValue:   types.StringValue("zone=new"),
+			wantReplace: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := planmodifier.StringRequest{
+				StateValue:  tt.stateValue,
+				ConfigValue: tt.configValue,
+				PlanValue:   tt.planValue,
+			}
+			resp := &stringplanmodifier.RequiresReplaceIfFuncResponse{}
+			placementRequiresReplacefunc(context.Background(), req, resp)
+			if resp.RequiresReplace != tt.wantReplace {
+				t.Fatalf("RequiresReplace = %v, want %v", resp.RequiresReplace, tt.wantReplace)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Addresses missing machine placement on import.

re #1149

## Type of change

- Logic changes in resources (the API interaction with Juju has been changed)

## Environment
