### PR TITLE
fix: ssh key imports

### DIFF
--- a/internal/provider/resource_ssh_key.go
+++ b/internal/provider/resource_ssh_key.go
@@ -206,10 +206,38 @@ func (s *sshKeyResource) Read(ctx context.Context, req resource.ReadRequest, res
 		return
 	}
 
-	_, err := s.client.SSHKeys.ReadSSHKey(ctx, &juju.ReadSSHKeyInput{
+	modelUUID, fingerprint, err := modelUUIDAndFingerprintFromSSHKeyID(state.ID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Malformed ID", err.Error())
+		return
+	}
+
+	payload := strings.TrimSuffix(state.Payload.ValueString(), "\n")
+	if payload == "" {
+		keys, err := s.client.SSHKeys.ListKeys(ctx, juju.ListSSHKeysInput{
+			Username:  s.client.Username(),
+			ModelUUID: modelUUID,
+		})
+		if err != nil {
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to list ssh keys, got error: %s", err))
+			return
+		}
+
+		payload, err = sshKeyPayloadFromFingerprint(keys, fingerprint)
+		if err != nil {
+			if errors.Is(err, juju.SSHKeyNotFoundError) {
+				resp.State.RemoveResource(ctx)
+				return
+			}
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to resolve imported ssh key from id %q, got error: %s", state.ID.ValueString(), err))
+			return
+		}
+	}
+
+	readResp, err := s.client.SSHKeys.ReadSSHKey(ctx, &juju.ReadSSHKeyInput{
 		Username:  s.client.Username(),
-		ModelUUID: state.ModelUUID.ValueString(),
-		Payload:   state.Payload.ValueString(),
+		ModelUUID: modelUUID,
+		Payload:   payload,
 	})
 	if err != nil {
 		if errors.Is(err, juju.SSHKeyNotFoundError) {
@@ -220,6 +248,10 @@ func (s *sshKeyResource) Read(ctx context.Context, req resource.ReadRequest, res
 		return
 	}
 	s.trace(fmt.Sprintf("read ssh key resource %q", state.ID.ValueString()))
+
+	state.ModelUUID = types.StringValue(modelUUID)
+	state.Payload = types.StringValue(strings.TrimSuffix(readResp.Payload, "\n"))
+	state.ID = types.StringValue(newSSHKeyID(modelUUID, fingerprint))
 
 	// Set the plan onto the Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
@@ -280,4 +312,26 @@ func (s *sshKeyResource) trace(msg string, additionalFields ...map[string]interf
 	// Output:
 	// {"@level":"trace","@message":"hello, world","@module":"provider.my-subsystem","foo":123}
 	tflog.SubsystemTrace(s.subCtx, LogResourceSSHKey, msg, additionalFields...)
+}
+
+func modelUUIDAndFingerprintFromSSHKeyID(id string) (string, string, error) {
+	parts := strings.SplitN(id, ":", 3)
+	if len(parts) != 3 || parts[0] != "sshkey" || parts[1] == "" || parts[2] == "" {
+		return "", "", fmt.Errorf("expected id in format sshkey:<model_uuid>:<key_fingerprint>, got: %q", id)
+	}
+	return parts[1], parts[2], nil
+}
+
+func sshKeyPayloadFromFingerprint(keys []string, targetFingerprint string) (string, error) {
+	for _, key := range keys {
+		normalized := strings.TrimSuffix(key, "\n")
+		fingerprint, _, err := ssh.KeyFingerprint(normalized)
+		if err != nil {
+			continue
+		}
+		if fingerprint == targetFingerprint {
+			return normalized, nil
+		}
+	}
+	return "", juju.NewSSHKeyNotFoundError(targetFingerprint)
 }

--- a/internal/provider/resource_ssh_key.go
+++ b/internal/provider/resource_ssh_key.go
@@ -212,45 +212,28 @@ func (s *sshKeyResource) Read(ctx context.Context, req resource.ReadRequest, res
 		return
 	}
 
-	payload := strings.TrimSuffix(state.Payload.ValueString(), "\n")
-	if payload == "" {
-		keys, err := s.client.SSHKeys.ListKeys(ctx, juju.ListSSHKeysInput{
-			Username:  s.client.Username(),
-			ModelUUID: modelUUID,
-		})
-		if err != nil {
-			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to list ssh keys, got error: %s", err))
-			return
-		}
-
-		payload, err = sshKeyPayloadFromFingerprint(keys, fingerprint)
-		if err != nil {
-			if errors.Is(err, juju.SSHKeyNotFoundError) {
-				resp.State.RemoveResource(ctx)
-				return
-			}
-			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to resolve imported ssh key from id %q, got error: %s", state.ID.ValueString(), err))
-			return
-		}
-	}
-
-	readResp, err := s.client.SSHKeys.ReadSSHKey(ctx, &juju.ReadSSHKeyInput{
+	keys, err := s.client.SSHKeys.ListKeys(ctx, juju.ListSSHKeysInput{
 		Username:  s.client.Username(),
 		ModelUUID: modelUUID,
-		Payload:   payload,
 	})
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to list ssh keys, got error: %s", err))
+		return
+	}
+
+	payload, err := sshKeyPayloadFromFingerprint(keys, fingerprint)
 	if err != nil {
 		if errors.Is(err, juju.SSHKeyNotFoundError) {
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read ssh key, got error: %s", err))
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to resolve ssh key from id %q, got error: %s", state.ID.ValueString(), err))
 		return
 	}
 	s.trace(fmt.Sprintf("read ssh key resource %q", state.ID.ValueString()))
 
 	state.ModelUUID = types.StringValue(modelUUID)
-	state.Payload = types.StringValue(strings.TrimSuffix(readResp.Payload, "\n"))
+	state.Payload = types.StringValue(payload)
 	state.ID = types.StringValue(newSSHKeyID(modelUUID, fingerprint))
 
 	// Set the plan onto the Terraform state

--- a/internal/provider/resource_ssh_key.go
+++ b/internal/provider/resource_ssh_key.go
@@ -212,28 +212,48 @@ func (s *sshKeyResource) Read(ctx context.Context, req resource.ReadRequest, res
 		return
 	}
 
-	keys, err := s.client.SSHKeys.ListKeys(ctx, juju.ListSSHKeysInput{
-		Username:  s.client.Username(),
-		ModelUUID: modelUUID,
-	})
-	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to list ssh keys, got error: %s", err))
-		return
-	}
-
-	payload, err := sshKeyPayloadFromFingerprint(keys, fingerprint)
-	if err != nil {
-		if errors.Is(err, juju.SSHKeyNotFoundError) {
-			resp.State.RemoveResource(ctx)
+	payload := strings.TrimSuffix(state.Payload.ValueString(), "\n")
+	var payloadToWrite string
+	if payload == "" {
+		keys, err := s.client.SSHKeys.ListKeys(ctx, juju.ListSSHKeysInput{
+			Username:  s.client.Username(),
+			ModelUUID: modelUUID,
+		})
+		if err != nil {
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to list ssh keys, got error: %s", err))
 			return
 		}
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to resolve ssh key from id %q, got error: %s", state.ID.ValueString(), err))
-		return
+
+		payloadToWrite, err = sshKeyPayloadFromFingerprint(keys, fingerprint)
+		if err != nil {
+			if errors.Is(err, juju.SSHKeyNotFoundError) {
+				resp.State.RemoveResource(ctx)
+				return
+			}
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to resolve imported ssh key from id %q, got error: %s", state.ID.ValueString(), err))
+			return
+		}
+	} else {
+		readResp, err := s.client.SSHKeys.ReadSSHKey(ctx, &juju.ReadSSHKeyInput{
+			Username:  s.client.Username(),
+			ModelUUID: modelUUID,
+			Payload:   payload,
+		})
+		if err != nil {
+			if errors.Is(err, juju.SSHKeyNotFoundError) {
+				resp.State.RemoveResource(ctx)
+				return
+			}
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read ssh key, got error: %s", err))
+			return
+		}
+		s.trace(fmt.Sprintf("read ssh key resource %q", state.ID.ValueString()))
+
+		payloadToWrite = readResp.Payload
 	}
-	s.trace(fmt.Sprintf("read ssh key resource %q", state.ID.ValueString()))
 
 	state.ModelUUID = types.StringValue(modelUUID)
-	state.Payload = types.StringValue(payload)
+	state.Payload = types.StringValue(strings.TrimSuffix(payloadToWrite, "\n"))
 	state.ID = types.StringValue(newSSHKeyID(modelUUID, fingerprint))
 
 	// Set the plan onto the Terraform state

--- a/internal/provider/resource_ssh_key_test.go
+++ b/internal/provider/resource_ssh_key_test.go
@@ -40,6 +40,31 @@ func TestAcc_ResourceSSHKey(t *testing.T) {
 				ResourceName:      "juju_ssh_key.this",
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"payload"},
+				ImportStateCheck: func(is []*terraform.InstanceState) error {
+					if len(is) != 1 {
+						return fmt.Errorf("expected 1 instance in import state, got %d", len(is))
+					}
+
+					payload, ok := is[0].Attributes["payload"]
+					if !ok {
+						return fmt.Errorf("did not find payload attribute in import state")
+					}
+
+					expectedClean, err := extractCleanSSHKey(sshKey1)
+					if err != nil {
+						return fmt.Errorf("clean expected ssh key: %w", err)
+					}
+					actualClean, err := extractCleanSSHKey(payload)
+					if err != nil {
+						return fmt.Errorf("clean imported ssh key: %w", err)
+					}
+					if expectedClean != actualClean {
+						return fmt.Errorf("imported payload mismatch: expected %q got %q", expectedClean, actualClean)
+					}
+
+					return nil
+				},
 			},
 			// we update the key
 			{

--- a/internal/provider/resource_ssh_key_test.go
+++ b/internal/provider/resource_ssh_key_test.go
@@ -37,9 +37,9 @@ func TestAcc_ResourceSSHKey(t *testing.T) {
 					testCheckSSHKeyPayload("juju_ssh_key.this", sshKey1)),
 			},
 			{
-				ResourceName:      "juju_ssh_key.this",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "juju_ssh_key.this",
+				ImportState:             true,
+				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"payload"},
 				ImportStateCheck: func(is []*terraform.InstanceState) error {
 					if len(is) != 1 {

--- a/internal/provider/resource_ssh_key_test.go
+++ b/internal/provider/resource_ssh_key_test.go
@@ -36,6 +36,11 @@ func TestAcc_ResourceSSHKey(t *testing.T) {
 					resource.TestCheckResourceAttrPair("juju_model.this", "uuid", "juju_ssh_key.this", "model_uuid"),
 					testCheckSSHKeyPayload("juju_ssh_key.this", sshKey1)),
 			},
+			{
+				ResourceName:      "juju_ssh_key.this",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 			// we update the key
 			{
 				Config: testAccResourceSSHKey(modelName, sshKey2),


### PR DESCRIPTION
## Description
Due to our recent issues with SSH keys, I decided to read over the resource to make sure everything is sound.

Upon reading I noticed the read method didn't utilise the ID and as such couldn't be imported, I then realised - we didn't catch this? And noticed we didn't cover importing them. 

I verified v1 and v1.5 are OK - so this must be from the recent changes, but was simply missed due to no test coverage.

@kian99 recently noticed we can pass the payload to our ReadSSHKey method - so we now take the fingerprint from the ID, resolve it and continue to send the payload.

I've also added the missing state fields, if we had drift (not that we should), we wouldn't detect it. Adding them makes the resource more robust to drift.

For the test, we simply only need ImportStateVerify as it is checking the id attribute of the resource which is set by the top level path of PassthroughByIdentity (2nd arg).

## Type of change
- Bug fix (non-breaking change which fixes an issue)


