### PR TITLE
refactor(withconnection): introduces the withConnection helper function

### DIFF
--- a/internal/juju/annotations.go
+++ b/internal/juju/annotations.go
@@ -49,63 +49,58 @@ func newAnnotationsClient(sc SharedClient) *annotationsClient {
 // SetAnnotations set the annotations for the entity specified.
 // To unset a specific annotation a empty string "" needs to be set.
 func (c *annotationsClient) SetAnnotations(ctx context.Context, input *SetAnnotationsInput) error {
-	conn, err := c.GetConnection(ctx, &input.ModelUUID)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = conn.Close() }()
+	return withConnection(ctx, c.SharedClient, &input.ModelUUID, func(conn api.Connection) error {
+		annotationsAPIClient := c.getAnnotationsAPIClient(conn)
 
-	annotationsAPIClient := c.getAnnotationsAPIClient(conn)
-
-	args := map[string]map[string]string{
-		input.EntityTag.String(): input.Annotations,
-	}
-
-	results, err := annotationsAPIClient.Set(ctx, args)
-	if err != nil {
-		return err
-	}
-	// if there are no errors the results slice is empty.
-	if len(results) > 0 {
-		if len(results) != 1 {
-			return errors.Errorf("should receive just a single error for %q", input.EntityTag)
+		args := map[string]map[string]string{
+			input.EntityTag.String(): input.Annotations,
 		}
-		if err := results[0].Error; err != nil {
+
+		results, err := annotationsAPIClient.Set(ctx, args)
+		if err != nil {
 			return err
 		}
-	}
+		// if there are no errors the results slice is empty.
+		if len(results) > 0 {
+			if len(results) != 1 {
+				return errors.Errorf("should receive just a single error for %q", input.EntityTag)
+			}
+			if err := results[0].Error; err != nil {
+				return err
+			}
+		}
 
-	return nil
+		return nil
+	})
 }
 
 // GetAnnotations gets the annotation for an entity.
 func (c *annotationsClient) GetAnnotations(ctx context.Context, input *GetAnnotationsInput) (*GetAnnotationsOutput, error) {
-	conn, err := c.GetConnection(ctx, &input.ModelUUID)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = conn.Close() }()
+	var output *GetAnnotationsOutput
+	err := withConnection(ctx, c.SharedClient, &input.ModelUUID, func(conn api.Connection) error {
+		annotationsAPIClient := c.getAnnotationsAPIClient(conn)
 
-	annotationsAPIClient := c.getAnnotationsAPIClient(conn)
+		results, err := annotationsAPIClient.Get(ctx, []string{input.EntityTag.String()})
+		if err != nil {
+			return err
+		}
+		if len(results) == 0 {
+			return errors.NotFoundf("annotations for entity %q", input.EntityTag)
+		}
 
-	results, err := annotationsAPIClient.Get(ctx, []string{input.EntityTag.String()})
-	if err != nil {
-		return nil, err
-	}
-	if len(results) == 0 {
-		return nil, errors.NotFoundf("annotations for entity %q", input.EntityTag)
-	}
+		if len(results) > 1 {
+			return errors.Errorf("should receive just a single result for %q", input.EntityTag)
+		}
 
-	if len(results) > 1 {
-		return nil, errors.Errorf("should receive just a single result for %q", input.EntityTag)
-	}
-
-	result := results[0]
-	if err := result.Error.Error; err != nil {
-		return nil, err
-	}
-	return &GetAnnotationsOutput{
-		EntityTag:   input.EntityTag,
-		Annotations: result.Annotations,
-	}, nil
+		result := results[0]
+		if err := result.Error.Error; err != nil {
+			return err
+		}
+		output = &GetAnnotationsOutput{
+			EntityTag:   input.EntityTag,
+			Annotations: result.Annotations,
+		}
+		return nil
+	})
+	return output, err
 }

--- a/internal/juju/applications.go
+++ b/internal/juju/applications.go
@@ -362,45 +362,44 @@ type DestroyApplicationInput struct {
 
 // CreateApplication creates an application in the specified model.
 func (c applicationsClient) CreateApplication(ctx context.Context, input *CreateApplicationInput) (*CreateApplicationResponse, error) {
-	conn, err := c.GetConnection(ctx, &input.ModelUUID)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = conn.Close() }()
-
-	transformedInput, err := input.validateAndTransform(ctx, conn)
-	if err != nil {
-		return nil, err
-	}
-
-	applicationAPIClient := apiapplication.NewClient(conn)
-	resourceAPIClient, err := apiresources.NewClient(conn)
-	if err != nil {
-		return nil, err
-	}
-	if applicationAPIClient.BestAPIVersion() >= 19 {
-		err := c.deployFromRepository(ctx, applicationAPIClient, resourceAPIClient, transformedInput)
+	var out *CreateApplicationResponse
+	err := withConnection(ctx, c.SharedClient, &input.ModelUUID, func(conn api.Connection) error {
+		transformedInput, err := input.validateAndTransform(ctx, conn)
 		if err != nil {
-			return nil, err
+			return err
 		}
-	} else {
-		return nil, jujuerrors.New("not supported: juju version does not support DeployFromRepository API")
-	}
 
-	// If we have managed to deploy something, now we have
-	// to check if we have to expose something
-	err = c.processExpose(ctx, applicationAPIClient, transformedInput.applicationName, transformedInput.expose)
-	if err != nil {
-		return nil, fmt.Errorf("%w: %w", newApplicationPartiallyCreatedError(transformedInput.applicationName), err)
-	}
-	modelType, err := c.ModelType(ctx, input.ModelUUID)
-	if err != nil {
-		return nil, fmt.Errorf("%w: %w", newApplicationPartiallyCreatedError(transformedInput.applicationName), err)
-	}
-	return &CreateApplicationResponse{
-		AppName:   transformedInput.applicationName,
-		ModelType: modelType.String(),
-	}, nil
+		applicationAPIClient := apiapplication.NewClient(conn)
+		resourceAPIClient, err := apiresources.NewClient(conn)
+		if err != nil {
+			return err
+		}
+		if applicationAPIClient.BestAPIVersion() >= 19 {
+			err := c.deployFromRepository(ctx, applicationAPIClient, resourceAPIClient, transformedInput)
+			if err != nil {
+				return err
+			}
+		} else {
+			return jujuerrors.New("not supported: juju version does not support DeployFromRepository API")
+		}
+
+		// If we have managed to deploy something, now we have
+		// to check if we have to expose something
+		err = c.processExpose(ctx, applicationAPIClient, transformedInput.applicationName, transformedInput.expose)
+		if err != nil {
+			return fmt.Errorf("%w: %w", newApplicationPartiallyCreatedError(transformedInput.applicationName), err)
+		}
+		modelType, err := c.ModelType(ctx, input.ModelUUID)
+		if err != nil {
+			return fmt.Errorf("%w: %w", newApplicationPartiallyCreatedError(transformedInput.applicationName), err)
+		}
+		out = &CreateApplicationResponse{
+			AppName:   transformedInput.applicationName,
+			ModelType: modelType.String(),
+		}
+		return nil
+	})
+	return out, err
 }
 
 func (c applicationsClient) deployFromRepository(ctx context.Context, applicationAPIClient ApplicationAPIClient, resourceAPIClient ResourceAPIClient, transformedInput transformedCreateApplicationInput) error {
@@ -711,233 +710,231 @@ func getStorageLabel(storageTag string) string {
 
 // ReadApplication retrieves application details from the specified model.
 func (c applicationsClient) ReadApplication(ctx context.Context, input *ReadApplicationInput) (*ReadApplicationResponse, error) {
-	conn, err := c.GetConnection(ctx, &input.ModelUUID)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = conn.Close() }()
+	var response *ReadApplicationResponse
+	err := withConnection(ctx, c.SharedClient, &input.ModelUUID, func(conn api.Connection) error {
+		applicationAPIClient := c.getApplicationAPIClient(conn)
+		modelconfigAPIClient := c.getModelConfigAPIClient(conn)
 
-	applicationAPIClient := c.getApplicationAPIClient(conn)
-	modelconfigAPIClient := c.getModelConfigAPIClient(conn)
-
-	apps, err := applicationAPIClient.ApplicationsInfo(ctx, []names.ApplicationTag{names.NewApplicationTag(input.AppName)})
-	if err != nil {
-		return nil, jujuerrors.Annotate(err, "when querying the applications info")
-	}
-	if len(apps) > 1 {
-		return nil, fmt.Errorf("more than one result for application: %s", input.AppName)
-	}
-	if len(apps) < 1 {
-		return nil, NewApplicationNotFoundError(input.AppName)
-	}
-	if apps[0].Error != nil {
-		// Return applicationNotFoundError to trigger retry.
-		c.Debugf("Actual error from ApplicationsInfo", map[string]interface{}{"err": apps[0].Error})
-		return nil, NewApplicationNotFoundError(input.AppName)
-	}
-
-	appInfo := apps[0].Result
-
-	var appStatus params.ApplicationStatus
-	var storageDirectives map[string]jujustorage.Directive
-	v, err := c.GetControllerVersion(ctx)
-	if err != nil {
-		return nil, err
-	}
-	if v.Major == 4 {
-		// With Juju 4 we have to manually filter storage/volumes/filesystems of an application.
-		appStatus, storageDirectives, err = c.getApplicationStatusAndStorageDirectives4(ctx, conn, input.AppName)
+		apps, err := applicationAPIClient.ApplicationsInfo(ctx, []names.ApplicationTag{names.NewApplicationTag(input.AppName)})
 		if err != nil {
-			return nil, err
+			return jujuerrors.Annotate(err, "when querying the applications info")
 		}
-	} else {
-		appStatus, storageDirectives, err = c.getApplicationStatusAndStorageDirectives(ctx, conn, input.AppName)
+		if len(apps) > 1 {
+			return fmt.Errorf("more than one result for application: %s", input.AppName)
+		}
+		if len(apps) < 1 {
+			return NewApplicationNotFoundError(input.AppName)
+		}
+		if apps[0].Error != nil {
+			// Return applicationNotFoundError to trigger retry.
+			c.Debugf("Actual error from ApplicationsInfo", map[string]interface{}{"err": apps[0].Error})
+			return NewApplicationNotFoundError(input.AppName)
+		}
+
+		appInfo := apps[0].Result
+
+		var appStatus params.ApplicationStatus
+		var storageDirectives map[string]jujustorage.Directive
+		v, err := c.GetControllerVersion(ctx)
 		if err != nil {
-			return nil, err
+			return err
 		}
-	}
-
-	allocatedMachines := set.NewStrings()
-	for _, v := range appStatus.Units {
-		if v.Machine != "" {
-			allocatedMachines.Add(v.Machine)
-		}
-	}
-	machines := allocatedMachines.SortedValues()
-
-	var placement string
-	if !allocatedMachines.IsEmpty() {
-		placement = strings.Join(allocatedMachines.SortedValues(), ",")
-	}
-
-	unitCount := len(appStatus.Units)
-	// if we have a CAAS we use scale instead of units length
-	modelType, err := c.ModelType(ctx, input.ModelUUID)
-	if err != nil {
-		return nil, err
-	}
-	if modelType == model.CAAS {
-		unitCount = appStatus.Scale
-	}
-
-	// NOTE: we are assuming that this charm comes from CharmHub
-	charmURL, err := charm.ParseURL(appStatus.Charm)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse charm: %v", err)
-	}
-
-	returnedConf, err := applicationAPIClient.Get(ctx, input.AppName)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get app configuration %v", err)
-	}
-
-	conf := make(map[string]ConfigEntry, 0)
-	if returnedConf.ApplicationConfig != nil {
-		for k, v := range returnedConf.ApplicationConfig {
-			// skip the trust value. We have an independent field for that
-			if k == "trust" {
-				continue
+		if v.Major == 4 {
+			// With Juju 4 we have to manually filter storage/volumes/filesystems of an application.
+			appStatus, storageDirectives, err = c.getApplicationStatusAndStorageDirectives4(ctx, conn, input.AppName)
+			if err != nil {
+				return err
 			}
-			// The API returns the configuration entries as interfaces
-			aux := v.(map[string]interface{})
-			// set if we find the value key and this is not a default
-			// value.
-			if value, found := aux["value"]; found {
-				conf[k] = ConfigEntry{
-					Value:     value,
-					IsDefault: aux["source"] == "default",
-				}
-			}
-		}
-		// repeat the same steps for charm config values
-		for k, v := range returnedConf.CharmConfig {
-			aux := v.(map[string]interface{})
-			if value, found := aux["value"]; found {
-				conf[k] = ConfigEntry{
-					Value:     value,
-					IsDefault: aux["source"] == "default",
-				}
-			}
-		}
-	}
-
-	// trust field which has to be included into the configuration
-	trustValue := false
-	if returnedConf.ApplicationConfig != nil {
-		aux, found := returnedConf.ApplicationConfig["trust"]
-		if found {
-			m := aux.(map[string]any)
-			target, found := m["value"]
-			if found {
-				trustValue = target.(bool)
-			}
-		}
-	}
-
-	// the expose field requires additional logic because
-	// the API returns populated cidrs by default. Additionally,
-	// we populate the unexpose field in the response structure
-	// to indicate endpoints that has to be removed by comparing
-	var exposed map[string]interface{} = nil
-	if appStatus.Exposed {
-		// rebuild
-		exposed = make(map[string]interface{}, 0)
-		endpoints := []string{}
-		spaces := ""
-		cidrs := ""
-		for epName, value := range appStatus.ExposedEndpoints {
-			if epName != "" {
-				endpoints = append(endpoints, epName)
-			}
-			if len(spaces) == 0 {
-				spaces = strings.Join(value.ExposeToSpaces, ",")
-			}
-			if len(cidrs) == 0 {
-				// by default the API sets
-				// cidrs: "0.0.0.0/0,::/0"
-				// ignore them
-				aux := removeDefaultCidrs(value.ExposeToCIDRs)
-				cidrs = strings.Join(aux, ",")
-			}
-		}
-		if len(endpoints) > 0 {
-			slices.Sort(endpoints)
-			exposed["endpoints"] = strings.Join(endpoints, ",")
 		} else {
-			exposed["endpoints"] = ""
-		}
-		exposed["spaces"] = spaces
-		exposed["cidrs"] = cidrs
-	}
-	// ParseChannel to send back a base without the risk.
-	// Having the risk will cause issues with the provider
-	// saving a different value than the user did.
-	baseChannel, err := corebase.ParseChannel(appInfo.Base.Channel)
-	if err != nil {
-		return nil, jujuerrors.Annotate(err, "failed parse channel for base")
-	}
-
-	defaultSpace, err := getModelDefaultSpace(ctx, modelconfigAPIClient)
-	if err != nil {
-		return nil, err
-	}
-	appDefaultSpace := appStatus.EndpointBindings[""]
-	if appDefaultSpace == "" {
-		appDefaultSpace = defaultSpace
-	}
-
-	endpointBindings := make(map[string]string)
-	if appDefaultSpace != defaultSpace {
-		endpointBindings[""] = appDefaultSpace
-	}
-	for endpoint, space := range appStatus.EndpointBindings {
-		if endpoint != "" && space != appDefaultSpace {
-			endpointBindings[endpoint] = space
-		}
-	}
-
-	resourcesAPIClient, err := c.getResourceAPIClient(conn)
-	if err != nil {
-		return nil, err
-	}
-	resources, err := resourcesAPIClient.ListResources(ctx, []string{input.AppName})
-	if err != nil {
-		return nil, jujuerrors.Annotate(err, "failed to list application resources")
-	}
-	usedResources := make(map[string]string)
-	for _, iResources := range resources {
-		for _, resource := range iResources.Resources {
-			// Per juju convention, -1, indicates that an integer value has not been set.
-			// Uploaded resources currently have no revision number.
-			// So when the revision number is -1, we can use the value in state.
-			if resource.Origin == charmresources.OriginUpload {
-				usedResources[resource.Name] = "-1"
-			} else {
-				usedResources[resource.Name] = strconv.Itoa(resource.Revision)
+			appStatus, storageDirectives, err = c.getApplicationStatusAndStorageDirectives(ctx, conn, input.AppName)
+			if err != nil {
+				return err
 			}
 		}
-	}
 
-	response := &ReadApplicationResponse{
-		Name:             charmURL.Name,
-		Channel:          appInfo.Channel,
-		Revision:         charmURL.Revision,
-		Base:             fmt.Sprintf("%s@%s", appInfo.Base.Name, baseChannel.Track),
-		ModelType:        modelType.String(),
-		Units:            unitCount,
-		Trust:            trustValue,
-		Expose:           exposed,
-		Config:           conf,
-		Constraints:      appInfo.Constraints,
-		Principal:        appInfo.Principal,
-		Placement:        placement,
-		Machines:         machines,
-		EndpointBindings: endpointBindings,
-		Storage:          storageDirectives,
-		Resources:        usedResources,
-	}
+		allocatedMachines := set.NewStrings()
+		for _, v := range appStatus.Units {
+			if v.Machine != "" {
+				allocatedMachines.Add(v.Machine)
+			}
+		}
+		machines := allocatedMachines.SortedValues()
 
-	return response, nil
+		var placement string
+		if !allocatedMachines.IsEmpty() {
+			placement = strings.Join(allocatedMachines.SortedValues(), ",")
+		}
+
+		unitCount := len(appStatus.Units)
+		// if we have a CAAS we use scale instead of units length
+		modelType, err := c.ModelType(ctx, input.ModelUUID)
+		if err != nil {
+			return err
+		}
+		if modelType == model.CAAS {
+			unitCount = appStatus.Scale
+		}
+
+		// NOTE: we are assuming that this charm comes from CharmHub
+		charmURL, err := charm.ParseURL(appStatus.Charm)
+		if err != nil {
+			return fmt.Errorf("failed to parse charm: %v", err)
+		}
+
+		returnedConf, err := applicationAPIClient.Get(ctx, input.AppName)
+		if err != nil {
+			return fmt.Errorf("failed to get app configuration %v", err)
+		}
+
+		conf := make(map[string]ConfigEntry, 0)
+		if returnedConf.ApplicationConfig != nil {
+			for k, v := range returnedConf.ApplicationConfig {
+				// skip the trust value. We have an independent field for that
+				if k == "trust" {
+					continue
+				}
+				// The API returns the configuration entries as interfaces
+				aux := v.(map[string]interface{})
+				// set if we find the value key and this is not a default
+				// value.
+				if value, found := aux["value"]; found {
+					conf[k] = ConfigEntry{
+						Value:     value,
+						IsDefault: aux["source"] == "default",
+					}
+				}
+			}
+			// repeat the same steps for charm config values
+			for k, v := range returnedConf.CharmConfig {
+				aux := v.(map[string]interface{})
+				if value, found := aux["value"]; found {
+					conf[k] = ConfigEntry{
+						Value:     value,
+						IsDefault: aux["source"] == "default",
+					}
+				}
+			}
+		}
+
+		// trust field which has to be included into the configuration
+		trustValue := false
+		if returnedConf.ApplicationConfig != nil {
+			aux, found := returnedConf.ApplicationConfig["trust"]
+			if found {
+				m := aux.(map[string]any)
+				target, found := m["value"]
+				if found {
+					trustValue = target.(bool)
+				}
+			}
+		}
+
+		// the expose field requires additional logic because
+		// the API returns populated cidrs by default. Additionally,
+		// we populate the unexpose field in the response structure
+		// to indicate endpoints that has to be removed by comparing
+		var exposed map[string]interface{} = nil
+		if appStatus.Exposed {
+			// rebuild
+			exposed = make(map[string]interface{}, 0)
+			endpoints := []string{}
+			spaces := ""
+			cidrs := ""
+			for epName, value := range appStatus.ExposedEndpoints {
+				if epName != "" {
+					endpoints = append(endpoints, epName)
+				}
+				if len(spaces) == 0 {
+					spaces = strings.Join(value.ExposeToSpaces, ",")
+				}
+				if len(cidrs) == 0 {
+					// by default the API sets
+					// cidrs: "0.0.0.0/0,::/0"
+					// ignore them
+					aux := removeDefaultCidrs(value.ExposeToCIDRs)
+					cidrs = strings.Join(aux, ",")
+				}
+			}
+			if len(endpoints) > 0 {
+				slices.Sort(endpoints)
+				exposed["endpoints"] = strings.Join(endpoints, ",")
+			} else {
+				exposed["endpoints"] = ""
+			}
+			exposed["spaces"] = spaces
+			exposed["cidrs"] = cidrs
+		}
+		// ParseChannel to send back a base without the risk.
+		// Having the risk will cause issues with the provider
+		// saving a different value than the user did.
+		baseChannel, err := corebase.ParseChannel(appInfo.Base.Channel)
+		if err != nil {
+			return jujuerrors.Annotate(err, "failed parse channel for base")
+		}
+
+		defaultSpace, err := getModelDefaultSpace(ctx, modelconfigAPIClient)
+		if err != nil {
+			return err
+		}
+		appDefaultSpace := appStatus.EndpointBindings[""]
+		if appDefaultSpace == "" {
+			appDefaultSpace = defaultSpace
+		}
+
+		endpointBindings := make(map[string]string)
+		if appDefaultSpace != defaultSpace {
+			endpointBindings[""] = appDefaultSpace
+		}
+		for endpoint, space := range appStatus.EndpointBindings {
+			if endpoint != "" && space != appDefaultSpace {
+				endpointBindings[endpoint] = space
+			}
+		}
+
+		resourcesAPIClient, err := c.getResourceAPIClient(conn)
+		if err != nil {
+			return err
+		}
+		resources, err := resourcesAPIClient.ListResources(ctx, []string{input.AppName})
+		if err != nil {
+			return jujuerrors.Annotate(err, "failed to list application resources")
+		}
+		usedResources := make(map[string]string)
+		for _, iResources := range resources {
+			for _, resource := range iResources.Resources {
+				// Per juju convention, -1, indicates that an integer value has not been set.
+				// Uploaded resources currently have no revision number.
+				// So when the revision number is -1, we can use the value in state.
+				if resource.Origin == charmresources.OriginUpload {
+					usedResources[resource.Name] = "-1"
+				} else {
+					usedResources[resource.Name] = strconv.Itoa(resource.Revision)
+				}
+			}
+		}
+
+		response = &ReadApplicationResponse{
+			Name:             charmURL.Name,
+			Channel:          appInfo.Channel,
+			Revision:         charmURL.Revision,
+			Base:             fmt.Sprintf("%s@%s", appInfo.Base.Name, baseChannel.Track),
+			ModelType:        modelType.String(),
+			Units:            unitCount,
+			Trust:            trustValue,
+			Expose:           exposed,
+			Config:           conf,
+			Constraints:      appInfo.Constraints,
+			Principal:        appInfo.Principal,
+			Placement:        placement,
+			Machines:         machines,
+			EndpointBindings: endpointBindings,
+			Storage:          storageDirectives,
+			Resources:        usedResources,
+		}
+
+		return nil
+	})
+	return response, err
 }
 
 func (c applicationsClient) getApplicationStatusAndStorageDirectives4(ctx context.Context, conn api.Connection, appName string) (params.ApplicationStatus, map[string]jujustorage.Directive, error) {
@@ -1009,184 +1006,180 @@ func removeDefaultCidrs(cidrs []string) []string {
 
 // UpdateApplication updates application settings, units, and resources.
 func (c applicationsClient) UpdateApplication(ctx context.Context, input *UpdateApplicationInput) error {
-	conn, err := c.GetConnection(ctx, &input.ModelUUID)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = conn.Close() }()
+	return withConnection(ctx, c.SharedClient, &input.ModelUUID, func(conn api.Connection) error {
+		applicationAPIClient := c.getApplicationAPIClient(conn)
+		charmsAPIClient := apicharms.NewClient(conn)
+		clientAPIClient := c.getClientAPIClient(conn)
+		modelconfigAPIClient := c.getModelConfigAPIClient(conn)
 
-	applicationAPIClient := c.getApplicationAPIClient(conn)
-	charmsAPIClient := apicharms.NewClient(conn)
-	clientAPIClient := c.getClientAPIClient(conn)
-	modelconfigAPIClient := c.getModelConfigAPIClient(conn)
-
-	resourcesAPIClient, err := c.getResourceAPIClient(conn)
-	if err != nil {
-		return err
-	}
-
-	status, err := clientAPIClient.Status(ctx, nil)
-	if err != nil {
-		return err
-	}
-	var appStatus params.ApplicationStatus
-	var exists bool
-	if appStatus, exists = status.Applications[input.AppName]; !exists {
-		return fmt.Errorf("no status returned for application: %s", input.AppName)
-	}
-
-	// process configuration
-	var auxConfig map[string]string
-	if input.Config != nil {
-		auxConfig = make(map[string]string)
-		for k, v := range input.Config {
-			auxConfig[k] = ConfigEntryToString(v)
-		}
-	}
-
-	// trust goes inside the config
-	if input.Trust != nil {
-		if auxConfig == nil {
-			auxConfig = make(map[string]string)
-		}
-		auxConfig["trust"] = fmt.Sprintf("%v", *input.Trust)
-	}
-
-	err = c.UpdateCharmAndResources(ctx, input, applicationAPIClient, charmsAPIClient, resourcesAPIClient)
-	if err != nil {
-		c.Errorf(err, "updating charm and resources")
-		return err
-	}
-
-	if auxConfig != nil {
-		err := applicationAPIClient.SetConfig(ctx, input.AppName, "", auxConfig)
+		resourcesAPIClient, err := c.getResourceAPIClient(conn)
 		if err != nil {
-			c.Errorf(err, "setting configuration params")
 			return err
 		}
-	}
 
-	if len(input.UnsetConfig) > 0 {
-		// unset config keys one by one, so we can swallow the `unknown option` error,
-		// which means the key was set in the state but is no longer valid (e.g. removed in a new charm revision).
-		// We don't want to fail the whole update.
-		for _, key := range input.UnsetConfig {
-			if err := applicationAPIClient.UnsetApplicationConfig(ctx, input.AppName, []string{key}); err != nil {
-				if strings.Contains(err.Error(), "unknown option") {
-					continue
-				}
+		status, err := clientAPIClient.Status(ctx, nil)
+		if err != nil {
+			return err
+		}
+		var appStatus params.ApplicationStatus
+		var exists bool
+		if appStatus, exists = status.Applications[input.AppName]; !exists {
+			return fmt.Errorf("no status returned for application: %s", input.AppName)
+		}
+
+		// process configuration
+		var auxConfig map[string]string
+		if input.Config != nil {
+			auxConfig = make(map[string]string)
+			for k, v := range input.Config {
+				auxConfig[k] = ConfigEntryToString(v)
+			}
+		}
+
+		// trust goes inside the config
+		if input.Trust != nil {
+			if auxConfig == nil {
+				auxConfig = make(map[string]string)
+			}
+			auxConfig["trust"] = fmt.Sprintf("%v", *input.Trust)
+		}
+
+		err = c.UpdateCharmAndResources(ctx, input, applicationAPIClient, charmsAPIClient, resourcesAPIClient)
+		if err != nil {
+			c.Errorf(err, "updating charm and resources")
+			return err
+		}
+
+		if auxConfig != nil {
+			err := applicationAPIClient.SetConfig(ctx, input.AppName, "", auxConfig)
+			if err != nil {
+				c.Errorf(err, "setting configuration params")
 				return err
 			}
 		}
-	}
 
-	if len(input.EndpointBindings) > 0 {
-		modelDefaultSpace, err := getModelDefaultSpace(ctx, modelconfigAPIClient)
-		if err != nil {
-			return err
+		if len(input.UnsetConfig) > 0 {
+			// unset config keys one by one, so we can swallow the `unknown option` error,
+			// which means the key was set in the state but is no longer valid (e.g. removed in a new charm revision).
+			// We don't want to fail the whole update.
+			for _, key := range input.UnsetConfig {
+				if err := applicationAPIClient.UnsetApplicationConfig(ctx, input.AppName, []string{key}); err != nil {
+					if strings.Contains(err.Error(), "unknown option") {
+						continue
+					}
+					return err
+				}
+			}
 		}
-		endpointBindingsParams, err := computeUpdatedBindings(modelDefaultSpace, appStatus.EndpointBindings, input.EndpointBindings, input.AppName)
-		if err != nil {
-			return err
-		}
-		err = applicationAPIClient.MergeBindings(ctx, endpointBindingsParams)
-		if err != nil {
-			c.Errorf(err, "setting endpoint bindings")
-			return err
-		}
-	}
 
-	// unexpose corresponding endpoints
-	if len(input.Unexpose) != 0 {
-		c.Tracef("Unexposing endpoints", map[string]interface{}{"endpoints": input.Unexpose})
-		if err := applicationAPIClient.Unexpose(ctx, input.AppName, input.Unexpose); err != nil {
-			c.Errorf(err, "when trying to unexpose")
-			return err
-		}
-	}
-	// expose endpoints if required
-	if input.Expose != nil {
-		c.Tracef("Expose endpoints", map[string]interface{}{"endpoints": input.Unexpose})
-		err := c.processExpose(ctx, applicationAPIClient, input.AppName, input.Expose)
-		if err != nil {
-			c.Errorf(err, "when trying to expose")
-			return err
-		}
-	}
-
-	if input.Constraints != nil {
-		err := applicationAPIClient.SetConstraints(ctx, input.AppName, *input.Constraints)
-		if err != nil {
-			c.Errorf(err, "setting application constraints")
-			return err
-		}
-	}
-
-	// TODO: Refactor this to a separate function
-	modelType, err := c.ModelType(ctx, input.ModelUUID)
-	if err != nil {
-		return err
-	}
-	if input.Units != nil {
-		if modelType == model.CAAS {
-			_, err := applicationAPIClient.ScaleApplication(ctx, apiapplication.ScaleApplicationParams{
-				ApplicationName: input.AppName,
-				Scale:           *input.Units,
-				Force:           false,
-			})
+		if len(input.EndpointBindings) > 0 {
+			modelDefaultSpace, err := getModelDefaultSpace(ctx, modelconfigAPIClient)
 			if err != nil {
 				return err
 			}
-		} else {
-			unitDiff := *input.Units - len(appStatus.Units)
+			endpointBindingsParams, err := computeUpdatedBindings(modelDefaultSpace, appStatus.EndpointBindings, input.EndpointBindings, input.AppName)
+			if err != nil {
+				return err
+			}
+			err = applicationAPIClient.MergeBindings(ctx, endpointBindingsParams)
+			if err != nil {
+				c.Errorf(err, "setting endpoint bindings")
+				return err
+			}
+		}
 
-			if unitDiff > 0 {
-				_, err := applicationAPIClient.AddUnits(
-					ctx,
-					apiapplication.AddUnitsParams{
-						ApplicationName: input.AppName,
-						NumUnits:        unitDiff,
-					})
+		// unexpose corresponding endpoints
+		if len(input.Unexpose) != 0 {
+			c.Tracef("Unexposing endpoints", map[string]interface{}{"endpoints": input.Unexpose})
+			if err := applicationAPIClient.Unexpose(ctx, input.AppName, input.Unexpose); err != nil {
+				c.Errorf(err, "when trying to unexpose")
+				return err
+			}
+		}
+		// expose endpoints if required
+		if input.Expose != nil {
+			c.Tracef("Expose endpoints", map[string]interface{}{"endpoints": input.Unexpose})
+			err := c.processExpose(ctx, applicationAPIClient, input.AppName, input.Expose)
+			if err != nil {
+				c.Errorf(err, "when trying to expose")
+				return err
+			}
+		}
+
+		if input.Constraints != nil {
+			err := applicationAPIClient.SetConstraints(ctx, input.AppName, *input.Constraints)
+			if err != nil {
+				c.Errorf(err, "setting application constraints")
+				return err
+			}
+		}
+
+		// TODO: Refactor this to a separate function
+		modelType, err := c.ModelType(ctx, input.ModelUUID)
+		if err != nil {
+			return err
+		}
+		if input.Units != nil {
+			if modelType == model.CAAS {
+				_, err := applicationAPIClient.ScaleApplication(ctx, apiapplication.ScaleApplicationParams{
+					ApplicationName: input.AppName,
+					Scale:           *input.Units,
+					Force:           false,
+				})
 				if err != nil {
 					return err
 				}
+			} else {
+				unitDiff := *input.Units - len(appStatus.Units)
+
+				if unitDiff > 0 {
+					_, err := applicationAPIClient.AddUnits(
+						ctx,
+						apiapplication.AddUnitsParams{
+							ApplicationName: input.AppName,
+							NumUnits:        unitDiff,
+						})
+					if err != nil {
+						return err
+					}
+				}
+
+				if unitDiff < 0 {
+					var unitNames []string
+					for unitName := range appStatus.Units {
+						unitNames = append(unitNames, unitName)
+					}
+
+					unitAbs := int(math.Abs(float64(unitDiff)))
+					var unitsToDestroy []string
+					for i := 0; i < unitAbs; i++ {
+						unitsToDestroy = append(unitsToDestroy, unitNames[i])
+					}
+					_, err := applicationAPIClient.DestroyUnits(
+						ctx,
+						apiapplication.DestroyUnitsParams{
+							Units:          unitsToDestroy,
+							DestroyStorage: true,
+						})
+					if err != nil {
+						return err
+					}
+				}
 			}
+		}
 
-			if unitDiff < 0 {
-				var unitNames []string
-				for unitName := range appStatus.Units {
-					unitNames = append(unitNames, unitName)
-				}
-
-				unitAbs := int(math.Abs(float64(unitDiff)))
-				var unitsToDestroy []string
-				for i := 0; i < unitAbs; i++ {
-					unitsToDestroy = append(unitsToDestroy, unitNames[i])
-				}
-				_, err := applicationAPIClient.DestroyUnits(
-					ctx,
-					apiapplication.DestroyUnitsParams{
-						Units:          unitsToDestroy,
-						DestroyStorage: true,
-					})
-				if err != nil {
-					return err
-				}
+		// for IAAS model we process additions/removals of units
+		if modelType == model.IAAS {
+			if err = c.addUnits(ctx, input, applicationAPIClient); err != nil {
+				return err
+			}
+			if err = c.removeUnits(ctx, input, applicationAPIClient, appStatus); err != nil {
+				return err
 			}
 		}
-	}
 
-	// for IAAS model we process additions/removals of units
-	if modelType == model.IAAS {
-		if err = c.addUnits(ctx, input, applicationAPIClient); err != nil {
-			return err
-		}
-		if err = c.removeUnits(ctx, input, applicationAPIClient, appStatus); err != nil {
-			return err
-		}
-	}
-
-	return nil
+		return nil
+	})
 }
 
 func (c applicationsClient) addUnits(ctx context.Context, input *UpdateApplicationInput, client ApplicationAPIClient) error {
@@ -1250,37 +1243,33 @@ type RemoveUnitsFromMachineInput struct {
 // This should be called before destroying a machine to ensure Juju can
 // cleanly remove it (Juju rejects machine destruction while units remain).
 func (c applicationsClient) RemoveUnitsFromMachine(ctx context.Context, input *RemoveUnitsFromMachineInput) error {
-	conn, err := c.GetConnection(ctx, &input.ModelUUID)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = conn.Close() }()
+	return withConnection(ctx, c.SharedClient, &input.ModelUUID, func(conn api.Connection) error {
+		clientAPIClient := c.getClientAPIClient(conn)
+		status, err := clientAPIClient.Status(ctx, nil)
+		if err != nil {
+			return err
+		}
 
-	clientAPIClient := c.getClientAPIClient(conn)
-	status, err := clientAPIClient.Status(ctx, nil)
-	if err != nil {
-		return err
-	}
-
-	var unitsToDestroy []string
-	for _, appStatus := range status.Applications {
-		for unitName, unitStatus := range appStatus.Units {
-			if unitStatus.Machine == input.MachineID {
-				unitsToDestroy = append(unitsToDestroy, unitName)
+		var unitsToDestroy []string
+		for _, appStatus := range status.Applications {
+			for unitName, unitStatus := range appStatus.Units {
+				if unitStatus.Machine == input.MachineID {
+					unitsToDestroy = append(unitsToDestroy, unitName)
+				}
 			}
 		}
-	}
 
-	if len(unitsToDestroy) == 0 {
-		return nil
-	}
+		if len(unitsToDestroy) == 0 {
+			return nil
+		}
 
-	applicationAPIClient := c.getApplicationAPIClient(conn)
-	_, err = applicationAPIClient.DestroyUnits(ctx, apiapplication.DestroyUnitsParams{
-		Units:          unitsToDestroy,
-		DestroyStorage: true,
+		applicationAPIClient := c.getApplicationAPIClient(conn)
+		_, err = applicationAPIClient.DestroyUnits(ctx, apiapplication.DestroyUnitsParams{
+			Units:          unitsToDestroy,
+			DestroyStorage: true,
+		})
+		return err
 	})
-	return err
 }
 
 // UpdateCharmAndResources is a helper function to update the charm and resources
@@ -1355,28 +1344,24 @@ func (c applicationsClient) UpdateCharmAndResources(
 
 // DestroyApplication removes an application from the specified model.
 func (c applicationsClient) DestroyApplication(ctx context.Context, input *DestroyApplicationInput) error {
-	conn, err := c.GetConnection(ctx, &input.ModelUUID)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = conn.Close() }()
+	return withConnection(ctx, c.SharedClient, &input.ModelUUID, func(conn api.Connection) error {
+		applicationAPIClient := apiapplication.NewClient(conn)
 
-	applicationAPIClient := apiapplication.NewClient(conn)
+		var destroyParams = apiapplication.DestroyApplicationsParams{
+			Applications: []string{
+				input.ApplicationName,
+			},
+			DestroyStorage: true,
+		}
 
-	var destroyParams = apiapplication.DestroyApplicationsParams{
-		Applications: []string{
-			input.ApplicationName,
-		},
-		DestroyStorage: true,
-	}
+		_, err := applicationAPIClient.DestroyApplications(ctx, destroyParams)
 
-	_, err = applicationAPIClient.DestroyApplications(ctx, destroyParams)
+		if err != nil {
+			return err
+		}
 
-	if err != nil {
-		return err
-	}
-
-	return nil
+		return nil
+	})
 }
 
 // computeCharmID populates the corresponding CharmID struct

--- a/internal/juju/client.go
+++ b/internal/juju/client.go
@@ -206,16 +206,16 @@ func NewClient(ctx context.Context, config ControllerConfiguration, waitForResou
 
 // GetControllerVersion returns the version of the controller that the client is connected to.
 func (sc *sharedClient) GetControllerVersion(ctx context.Context) (semversion.Number, error) {
-	conn, err := sc.GetConnection(ctx, nil)
-	if err != nil {
-		return semversion.Number{}, err
-	}
-	defer func() { _ = conn.Close() }()
-	v, ok := conn.ServerVersion()
-	if !ok {
-		return semversion.Number{}, errors.New("failed to get controller version")
-	}
-	return v, nil
+	var version semversion.Number
+	err := withConnection(ctx, sc, nil, func(conn api.Connection) error {
+		v, ok := conn.ServerVersion()
+		if !ok {
+			return errors.New("failed to get controller version")
+		}
+		version = v
+		return nil
+	})
+	return version, err
 }
 
 // SetProxy sets the default HTTP transport to use the proxy configuration detected by the juju proxyutils package.
@@ -242,17 +242,15 @@ func SetProxy() error {
 func (sc *sharedClient) IsJAAS(ctx context.Context, defaultVal bool) bool {
 	sc.checkJAASOnce.Do(func() {
 		sc.isJAAS = defaultVal
-		conn, err := sc.GetConnection(ctx, nil)
-		if err != nil {
-			return
-		}
-		defer conn.Close()
-		jc := jaasApi.NewClient(JaasConnShim{conn})
-		_, err = jc.ListControllers()
-		if err == nil {
-			sc.isJAAS = true
-			return
-		}
+		// A failure to connect leaves isJAAS at defaultVal; the error is
+		// intentionally ignored as callers must not fail on this check.
+		_ = withConnection(ctx, sc, nil, func(conn api.Connection) error {
+			jc := jaasApi.NewClient(JaasConnShim{conn})
+			if _, err := jc.ListControllers(); err == nil {
+				sc.isJAAS = true
+			}
+			return nil
+		})
 	})
 	return sc.isJAAS
 }
@@ -345,6 +343,26 @@ func (sc *sharedClient) GetConnection(ctx context.Context, modelUUID *string) (a
 	return conn, nil
 }
 
+// withConnection opens a connection to the controller (optionally scoped to the
+// given model), passes it to f, and guarantees the connection is closed once f
+// returns. Unlike the open-coded `defer conn.Close()` pattern it replaces, any
+// error returned by closing the connection is logged rather than discarded.
+//
+// Functions that need to return a value should declare it in the enclosing
+// scope and assign it from within f, returning only the error from f.
+func withConnection(ctx context.Context, sc SharedClient, modelUUID *string, f func(conn api.Connection) error) error {
+	conn, err := sc.GetConnection(ctx, modelUUID)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if cerr := conn.Close(); cerr != nil {
+			sc.Errorf(cerr, "failed to close connection")
+		}
+	}()
+	return f(conn)
+}
+
 func (sc *sharedClient) connect(ctx context.Context, conf connector.SimpleConfig) (api.Connection, error) {
 	dialOptions := func(do *api.DialOpts) {
 		//this is set as a const above, in case we need to use it elsewhere to manage connection timings
@@ -414,29 +432,25 @@ func (sc *sharedClient) ModelUUID(ctx context.Context, modelName, modelOwner str
 // models and puts the relevant data in the model info cache.
 // Callers are expected to hold the modelUUIDmu lock.
 func (sc *sharedClient) fillModelCache(ctx context.Context) error {
-	conn, err := sc.GetConnection(ctx, nil)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = conn.Close() }()
+	return withConnection(ctx, sc, nil, func(conn api.Connection) error {
+		client := modelmanager.NewClient(conn)
 
-	client := modelmanager.NewClient(conn)
-
-	// Calling ListModelSummaries because other Model endpoints require
-	// the UUID, here we're trying to get the model UUID for other calls.
-	modelSummaries, err := client.ListModelSummaries(ctx, conn.AuthTag().Id(), false)
-	if err != nil {
-		return err
-	}
-	for _, modelSummary := range modelSummaries {
-		modelWithUUID := jujuModel{
-			name:      modelSummary.Name,
-			modelType: modelSummary.Type,
-			owner:     modelSummary.Qualifier.String(),
+		// Calling ListModelSummaries because other Model endpoints require
+		// the UUID, here we're trying to get the model UUID for other calls.
+		modelSummaries, err := client.ListModelSummaries(ctx, conn.AuthTag().Id(), false)
+		if err != nil {
+			return err
 		}
-		sc.modelUUIDcache[modelSummary.UUID] = modelWithUUID
-	}
-	return nil
+		for _, modelSummary := range modelSummaries {
+			modelWithUUID := jujuModel{
+				name:      modelSummary.Name,
+				modelType: modelSummary.Type,
+				owner:     modelSummary.Qualifier.String(),
+			}
+			sc.modelUUIDcache[modelSummary.UUID] = modelWithUUID
+		}
+		return nil
+	})
 }
 
 // ModelType returns the model type for the provided modelUUID from

--- a/internal/juju/clouds.go
+++ b/internal/juju/clouds.go
@@ -229,277 +229,255 @@ func newCloudsClient(sc SharedClient) *cloudsClient {
 // CreateKubernetesCloud creates a new Kubernetes cloud with juju cloud facade.
 // The credential name for this cloud is returned.
 func (c *cloudsClient) CreateKubernetesCloud(ctx context.Context, input *CreateKubernetesCloudInput) (string, error) {
-	conn, err := c.GetConnection(ctx, nil)
-	if err != nil {
-		return "", err
-	}
-	defer func() { _ = conn.Close() }()
+	var credentialName string
+	err := withConnection(ctx, c.SharedClient, nil, func(conn api.Connection) error {
+		k8sConf, err := createKubernetesConfig(ctx, []byte(input.KubernetesConfig), input.CreateServiceAccount)
+		if err != nil {
+			return errors.Annotate(err, "parsing kubernetes configuration data")
+		}
 
-	k8sConf, err := createKubernetesConfig(ctx, []byte(input.KubernetesConfig), input.CreateServiceAccount)
-	if err != nil {
-		return "", errors.Annotate(err, "parsing kubernetes configuration data")
-	}
+		var hostCloudRegion string
+		if input.ParentCloudName != "" || input.ParentCloudRegion != "" {
+			hostCloudRegion = input.ParentCloudName + "/" + input.ParentCloudRegion
+		} else {
+			hostCloudRegion = k8s.K8sCloudOther
+		}
+		newCloud, err := k8scloud.CloudFromKubeConfigContext(
+			k8sConf.CurrentContext,
+			k8sConf,
+			k8scloud.CloudParamaters{
+				Name:            input.Name,
+				HostCloudRegion: hostCloudRegion,
+			},
+		)
+		if err != nil {
+			return errors.Trace(err)
+		}
 
-	var hostCloudRegion string
-	if input.ParentCloudName != "" || input.ParentCloudRegion != "" {
-		hostCloudRegion = input.ParentCloudName + "/" + input.ParentCloudRegion
-	} else {
-		hostCloudRegion = k8s.K8sCloudOther
-	}
-	newCloud, err := k8scloud.CloudFromKubeConfigContext(
-		k8sConf.CurrentContext,
-		k8sConf,
-		k8scloud.CloudParamaters{
-			Name:            input.Name,
-			HostCloudRegion: hostCloudRegion,
-		},
-	)
-	if err != nil {
-		return "", errors.Trace(err)
-	}
+		// For the details of storage class skippage, see [provider.StorageClassNameMarkdownDescription].
+		if input.StorageClassName != "" {
+			newCloud.Config = make(map[string]interface{})
+			newCloud.Config[operatorStorageKey] = input.StorageClassName
+			newCloud.Config[workloadStorageKey] = input.StorageClassName
+		}
 
-	// For the details of storage class skippage, see [provider.StorageClassNameMarkdownDescription].
-	if input.StorageClassName != "" {
-		newCloud.Config = make(map[string]interface{})
-		newCloud.Config[operatorStorageKey] = input.StorageClassName
-		newCloud.Config[workloadStorageKey] = input.StorageClassName
-	}
+		cloudClient := c.getCloudAPIClient(conn)
+		err = cloudClient.AddCloud(ctx, newCloud, false)
+		if err != nil {
+			return errors.Annotate(err, "adding kubernetes cloud")
+		}
 
-	cloudClient := c.getCloudAPIClient(conn)
-	err = cloudClient.AddCloud(ctx, newCloud, false)
-	if err != nil {
-		return "", errors.Annotate(err, "adding kubernetes cloud")
-	}
+		credentialName = input.Name
+		cloudName := input.Name
 
-	credentialName := input.Name
-	cloudName := input.Name
+		currentUser := getCurrentJujuUser(conn)
 
-	currentUser := getCurrentJujuUser(conn)
+		cloudCredTag, err := GetCloudCredentialTag(cloudName, currentUser, credentialName)
+		if err != nil {
+			return errors.Annotate(err, "getting cloud credential tag")
+		}
 
-	cloudCredTag, err := GetCloudCredentialTag(cloudName, currentUser, credentialName)
-	if err != nil {
-		return "", errors.Annotate(err, "getting cloud credential tag")
-	}
+		newCredential, err := k8scloud.CredentialFromKubeConfigContext(k8sConf.CurrentContext, k8sConf)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		err = cloudClient.AddCredential(ctx, cloudCredTag.String(), newCredential)
+		if err != nil {
+			return errors.Annotate(err, "adding kubernetes cloud credential")
+		}
 
-	newCredential, err := k8scloud.CredentialFromKubeConfigContext(k8sConf.CurrentContext, k8sConf)
-	if err != nil {
-		return "", errors.Trace(err)
-	}
-	err = cloudClient.AddCredential(ctx, cloudCredTag.String(), newCredential)
-	if err != nil {
-		return "", errors.Annotate(err, "adding kubernetes cloud credential")
-	}
-
-	return credentialName, nil
+		return nil
+	})
+	return credentialName, err
 }
 
 // ReadKubernetesCloud reads a Kubernetes cloud with juju cloud facade.
 func (c *cloudsClient) ReadKubernetesCloud(ctx context.Context, input ReadKubernetesCloudInput) (*ReadKubernetesCloudOutput, error) {
-	conn, err := c.GetConnection(ctx, nil)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = conn.Close() }()
+	var out *ReadKubernetesCloudOutput
+	err := withConnection(ctx, c.SharedClient, nil, func(conn api.Connection) error {
+		cloudClient := c.getCloudAPIClient(conn)
 
-	cloudClient := c.getCloudAPIClient(conn)
+		cld, err := cloudClient.Cloud(ctx, names.NewCloudTag(input.Name))
+		if err != nil {
+			return errors.Annotate(err, "getting clouds")
+		}
 
-	cld, err := cloudClient.Cloud(ctx, names.NewCloudTag(input.Name))
-	if err != nil {
-		return nil, errors.Annotate(err, "getting clouds")
-	}
+		userName := getCurrentJujuUser(conn)
 
-	userName := getCurrentJujuUser(conn)
+		cloudCredentialTags, err := cloudClient.UserCredentials(ctx, names.NewUserTag(userName), names.NewCloudTag(input.Name))
+		if err != nil {
+			return errors.Annotate(err, "getting user credentials")
+		}
+		if len(cloudCredentialTags) == 0 {
+			return errors.NotFoundf("cloud credentials for user %q", userName)
+		}
 
-	cloudCredentialTags, err := cloudClient.UserCredentials(ctx, names.NewUserTag(userName), names.NewCloudTag(input.Name))
-	if err != nil {
-		return nil, errors.Annotate(err, "getting user credentials")
-	}
-	if len(cloudCredentialTags) == 0 {
-		return nil, errors.NotFoundf("cloud credentials for user %q", userName)
-	}
+		credentialName := cloudCredentialTags[0].Name()
 
-	credentialName := cloudCredentialTags[0].Name()
-
-	parentCloudName, parentCloudRegion := getParentCloudNameAndRegion(cld.HostCloudRegion)
-	return &ReadKubernetesCloudOutput{
-		Name:              input.Name,
-		CredentialName:    credentialName,
-		ParentCloudName:   parentCloudName,
-		ParentCloudRegion: parentCloudRegion,
-	}, nil
+		parentCloudName, parentCloudRegion := getParentCloudNameAndRegion(cld.HostCloudRegion)
+		out = &ReadKubernetesCloudOutput{
+			Name:              input.Name,
+			CredentialName:    credentialName,
+			ParentCloudName:   parentCloudName,
+			ParentCloudRegion: parentCloudRegion,
+		}
+		return nil
+	})
+	return out, err
 }
 
 // UpdateKubernetesCloud updates a Kubernetes cloud with juju cloud facade.
 func (c *cloudsClient) UpdateKubernetesCloud(ctx context.Context, input UpdateKubernetesCloudInput) error {
-	conn, err := c.GetConnection(ctx, nil)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = conn.Close() }()
+	return withConnection(ctx, c.SharedClient, nil, func(conn api.Connection) error {
+		cloudClient := c.getCloudAPIClient(conn)
+		k8sConf, err := createKubernetesConfig(ctx, []byte(input.KubernetesConfig), input.CreateServiceAccount)
+		if err != nil {
+			return errors.Annotate(err, "parsing kubernetes configuration data")
+		}
 
-	cloudClient := c.getCloudAPIClient(conn)
-	k8sConf, err := createKubernetesConfig(ctx, []byte(input.KubernetesConfig), input.CreateServiceAccount)
-	if err != nil {
-		return errors.Annotate(err, "parsing kubernetes configuration data")
-	}
+		var hostCloudRegion string
+		if input.ParentCloudName != "" || input.ParentCloudRegion != "" {
+			hostCloudRegion = input.ParentCloudName + "/" + input.ParentCloudRegion
+		} else {
+			hostCloudRegion = k8s.K8sCloudOther
+		}
 
-	var hostCloudRegion string
-	if input.ParentCloudName != "" || input.ParentCloudRegion != "" {
-		hostCloudRegion = input.ParentCloudName + "/" + input.ParentCloudRegion
-	} else {
-		hostCloudRegion = k8s.K8sCloudOther
-	}
+		newCloud, err := k8scloud.CloudFromKubeConfigContext(
+			k8sConf.CurrentContext,
+			k8sConf,
+			k8scloud.CloudParamaters{
+				Name:            input.Name,
+				HostCloudRegion: hostCloudRegion,
+			},
+		)
+		if err != nil {
+			return errors.Trace(err)
+		}
 
-	newCloud, err := k8scloud.CloudFromKubeConfigContext(
-		k8sConf.CurrentContext,
-		k8sConf,
-		k8scloud.CloudParamaters{
-			Name:            input.Name,
-			HostCloudRegion: hostCloudRegion,
-		},
-	)
-	if err != nil {
-		return errors.Trace(err)
-	}
+		err = cloudClient.UpdateCloud(ctx, newCloud)
+		if err != nil {
+			return errors.Annotate(err, "updating kubernetes cloud")
+		}
 
-	err = cloudClient.UpdateCloud(ctx, newCloud)
-	if err != nil {
-		return errors.Annotate(err, "updating kubernetes cloud")
-	}
-
-	return nil
+		return nil
+	})
 }
 
 // AddCloud adds a cloud definition to the controller.
 func (c *cloudsClient) AddCloud(ctx context.Context, input AddCloudInput) error {
-	conn, err := c.GetConnection(ctx, nil)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = conn.Close() }()
+	return withConnection(ctx, c.SharedClient, nil, func(conn api.Connection) error {
+		cloudClient := c.getCloudAPIClient(conn)
 
-	cloudClient := c.getCloudAPIClient(conn)
+		// All clouds must have at least one default region - lp#1819409.
+		if len(input.Regions) == 0 {
+			input.Regions = []jujucloud.Region{{Name: jujucloud.DefaultCloudRegion}}
+		}
 
-	// All clouds must have at least one default region - lp#1819409.
-	if len(input.Regions) == 0 {
-		input.Regions = []jujucloud.Region{{Name: jujucloud.DefaultCloudRegion}}
-	}
+		cloud := jujucloud.Cloud{
+			Name:              input.Name,
+			Type:              input.Type,
+			Description:       input.Description,
+			AuthTypes:         input.AuthTypes,
+			Endpoint:          input.Endpoint,
+			IdentityEndpoint:  input.IdentityEndpoint,
+			StorageEndpoint:   input.StorageEndpoint,
+			Regions:           input.Regions,
+			CACertificates:    encodeB64Certs(input.CACertificates),
+			SkipTLSVerify:     false,
+			IsControllerCloud: false,
+		}
 
-	cloud := jujucloud.Cloud{
-		Name:              input.Name,
-		Type:              input.Type,
-		Description:       input.Description,
-		AuthTypes:         input.AuthTypes,
-		Endpoint:          input.Endpoint,
-		IdentityEndpoint:  input.IdentityEndpoint,
-		StorageEndpoint:   input.StorageEndpoint,
-		Regions:           input.Regions,
-		CACertificates:    encodeB64Certs(input.CACertificates),
-		SkipTLSVerify:     false,
-		IsControllerCloud: false,
-	}
-
-	return cloudClient.AddCloud(ctx, cloud, input.Force)
+		return cloudClient.AddCloud(ctx, cloud, input.Force)
+	})
 }
 
 // UpdateCloud updates a cloud definition on the controller.
 func (c *cloudsClient) UpdateCloud(ctx context.Context, input UpdateCloudInput) error {
-	conn, err := c.GetConnection(ctx, nil)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = conn.Close() }()
+	return withConnection(ctx, c.SharedClient, nil, func(conn api.Connection) error {
+		cloudClient := c.getCloudAPIClient(conn)
 
-	cloudClient := c.getCloudAPIClient(conn)
+		cloud := jujucloud.Cloud{
+			Name:              input.Name,
+			Type:              input.Type,
+			Description:       input.Description,
+			AuthTypes:         input.AuthTypes,
+			Endpoint:          input.Endpoint,
+			IdentityEndpoint:  input.IdentityEndpoint,
+			StorageEndpoint:   input.StorageEndpoint,
+			Regions:           input.Regions,
+			CACertificates:    encodeB64Certs(input.CACertificates),
+			SkipTLSVerify:     false,
+			IsControllerCloud: false,
+		}
 
-	cloud := jujucloud.Cloud{
-		Name:              input.Name,
-		Type:              input.Type,
-		Description:       input.Description,
-		AuthTypes:         input.AuthTypes,
-		Endpoint:          input.Endpoint,
-		IdentityEndpoint:  input.IdentityEndpoint,
-		StorageEndpoint:   input.StorageEndpoint,
-		Regions:           input.Regions,
-		CACertificates:    encodeB64Certs(input.CACertificates),
-		SkipTLSVerify:     false,
-		IsControllerCloud: false,
-	}
-
-	return cloudClient.UpdateCloud(ctx, cloud)
+		return cloudClient.UpdateCloud(ctx, cloud)
+	})
 }
 
 // RemoveCloud removes a cloud.
 func (c *cloudsClient) RemoveCloud(ctx context.Context, input RemoveCloudInput) error {
-	conn, err := c.GetConnection(ctx, nil)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = conn.Close() }()
+	return withConnection(ctx, c.SharedClient, nil, func(conn api.Connection) error {
+		cloudClient := c.getCloudAPIClient(conn)
 
-	cloudClient := c.getCloudAPIClient(conn)
-
-	return cloudClient.RemoveCloud(ctx, input.Name)
+		return cloudClient.RemoveCloud(ctx, input.Name)
+	})
 }
 
 // ReadCloud reads a cloud.
 func (c *cloudsClient) ReadCloud(ctx context.Context, input ReadCloudInput) (*ReadCloudOutput, error) {
-	conn, err := c.GetConnection(ctx, nil)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = conn.Close() }()
+	var out *ReadCloudOutput
+	err := withConnection(ctx, c.SharedClient, nil, func(conn api.Connection) error {
+		cloudClient := c.getCloudAPIClient(conn)
 
-	cloudClient := c.getCloudAPIClient(conn)
+		jjCloud, err := cloudClient.Cloud(ctx, names.NewCloudTag(input.Name))
+		if errors.Is(err, errors.NotFound) {
+			return CloudNotFoundError
+		}
 
-	jjCloud, err := cloudClient.Cloud(ctx, names.NewCloudTag(input.Name))
-	if errors.Is(err, errors.NotFound) {
-		return nil, CloudNotFoundError
-	}
+		if err != nil {
+			return errors.Annotate(err, "getting cloud")
+		}
 
-	if err != nil {
-		return nil, errors.Annotate(err, "getting cloud")
-	}
+		decodedCACertificates, decodedCACertificatesErr := decodeB64Certs(jjCloud.CACertificates)
+		if decodedCACertificatesErr != nil {
+			return errors.Annotate(decodedCACertificatesErr, "decoding cloud CA certificates")
+		}
 
-	decodedCACertificates, decodedCACertificatesErr := decodeB64Certs(jjCloud.CACertificates)
-	if decodedCACertificatesErr != nil {
-		return nil, errors.Annotate(decodedCACertificatesErr, "decoding cloud CA certificates")
-	}
-
-	return &ReadCloudOutput{
-		Name:             jjCloud.Name,
-		Type:             jjCloud.Type,
-		Description:      jjCloud.Description,
-		AuthTypes:        jjCloud.AuthTypes,
-		Endpoint:         jjCloud.Endpoint,
-		IdentityEndpoint: jjCloud.IdentityEndpoint,
-		StorageEndpoint:  jjCloud.StorageEndpoint,
-		Regions:          jjCloud.Regions,
-		CACertificates:   decodedCACertificates,
-	}, nil
+		out = &ReadCloudOutput{
+			Name:             jjCloud.Name,
+			Type:             jjCloud.Type,
+			Description:      jjCloud.Description,
+			AuthTypes:        jjCloud.AuthTypes,
+			Endpoint:         jjCloud.Endpoint,
+			IdentityEndpoint: jjCloud.IdentityEndpoint,
+			StorageEndpoint:  jjCloud.StorageEndpoint,
+			Regions:          jjCloud.Regions,
+			CACertificates:   decodedCACertificates,
+		}
+		return nil
+	})
+	return out, err
 }
 
 // ListClouds returns the names of all clouds available on the controller.
 func (c *cloudsClient) ListClouds(ctx context.Context) ([]string, error) {
-	conn, err := c.GetConnection(ctx, nil)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = conn.Close() }()
+	var clouds []string
+	err := withConnection(ctx, c.SharedClient, nil, func(conn api.Connection) error {
+		cloudClient := c.getCloudAPIClient(conn)
 
-	cloudClient := c.getCloudAPIClient(conn)
+		jjClouds, err := cloudClient.Clouds(ctx)
+		if err != nil {
+			return errors.Annotate(err, "getting clouds")
+		}
 
-	jjClouds, err := cloudClient.Clouds(ctx)
-	if err != nil {
-		return nil, errors.Annotate(err, "getting clouds")
-	}
+		clouds = make([]string, 0, len(jjClouds))
+		for cloudTag := range jjClouds {
+			clouds = append(clouds, cloudTag.Id())
+		}
 
-	clouds := make([]string, 0, len(jjClouds))
-	for cloudTag := range jjClouds {
-		clouds = append(clouds, cloudTag.Id())
-	}
-
-	return clouds, nil
+		return nil
+	})
+	return clouds, err
 }
 
 // createKubernetesConfig creates a Kubernetes configuration from the provided config data.

--- a/internal/juju/credentials.go
+++ b/internal/juju/credentials.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/juju/errors"
+	"github.com/juju/juju/api"
 	cloudapi "github.com/juju/juju/api/client/cloud"
 	"github.com/juju/juju/api/jujuclient"
 	jujucloud "github.com/juju/juju/cloud"
@@ -100,25 +101,21 @@ func supportedAuth(cloud jujucloud.Cloud, authTypeReceived string) bool {
 
 // ValidateCredentialForCloud checks whether the cloud supports the given auth type.
 func (c *credentialsClient) ValidateCredentialForCloud(ctx context.Context, cloudName, authTypeReceived string) error {
-	conn, err := c.GetConnection(ctx, nil)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = conn.Close() }()
+	return withConnection(ctx, c.SharedClient, nil, func(conn api.Connection) error {
+		client := cloudapi.NewClient(conn)
 
-	client := cloudapi.NewClient(conn)
+		cloudTag := names.NewCloudTag(cloudName)
 
-	cloudTag := names.NewCloudTag(cloudName)
+		cloud, err := client.Cloud(ctx, cloudTag)
+		if err != nil {
+			return err
+		}
 
-	cloud, err := client.Cloud(ctx, cloudTag)
-	if err != nil {
-		return err
-	}
-
-	if !supportedAuth(cloud, authTypeReceived) {
-		return errors.NotSupportedf("supported auth-types %q, %q", cloud.AuthTypes, authTypeReceived)
-	}
-	return nil
+		if !supportedAuth(cloud, authTypeReceived) {
+			return errors.NotSupportedf("supported auth-types %q, %q", cloud.AuthTypes, authTypeReceived)
+		}
+		return nil
+	})
 }
 
 // CreateCredential creates a credential in the controller and/or client store.
@@ -139,41 +136,40 @@ func (c *credentialsClient) CreateCredential(ctx context.Context, input CreateCr
 		return nil, err
 	}
 
-	conn, err := c.GetConnection(ctx, nil)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = conn.Close() }()
+	var out *CreateCredentialResponse
+	err := withConnection(ctx, c.SharedClient, nil, func(conn api.Connection) error {
+		client := cloudapi.NewClient(conn)
 
-	client := cloudapi.NewClient(conn)
+		currentUser := getCurrentJujuUser(conn)
 
-	currentUser := getCurrentJujuUser(conn)
-
-	cloudCredTag, err := GetCloudCredentialTag(cloudName, currentUser, credentialName)
-	if err != nil {
-		return nil, err
-	}
-
-	cloudCredential := jujucloud.NewNamedCredential(
-		credentialName,
-		jujucloud.AuthType(input.AuthType),
-		input.Attributes,
-		false,
-	)
-
-	if input.ClientCredential {
-		if err := updateClientCredential(cloudName, credentialName, cloudCredential); err != nil {
-			return nil, err
+		cloudCredTag, err := GetCloudCredentialTag(cloudName, currentUser, credentialName)
+		if err != nil {
+			return err
 		}
-	}
 
-	if input.ControllerCredential {
-		if err := client.AddCredential(ctx, cloudCredTag.String(), cloudCredential); err != nil {
-			return nil, err
+		cloudCredential := jujucloud.NewNamedCredential(
+			credentialName,
+			jujucloud.AuthType(input.AuthType),
+			input.Attributes,
+			false,
+		)
+
+		if input.ClientCredential {
+			if err := updateClientCredential(cloudName, credentialName, cloudCredential); err != nil {
+				return err
+			}
 		}
-	}
 
-	return &CreateCredentialResponse{CloudCredential: cloudCredential, CloudName: cloudName}, nil
+		if input.ControllerCredential {
+			if err := client.AddCredential(ctx, cloudCredTag.String(), cloudCredential); err != nil {
+				return err
+			}
+		}
+
+		out = &CreateCredentialResponse{CloudCredential: cloudCredential, CloudName: cloudName}
+		return nil
+	})
+	return out, err
 }
 
 // ListClientCredentials lists all credentials on the client.
@@ -189,36 +185,35 @@ func (c *credentialsClient) ListClientCredentials(ctx context.Context) (*ListCre
 
 // ListControllerCredentials lists all credentials on the controller.
 func (c *credentialsClient) ListControllerCredentials(ctx context.Context) (*ListCredentialResponse, error) {
-	conn, err := c.GetConnection(ctx, nil)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = conn.Close() }()
+	var out *ListCredentialResponse
+	err := withConnection(ctx, c.SharedClient, nil, func(conn api.Connection) error {
+		client := cloudapi.NewClient(conn)
 
-	client := cloudapi.NewClient(conn)
-
-	controllerCredentialFound := map[string]jujucloud.CloudCredential{}
-	credentialContents, err := client.CredentialContents(ctx, "", "", true)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, one := range credentialContents {
-		remoteCredential := one.Result.Content
-		cloudCredential, ok := controllerCredentialFound[remoteCredential.Cloud]
-		if !ok {
-			cloudCredential = jujucloud.CloudCredential{}
+		controllerCredentialFound := map[string]jujucloud.CloudCredential{}
+		credentialContents, err := client.CredentialContents(ctx, "", "", true)
+		if err != nil {
+			return err
 		}
-		if cloudCredential.AuthCredentials == nil {
-			cloudCredential.AuthCredentials = map[string]jujucloud.Credential{}
-		}
-		cloudCredential.AuthCredentials[remoteCredential.Name] = jujucloud.NewCredential(jujucloud.AuthType(remoteCredential.AuthType), remoteCredential.Attributes)
-		controllerCredentialFound[remoteCredential.Cloud] = cloudCredential
-	}
 
-	return &ListCredentialResponse{
-		CloudCredentials: controllerCredentialFound,
-	}, nil
+		for _, one := range credentialContents {
+			remoteCredential := one.Result.Content
+			cloudCredential, ok := controllerCredentialFound[remoteCredential.Cloud]
+			if !ok {
+				cloudCredential = jujucloud.CloudCredential{}
+			}
+			if cloudCredential.AuthCredentials == nil {
+				cloudCredential.AuthCredentials = map[string]jujucloud.Credential{}
+			}
+			cloudCredential.AuthCredentials[remoteCredential.Name] = jujucloud.NewCredential(jujucloud.AuthType(remoteCredential.AuthType), remoteCredential.Attributes)
+			controllerCredentialFound[remoteCredential.Cloud] = cloudCredential
+		}
+
+		out = &ListCredentialResponse{
+			CloudCredentials: controllerCredentialFound,
+		}
+		return nil
+	})
+	return out, err
 }
 
 // ReadCredential reads a credential from the controller and/or client store.
@@ -228,68 +223,68 @@ func (c *credentialsClient) ReadCredential(ctx context.Context, input ReadCreden
 	controllerCredential := input.ControllerCredential
 	credentialName := input.Name
 
-	conn, err := c.GetConnection(ctx, nil)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = conn.Close() }()
+	var out *ReadCredentialResponse
+	err := withConnection(ctx, c.SharedClient, nil, func(conn api.Connection) error {
+		client := cloudapi.NewClient(conn)
 
-	client := cloudapi.NewClient(conn)
-
-	var clientCredentialFound jujucloud.Credential
-	if clientCredential {
-		existingCredentials, err := getExistingClientCredential(cloudName)
-		if err != nil {
-			return nil, err
-		}
-		clientCredentialFound = existingCredentials.AuthCredentials[credentialName]
-	}
-
-	var controllerCredentialFound jujucloud.Credential
-	if controllerCredential {
-		credentialContents, err := client.CredentialContents(ctx, cloudName, credentialName, true)
-		if err != nil {
-			return nil, err
-		}
-
-		for _, content := range credentialContents {
-			if content.Error != nil {
-				continue
+		var clientCredentialFound jujucloud.Credential
+		if clientCredential {
+			existingCredentials, err := getExistingClientCredential(cloudName)
+			if err != nil {
+				return err
 			}
-			remoteCredential := content.Result.Content
-			if remoteCredential.Name == credentialName {
-				controllerCredentialFound = jujucloud.NewNamedCredential(
-					credentialName,
-					jujucloud.AuthType(remoteCredential.AuthType),
-					remoteCredential.Attributes,
-					false, //  CredentialContents does not provides this field
-				)
-				break
+			clientCredentialFound = existingCredentials.AuthCredentials[credentialName]
+		}
+
+		var controllerCredentialFound jujucloud.Credential
+		if controllerCredential {
+			credentialContents, err := client.CredentialContents(ctx, cloudName, credentialName, true)
+			if err != nil {
+				return err
+			}
+
+			for _, content := range credentialContents {
+				if content.Error != nil {
+					continue
+				}
+				remoteCredential := content.Result.Content
+				if remoteCredential.Name == credentialName {
+					controllerCredentialFound = jujucloud.NewNamedCredential(
+						credentialName,
+						jujucloud.AuthType(remoteCredential.AuthType),
+						remoteCredential.Attributes,
+						false, //  CredentialContents does not provides this field
+					)
+					break
+				}
 			}
 		}
-	}
 
-	if controllerCredential && clientCredential {
-		// compare if they are the same
-		// lets just check auth_type for now
-		if clientCredentialFound.AuthType() != controllerCredentialFound.AuthType() {
-			return nil, fmt.Errorf("client and controller credentials have different auth type: %s, %s", clientCredentialFound.AuthType(), controllerCredentialFound.AuthType())
+		if controllerCredential && clientCredential {
+			// compare if they are the same
+			// lets just check auth_type for now
+			if clientCredentialFound.AuthType() != controllerCredentialFound.AuthType() {
+				return fmt.Errorf("client and controller credentials have different auth type: %s, %s", clientCredentialFound.AuthType(), controllerCredentialFound.AuthType())
+			}
 		}
-	}
 
-	if controllerCredential {
-		return &ReadCredentialResponse{
-			CloudCredential: controllerCredentialFound,
-		}, nil
-	}
+		if controllerCredential {
+			out = &ReadCredentialResponse{
+				CloudCredential: controllerCredentialFound,
+			}
+			return nil
+		}
 
-	if clientCredential {
-		return &ReadCredentialResponse{
-			CloudCredential: clientCredentialFound,
-		}, nil
-	}
+		if clientCredential {
+			out = &ReadCredentialResponse{
+				CloudCredential: clientCredentialFound,
+			}
+			return nil
+		}
 
-	return nil, fmt.Errorf("credential %s not found for cloud %s", credentialName, cloudName)
+		return fmt.Errorf("credential %s not found for cloud %s", credentialName, cloudName)
+	})
+	return out, err
 }
 
 // UpdateCredential updates an existing credential.
@@ -310,41 +305,37 @@ func (c *credentialsClient) UpdateCredential(ctx context.Context, input UpdateCr
 		return err
 	}
 
-	conn, err := c.GetConnection(ctx, nil)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = conn.Close() }()
+	return withConnection(ctx, c.SharedClient, nil, func(conn api.Connection) error {
+		currentUser := getCurrentJujuUser(conn)
 
-	currentUser := getCurrentJujuUser(conn)
-
-	cloudCredTag, err := GetCloudCredentialTag(cloudName, currentUser, credentialName)
-	if err != nil {
-		return err
-	}
-
-	cloudCredential := jujucloud.NewNamedCredential(
-		input.Name,
-		jujucloud.AuthType(input.AuthType),
-		input.Attributes,
-		false,
-	)
-
-	if input.ClientCredential {
-		if err := updateClientCredential(cloudName, credentialName, cloudCredential); err != nil {
+		cloudCredTag, err := GetCloudCredentialTag(cloudName, currentUser, credentialName)
+		if err != nil {
 			return err
 		}
-	}
 
-	if input.ControllerCredential {
-		client := cloudapi.NewClient(conn)
+		cloudCredential := jujucloud.NewNamedCredential(
+			input.Name,
+			jujucloud.AuthType(input.AuthType),
+			input.Attributes,
+			false,
+		)
 
-		if _, err := client.UpdateCredentialsCheckModels(ctx, *cloudCredTag, cloudCredential); err != nil {
-			return err
+		if input.ClientCredential {
+			if err := updateClientCredential(cloudName, credentialName, cloudCredential); err != nil {
+				return err
+			}
 		}
-	}
 
-	return nil
+		if input.ControllerCredential {
+			client := cloudapi.NewClient(conn)
+
+			if _, err := client.UpdateCredentialsCheckModels(ctx, *cloudCredTag, cloudCredential); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
 }
 
 func getExistingClientCredentials() (map[string]jujucloud.CloudCredential, error) {
@@ -387,34 +378,30 @@ func (c *credentialsClient) DestroyCredential(ctx context.Context, input Destroy
 	cloudName := input.CloudName
 	credentialName := input.Name
 
-	conn, err := c.GetConnection(ctx, nil)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = conn.Close() }()
+	return withConnection(ctx, c.SharedClient, nil, func(conn api.Connection) error {
+		client := cloudapi.NewClient(conn)
 
-	client := cloudapi.NewClient(conn)
+		currentUser := getCurrentJujuUser(conn)
 
-	currentUser := getCurrentJujuUser(conn)
-
-	cloudCredTag, err := GetCloudCredentialTag(cloudName, currentUser, credentialName)
-	if err != nil {
-		return err
-	}
-
-	if input.ControllerCredential {
-		if err := client.RevokeCredential(ctx, *cloudCredTag, false); err != nil {
+		cloudCredTag, err := GetCloudCredentialTag(cloudName, currentUser, credentialName)
+		if err != nil {
 			return err
 		}
-	}
 
-	if input.ClientCredential {
-		if err := destroyClientCredential(cloudName, credentialName); err != nil {
-			return err
+		if input.ControllerCredential {
+			if err := client.RevokeCredential(ctx, *cloudCredTag, false); err != nil {
+				return err
+			}
 		}
-	}
 
-	return nil
+		if input.ClientCredential {
+			if err := destroyClientCredential(cloudName, credentialName); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
 }
 
 func destroyClientCredential(cloudName string, credentialName string) error {

--- a/internal/juju/integrations.go
+++ b/internal/juju/integrations.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/juju/errors"
+	"github.com/juju/juju/api"
 	apiapplication "github.com/juju/juju/api/client/application"
 	"github.com/juju/juju/rpc/params"
 )
@@ -100,164 +101,159 @@ func newIntegrationsClient(sc SharedClient) *integrationsClient {
 
 // CreateIntegration creates a new integration.
 func (c *integrationsClient) CreateIntegration(ctx context.Context, input *IntegrationInput) (*CreateIntegrationResponse, error) {
-	conn, err := c.GetConnection(ctx, &input.ModelUUID)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = conn.Close() }()
+	var out *CreateIntegrationResponse
+	err := withConnection(ctx, c.SharedClient, &input.ModelUUID, func(conn api.Connection) error {
+		client := apiapplication.NewClient(conn)
 
-	client := apiapplication.NewClient(conn)
+		// wait for the apps to be available
+		ctx, cancel := context.WithTimeout(ctx, IntegrationAppAvailableTimeout)
+		defer cancel()
 
-	// wait for the apps to be available
-	ctx, cancel := context.WithTimeout(ctx, IntegrationAppAvailableTimeout)
-	defer cancel()
+		err := WaitForAppsAvailable(ctx, client, input.Apps, IntegrationApiTickWait)
+		if err != nil {
+			return errors.Annotate(err, "the applications were not available to be integrated")
+		}
 
-	err = WaitForAppsAvailable(ctx, client, input.Apps, IntegrationApiTickWait)
-	if err != nil {
-		return nil, errors.Annotate(err, "the applications were not available to be integrated")
-	}
+		listViaCIDRs := splitCommaDelimitedList(input.ViaCIDRs)
+		response, err := client.AddRelation(
+			ctx,
+			input.Endpoints,
+			listViaCIDRs,
+		)
+		if err != nil {
+			return err
+		}
 
-	listViaCIDRs := splitCommaDelimitedList(input.ViaCIDRs)
-	response, err := client.AddRelation(
-		ctx,
-		input.Endpoints,
-		listViaCIDRs,
-	)
-	if err != nil {
-		return nil, err
-	}
+		// integration is created - fetch the status in order to validate
+		status, err := c.ModelStatus(ctx, input.ModelUUID, conn)
+		if err != nil {
+			return err
+		}
 
-	// integration is created - fetch the status in order to validate
-	status, err := c.ModelStatus(ctx, input.ModelUUID, conn)
-	if err != nil {
-		return nil, err
-	}
+		applications, err := parseApplications(status.RemoteApplicationOfferers, response.Endpoints)
+		if err != nil {
+			return err
+		}
+		c.Debugf("related apps", map[string]any{"apps": applications})
 
-	applications, err := parseApplications(status.RemoteApplicationOfferers, response.Endpoints)
-	if err != nil {
-		return nil, err
-	}
-	c.Debugf("related apps", map[string]any{"apps": applications})
-
-	return &CreateIntegrationResponse{
-		Applications: applications,
-	}, nil
+		out = &CreateIntegrationResponse{
+			Applications: applications,
+		}
+		return nil
+	})
+	return out, err
 }
 
 // ReadIntegration retrieves integration details for the given endpoints.
 func (c *integrationsClient) ReadIntegration(ctx context.Context, input *IntegrationInput) (*ReadIntegrationResponse, error) {
-	conn, err := c.GetConnection(ctx, &input.ModelUUID)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = conn.Close() }()
-	modelUUID, ok := conn.ModelTag()
-	if !ok {
-		return nil, errors.Errorf("Unable to get model uuid for %q", input.ModelUUID)
-	}
-	status, err := c.ModelStatus(ctx, input.ModelUUID, conn)
-	if err != nil {
-		return nil, err
-	}
-
-	integrations := status.Relations
-	var integration params.RelationStatus
-	if len(integrations) == 0 {
-		return nil, NewIntegrationNotFoundError(modelUUID.Id())
-	}
-
-	apps := make([][]string, 0, len(input.Endpoints))
-	for _, v := range input.Endpoints {
-		app := strings.Split(v, ":")
-		apps = append(apps, []string{
-			app[0],
-			app[1],
-		})
-	}
-
-	// the key is built assuming that the ID is "<provider>:<endpoint> <requirer>:<endpoint>"
-	// the integrations that come back from status have the key formatted as "<requirer>:<endpoint> <provider>:<endpoint>"
-	key := fmt.Sprintf("%v:%v %v:%v", apps[1][0], apps[1][1], apps[0][0], apps[0][1])
-
-	for _, v := range integrations {
-		if v.Key == key {
-			integration = v
-			break
+	var out *ReadIntegrationResponse
+	err := withConnection(ctx, c.SharedClient, &input.ModelUUID, func(conn api.Connection) error {
+		modelUUID, ok := conn.ModelTag()
+		if !ok {
+			return errors.Errorf("Unable to get model uuid for %q", input.ModelUUID)
 		}
-	}
+		status, err := c.ModelStatus(ctx, input.ModelUUID, conn)
+		if err != nil {
+			return err
+		}
 
-	if integration.Id == 0 && integration.Key == "" {
-		keyReversed := fmt.Sprintf("%v:%v %v:%v", apps[1][0], apps[1][1], apps[0][0], apps[0][1])
+		integrations := status.Relations
+		var integration params.RelationStatus
+		if len(integrations) == 0 {
+			return NewIntegrationNotFoundError(modelUUID.Id())
+		}
+
+		apps := make([][]string, 0, len(input.Endpoints))
+		for _, v := range input.Endpoints {
+			app := strings.Split(v, ":")
+			apps = append(apps, []string{
+				app[0],
+				app[1],
+			})
+		}
+
+		// the key is built assuming that the ID is "<provider>:<endpoint> <requirer>:<endpoint>"
+		// the integrations that come back from status have the key formatted as "<requirer>:<endpoint> <provider>:<endpoint>"
+		key := fmt.Sprintf("%v:%v %v:%v", apps[1][0], apps[1][1], apps[0][0], apps[0][1])
+
 		for _, v := range integrations {
-			if v.Key == keyReversed {
-				return nil, fmt.Errorf("check the endpoint order in your ID")
+			if v.Key == key {
+				integration = v
+				break
 			}
 		}
-	}
 
-	if integration.Id == 0 && integration.Key == "" {
-		return nil, NewIntegrationNotFoundError(modelUUID.Id())
-	}
+		if integration.Id == 0 && integration.Key == "" {
+			keyReversed := fmt.Sprintf("%v:%v %v:%v", apps[1][0], apps[1][1], apps[0][0], apps[0][1])
+			for _, v := range integrations {
+				if v.Key == keyReversed {
+					return fmt.Errorf("check the endpoint order in your ID")
+				}
+			}
+		}
 
-	applications, err := parseApplications(status.RemoteApplicationOfferers, integration.Endpoints)
-	if err != nil {
-		return nil, err
-	}
+		if integration.Id == 0 && integration.Key == "" {
+			return NewIntegrationNotFoundError(modelUUID.Id())
+		}
 
-	return &ReadIntegrationResponse{
-		Applications: applications,
-	}, nil
+		applications, err := parseApplications(status.RemoteApplicationOfferers, integration.Endpoints)
+		if err != nil {
+			return err
+		}
+
+		out = &ReadIntegrationResponse{
+			Applications: applications,
+		}
+		return nil
+	})
+	return out, err
 }
 
 func (c *integrationsClient) DestroyIntegration(ctx context.Context, input *IntegrationInput) error {
-	conn, err := c.GetConnection(ctx, &input.ModelUUID)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = conn.Close() }()
+	return withConnection(ctx, c.SharedClient, &input.ModelUUID, func(conn api.Connection) error {
+		client := apiapplication.NewClient(conn)
 
-	client := apiapplication.NewClient(conn)
+		err := client.DestroyRelation(
+			ctx,
+			nil,
+			nil,
+			input.Endpoints...,
+		)
+		if err != nil {
+			return err
+		}
 
-	err = client.DestroyRelation(
-		ctx,
-		nil,
-		nil,
-		input.Endpoints...,
-	)
-	if err != nil {
-		return err
-	}
-
-	return nil
+		return nil
+	})
 }
 
 // ListIntegrations lists the integrations in a model
 func (c integrationsClient) ListIntegrations(ctx context.Context, input *ListIntegrationsInput) ([]ListIntegrationsOutput, error) {
-	conn, err := c.GetConnection(ctx, &input.ModelUUID)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = conn.Close() }()
-
-	status, err := c.ModelStatus(ctx, input.ModelUUID, conn)
-	if err != nil {
-		return nil, err
-	}
-
-	if len(status.Relations) == 0 {
-		return []ListIntegrationsOutput{}, nil
-	}
-
-	results := make([]ListIntegrationsOutput, 0, len(status.Relations))
-	for _, relation := range status.Relations {
-		applications, err := parseApplications(status.RemoteApplicationOfferers, relation.Endpoints)
+	var out []ListIntegrationsOutput
+	err := withConnection(ctx, c.SharedClient, &input.ModelUUID, func(conn api.Connection) error {
+		status, err := c.ModelStatus(ctx, input.ModelUUID, conn)
 		if err != nil {
-			return nil, err
+			return err
 		}
-		results = append(results, ListIntegrationsOutput{Applications: applications})
-	}
 
-	return results, nil
+		if len(status.Relations) == 0 {
+			out = []ListIntegrationsOutput{}
+			return nil
+		}
+
+		results := make([]ListIntegrationsOutput, 0, len(status.Relations))
+		for _, relation := range status.Relations {
+			applications, err := parseApplications(status.RemoteApplicationOfferers, relation.Endpoints)
+			if err != nil {
+				return err
+			}
+			results = append(results, ListIntegrationsOutput{Applications: applications})
+		}
+
+		out = results
+		return nil
+	})
+	return out, err
 }
 
 // This function takes remote applications and endpoint status and combines them into a more usable format to return to the provider

--- a/internal/juju/jaas.go
+++ b/internal/juju/jaas.go
@@ -80,16 +80,13 @@ func (jc *jaasClient) AddRelations(ctx context.Context, tuples []JaasTuple) erro
 	if len(tuples) == 0 {
 		return errors.New("empty slice of tuples")
 	}
-	conn, err := jc.GetConnection(ctx, nil)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = conn.Close() }()
-	cl := jc.getJaasApiClient(conn)
-	req := params.AddRelationRequest{
-		Tuples: toAPITuples(tuples),
-	}
-	return cl.AddRelation(&req)
+	return withConnection(ctx, jc.SharedClient, nil, func(conn jujuapi.Connection) error {
+		cl := jc.getJaasApiClient(conn)
+		req := params.AddRelationRequest{
+			Tuples: toAPITuples(tuples),
+		}
+		return cl.AddRelation(&req)
+	})
 }
 
 // DeleteRelations attempts to delete the provided slice of relationship tuples.
@@ -98,16 +95,13 @@ func (jc *jaasClient) DeleteRelations(ctx context.Context, tuples []JaasTuple) e
 	if len(tuples) == 0 {
 		return errors.New("empty slice of tuples")
 	}
-	conn, err := jc.GetConnection(ctx, nil)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = conn.Close() }()
-	cl := jc.getJaasApiClient(conn)
-	req := params.RemoveRelationRequest{
-		Tuples: toAPITuples(tuples),
-	}
-	return cl.RemoveRelation(&req)
+	return withConnection(ctx, jc.SharedClient, nil, func(conn jujuapi.Connection) error {
+		cl := jc.getJaasApiClient(conn)
+		req := params.RemoveRelationRequest{
+			Tuples: toAPITuples(tuples),
+		}
+		return cl.RemoveRelation(&req)
+	})
 }
 
 // ReadRelations attempts to read relations that match the criteria defined by `tuple`.
@@ -117,54 +111,54 @@ func (jc *jaasClient) ReadRelations(ctx context.Context, tuple *JaasTuple) ([]Ja
 		return nil, errors.New("read relation tuple is nil")
 	}
 
-	conn, err := jc.GetConnection(ctx, nil)
+	var relations []JaasTuple
+	err := withConnection(ctx, jc.SharedClient, nil, func(conn jujuapi.Connection) error {
+		client := jc.getJaasApiClient(conn)
+		relations = make([]JaasTuple, 0)
+		req := &params.ListRelationshipTuplesRequest{Tuple: toAPITuple(*tuple)}
+		for {
+			resp, err := client.ListRelationshipTuples(req)
+			if err != nil {
+				jc.Errorf(err, "call to ListRelationshipTuples failed")
+				return err
+			}
+			if len(resp.Errors) > 0 {
+				jc.Errorf(err, "call to ListRelationshipTuples contained error(s)")
+				return errors.New(resp.Errors[0])
+			}
+			relations = append(relations, toJaasTuples(resp.Tuples)...)
+			if resp.ContinuationToken == "" {
+				return nil
+			}
+			req.ContinuationToken = resp.ContinuationToken
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
+			}
+		}
+	})
 	if err != nil {
 		return nil, err
 	}
-	defer func() { _ = conn.Close() }()
-
-	client := jc.getJaasApiClient(conn)
-	relations := make([]JaasTuple, 0)
-	req := &params.ListRelationshipTuplesRequest{Tuple: toAPITuple(*tuple)}
-	for {
-		resp, err := client.ListRelationshipTuples(req)
-		if err != nil {
-			jc.Errorf(err, "call to ListRelationshipTuples failed")
-			return nil, err
-		}
-		if len(resp.Errors) > 0 {
-			jc.Errorf(err, "call to ListRelationshipTuples contained error(s)")
-			return nil, errors.New(resp.Errors[0])
-		}
-		relations = append(relations, toJaasTuples(resp.Tuples)...)
-		if resp.ContinuationToken == "" {
-			return relations, nil
-		}
-		req.ContinuationToken = resp.ContinuationToken
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		default:
-		}
-	}
+	return relations, nil
 }
 
 // AddGroup attempts to create a new group with the provided name.
 func (jc *jaasClient) AddGroup(ctx context.Context, name string) (string, error) {
-	conn, err := jc.GetConnection(ctx, nil)
-	if err != nil {
-		return "", err
-	}
-	defer func() { _ = conn.Close() }()
+	var uuid string
+	err := withConnection(ctx, jc.SharedClient, nil, func(conn jujuapi.Connection) error {
+		client := jc.getJaasApiClient(conn)
+		req := params.AddGroupRequest{Name: name}
 
-	client := jc.getJaasApiClient(conn)
-	req := params.AddGroupRequest{Name: name}
-
-	resp, err := client.AddGroup(&req)
-	if err != nil {
-		return "", err
-	}
-	return resp.UUID, nil
+		resp, err := client.AddGroup(&req)
+		if err != nil {
+			return err
+		}
+		uuid = resp.UUID
+		return nil
+	})
+	return uuid, err
 }
 
 // ReadGroupByUUID attempts to read a group that matches the provided UUID.
@@ -178,44 +172,38 @@ func (jc *jaasClient) ReadGroupByName(ctx context.Context, name string) (*JaasGr
 }
 
 func (jc *jaasClient) readGroup(ctx context.Context, req *params.GetGroupRequest) (*JaasGroup, error) {
-	conn, err := jc.GetConnection(ctx, nil)
+	var group *JaasGroup
+	err := withConnection(ctx, jc.SharedClient, nil, func(conn jujuapi.Connection) error {
+		client := jc.getJaasApiClient(conn)
+		resp, err := client.GetGroup(req)
+		if err != nil {
+			return err
+		}
+		group = &JaasGroup{Name: resp.Name, UUID: resp.UUID}
+		return nil
+	})
 	if err != nil {
 		return nil, err
 	}
-	defer func() { _ = conn.Close() }()
-
-	client := jc.getJaasApiClient(conn)
-	resp, err := client.GetGroup(req)
-	if err != nil {
-		return nil, err
-	}
-	return &JaasGroup{Name: resp.Name, UUID: resp.UUID}, nil
+	return group, nil
 }
 
 // RenameGroup attempts to rename a group that matches the provided name.
 func (jc *jaasClient) RenameGroup(ctx context.Context, name, newName string) error {
-	conn, err := jc.GetConnection(ctx, nil)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = conn.Close() }()
-
-	client := jc.getJaasApiClient(conn)
-	req := params.RenameGroupRequest{Name: name, NewName: newName}
-	return client.RenameGroup(&req)
+	return withConnection(ctx, jc.SharedClient, nil, func(conn jujuapi.Connection) error {
+		client := jc.getJaasApiClient(conn)
+		req := params.RenameGroupRequest{Name: name, NewName: newName}
+		return client.RenameGroup(&req)
+	})
 }
 
 // RemoveGroup attempts to remove a group that matches the provided name.
 func (jc *jaasClient) RemoveGroup(ctx context.Context, name string) error {
-	conn, err := jc.GetConnection(ctx, nil)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = conn.Close() }()
-
-	client := jc.getJaasApiClient(conn)
-	req := params.RemoveGroupRequest{Name: name}
-	return client.RemoveGroup(&req)
+	return withConnection(ctx, jc.SharedClient, nil, func(conn jujuapi.Connection) error {
+		client := jc.getJaasApiClient(conn)
+		req := params.RemoveGroupRequest{Name: name}
+		return client.RemoveGroup(&req)
+	})
 }
 
 // JaasRole represents a JAAS role used for permissions management.
@@ -226,20 +214,19 @@ type JaasRole struct {
 
 // AddRole attempts to create a new role with the provided name.
 func (jc *jaasClient) AddRole(ctx context.Context, name string) (string, error) {
-	conn, err := jc.GetConnection(ctx, nil)
-	if err != nil {
-		return "", err
-	}
-	defer func() { _ = conn.Close() }()
+	var uuid string
+	err := withConnection(ctx, jc.SharedClient, nil, func(conn jujuapi.Connection) error {
+		client := jc.getJaasApiClient(conn)
+		req := params.AddRoleRequest{Name: name}
 
-	client := jc.getJaasApiClient(conn)
-	req := params.AddRoleRequest{Name: name}
-
-	resp, err := client.AddRole(&req)
-	if err != nil {
-		return "", err
-	}
-	return resp.UUID, nil
+		resp, err := client.AddRole(&req)
+		if err != nil {
+			return err
+		}
+		uuid = resp.UUID
+		return nil
+	})
+	return uuid, err
 }
 
 // ReadRoleByUUID attempts to read a role that matches the provided UUID.
@@ -253,78 +240,75 @@ func (jc *jaasClient) ReadRoleByName(ctx context.Context, name string) (*JaasRol
 }
 
 func (jc *jaasClient) readRole(ctx context.Context, req *params.GetRoleRequest) (*JaasRole, error) {
-	conn, err := jc.GetConnection(ctx, nil)
+	var role *JaasRole
+	err := withConnection(ctx, jc.SharedClient, nil, func(conn jujuapi.Connection) error {
+		client := jc.getJaasApiClient(conn)
+		resp, err := client.GetRole(req)
+		if err != nil {
+			return err
+		}
+		role = &JaasRole{Name: resp.Name, UUID: resp.UUID}
+		return nil
+	})
 	if err != nil {
 		return nil, err
 	}
-	defer func() { _ = conn.Close() }()
-
-	client := jc.getJaasApiClient(conn)
-	resp, err := client.GetRole(req)
-	if err != nil {
-		return nil, err
-	}
-	return &JaasRole{Name: resp.Name, UUID: resp.UUID}, nil
+	return role, nil
 }
 
 // RenameRole attempts to rename a role that matches the provided name.
 func (jc *jaasClient) RenameRole(ctx context.Context, name, newName string) error {
-	conn, err := jc.GetConnection(ctx, nil)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = conn.Close() }()
-
-	client := jc.getJaasApiClient(conn)
-	req := params.RenameRoleRequest{Name: name, NewName: newName}
-	return client.RenameRole(&req)
+	return withConnection(ctx, jc.SharedClient, nil, func(conn jujuapi.Connection) error {
+		client := jc.getJaasApiClient(conn)
+		req := params.RenameRoleRequest{Name: name, NewName: newName}
+		return client.RenameRole(&req)
+	})
 }
 
 // RemoveRole attempts to remove a role that matches the provided name.
 func (jc *jaasClient) RemoveRole(ctx context.Context, name string) error {
-	conn, err := jc.GetConnection(ctx, nil)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = conn.Close() }()
-
-	client := jc.getJaasApiClient(conn)
-	req := params.RemoveRoleRequest{Name: name}
-	return client.RemoveRole(&req)
+	return withConnection(ctx, jc.SharedClient, nil, func(conn jujuapi.Connection) error {
+		client := jc.getJaasApiClient(conn)
+		req := params.RemoveRoleRequest{Name: name}
+		return client.RemoveRole(&req)
+	})
 }
 
 // ListControllers returns a list of controllers accessible to the client.
 func (jc *jaasClient) ListControllers(ctx context.Context) ([]params.ControllerInfo, error) {
-	conn, err := jc.GetConnection(ctx, nil)
+	var controllers []params.ControllerInfo
+	err := withConnection(ctx, jc.SharedClient, nil, func(conn jujuapi.Connection) error {
+		client := jc.getJaasApiClient(conn)
+		var err error
+		controllers, err = client.ListControllers()
+		return err
+	})
 	if err != nil {
 		return nil, err
 	}
-	defer func() { _ = conn.Close() }()
-
-	client := jc.getJaasApiClient(conn)
-	return client.ListControllers()
+	return controllers, nil
 }
 
 // AddController registers a controller with JIMM.
 func (jc *jaasClient) AddController(ctx context.Context, req *params.AddControllerRequest) (params.ControllerInfo, error) {
-	conn, err := jc.GetConnection(ctx, nil)
-	if err != nil {
-		return params.ControllerInfo{}, err
-	}
-	defer func() { _ = conn.Close() }()
-
-	client := jc.getJaasApiClient(conn)
-	return client.AddController(req)
+	var info params.ControllerInfo
+	err := withConnection(ctx, jc.SharedClient, nil, func(conn jujuapi.Connection) error {
+		client := jc.getJaasApiClient(conn)
+		var err error
+		info, err = client.AddController(req)
+		return err
+	})
+	return info, err
 }
 
 // RemoveController removes a controller registration from JIMM.
 func (jc *jaasClient) RemoveController(ctx context.Context, req *params.RemoveControllerRequest) (params.ControllerInfo, error) {
-	conn, err := jc.GetConnection(ctx, nil)
-	if err != nil {
-		return params.ControllerInfo{}, err
-	}
-	defer func() { _ = conn.Close() }()
-
-	client := jc.getJaasApiClient(conn)
-	return client.RemoveController(req)
+	var info params.ControllerInfo
+	err := withConnection(ctx, jc.SharedClient, nil, func(conn jujuapi.Connection) error {
+		client := jc.getJaasApiClient(conn)
+		var err error
+		info, err = client.RemoveController(req)
+		return err
+	})
+	return info, err
 }

--- a/internal/juju/machines.go
+++ b/internal/juju/machines.go
@@ -132,19 +132,18 @@ func getTargetStatusFunc(machineID string) targetStatusFunc {
 
 // CreateMachine provisions a new machine in the specified model.
 func (c *machinesClient) CreateMachine(ctx context.Context, input *CreateMachineInput) (*CreateMachineResponse, error) {
-	conn, err := c.GetConnection(ctx, &input.ModelUUID)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = conn.Close() }()
-
-	machineID, err := c.createMachine(ctx, conn, input)
-	if err != nil {
-		return nil, err
-	}
-	return &CreateMachineResponse{
-		ID: machineID,
-	}, nil
+	var out *CreateMachineResponse
+	err := withConnection(ctx, c.SharedClient, &input.ModelUUID, func(conn api.Connection) error {
+		machineID, err := c.createMachine(ctx, conn, input)
+		if err != nil {
+			return err
+		}
+		out = &CreateMachineResponse{
+			ID: machineID,
+		}
+		return nil
+	})
+	return out, err
 }
 
 func (c *machinesClient) createMachine(ctx context.Context, conn api.Connection, input *CreateMachineInput) (string, error) {
@@ -322,91 +321,84 @@ func manualProvision(ctx context.Context, client manual.ProvisioningClientAPI,
 
 // ReadMachine retrieves a machine by ID from the specified model.
 func (c *machinesClient) ReadMachine(ctx context.Context, input *ReadMachineInput) (*ReadMachineResponse, error) {
-	conn, err := c.GetConnection(ctx, &input.ModelUUID)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = conn.Close() }()
+	var out *ReadMachineResponse
+	err := withConnection(ctx, c.SharedClient, &input.ModelUUID, func(conn api.Connection) error {
+		clientAPIClient := apiclient.NewClient(conn, c.JujuLogger())
 
-	clientAPIClient := apiclient.NewClient(conn, c.JujuLogger())
-
-	status, err := clientAPIClient.Status(ctx, nil)
-	if err != nil {
-		return nil, err
-	}
-	machineIDParts := strings.Split(input.ID, "/")
-	machineStatus, exists := status.Machines[machineIDParts[0]]
-	if !exists {
-		return nil, NewMachineNotFoundError(input.ID)
-	}
-	c.Tracef("ReadMachine:Machine status result", map[string]interface{}{"machineStatus": machineStatus})
-	if len(machineIDParts) > 1 {
-		// check for containers
-		machineStatus, exists = machineStatus.Containers[input.ID]
-		if !exists {
-			return nil, NewMachineNotFoundError(input.ID)
+		status, err := clientAPIClient.Status(ctx, nil)
+		if err != nil {
+			return err
 		}
-	}
+		machineIDParts := strings.Split(input.ID, "/")
+		machineStatus, exists := status.Machines[machineIDParts[0]]
+		if !exists {
+			return NewMachineNotFoundError(input.ID)
+		}
+		c.Tracef("ReadMachine:Machine status result", map[string]interface{}{"machineStatus": machineStatus})
+		if len(machineIDParts) > 1 {
+			// check for containers
+			machineStatus, exists = machineStatus.Containers[input.ID]
+			if !exists {
+				return NewMachineNotFoundError(input.ID)
+			}
+		}
 
-	machineStatusString, err := getTargetStatusFunc(input.ID)(status)
-	if err != nil {
-		return nil, err
-	}
+		machineStatusString, err := getTargetStatusFunc(input.ID)(status)
+		if err != nil {
+			return err
+		}
 
-	base, err := baseFromParams(&machineStatus.Base)
-	if err != nil {
-		return nil, err
-	}
+		base, err := baseFromParams(&machineStatus.Base)
+		if err != nil {
+			return err
+		}
 
-	return &ReadMachineResponse{
-		ID:          machineStatus.Id,
-		Hostname:    machineStatus.Hostname,
-		Constraints: machineStatus.Constraints,
-		Base:        base,
-		Status:      machineStatusString,
-	}, nil
+		out = &ReadMachineResponse{
+			ID:          machineStatus.Id,
+			Hostname:    machineStatus.Hostname,
+			Constraints: machineStatus.Constraints,
+			Base:        base,
+			Status:      machineStatusString,
+		}
+		return nil
+	})
+	return out, err
 }
 
 // DestroyMachine removes a machine from the specified model.
 func (c *machinesClient) DestroyMachine(ctx context.Context, input *DestroyMachineInput) error {
-	conn, err := c.GetConnection(ctx, &input.ModelUUID)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = conn.Close() }()
+	return withConnection(ctx, c.SharedClient, &input.ModelUUID, func(conn api.Connection) error {
+		machineAPIClient := apimachinemanager.NewClient(conn)
 
-	machineAPIClient := apimachinemanager.NewClient(conn)
+		_, err := machineAPIClient.DestroyMachinesWithParams(ctx, false, false, false, (*time.Duration)(nil), input.ID)
+		if err != nil {
+			return err
+		}
 
-	_, err = machineAPIClient.DestroyMachinesWithParams(ctx, false, false, false, (*time.Duration)(nil), input.ID)
-	if err != nil {
-		return err
-	}
-
-	return nil
+		return nil
+	})
 }
 
 // ListMachines returns the list of machine IDs in the given model.
 func (c *machinesClient) ListMachines(ctx context.Context, modelUUID string) ([]string, error) {
-	conn, err := c.GetConnection(ctx, &modelUUID)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = conn.Close() }()
+	var machineIDs []string
+	err := withConnection(ctx, c.SharedClient, &modelUUID, func(conn api.Connection) error {
+		clientAPIClient := apiclient.NewClient(conn, c.JujuLogger())
 
-	clientAPIClient := apiclient.NewClient(conn, c.JujuLogger())
-
-	status, err := clientAPIClient.Status(ctx, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	machineIDs := make([]string, 0, len(status.Machines))
-	for machineID := range status.Machines {
-		machineIDs = append(machineIDs, machineID)
-		for containerID := range status.Machines[machineID].Containers {
-			machineIDs = append(machineIDs, containerID)
+		status, err := clientAPIClient.Status(ctx, nil)
+		if err != nil {
+			return err
 		}
-	}
 
-	return machineIDs, nil
+		machineIDs = make([]string, 0, len(status.Machines))
+		for machineID := range status.Machines {
+			machineIDs = append(machineIDs, machineID)
+			for containerID := range status.Machines[machineID].Containers {
+				machineIDs = append(machineIDs, containerID)
+			}
+		}
+
+		return nil
+	})
+	return machineIDs, err
 }

--- a/internal/juju/models.go
+++ b/internal/juju/models.go
@@ -123,31 +123,29 @@ func newModelsClient(sc SharedClient, isJAAS bool) *modelsClient {
 
 // GetModel retrieves a model by UUID.
 func (c *modelsClient) GetModel(ctx context.Context, modelUUID string) (*params.ModelInfo, error) {
-	conn, err := c.GetConnection(ctx, nil)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = conn.Close() }()
+	var modelInfo *params.ModelInfo
+	err := withConnection(ctx, c.SharedClient, nil, func(conn jujuapi.Connection) error {
+		client := modelmanager.NewClient(conn)
 
-	client := modelmanager.NewClient(conn)
+		modelTag := names.NewModelTag(modelUUID)
 
-	modelTag := names.NewModelTag(modelUUID)
+		results, err := client.ModelInfo(ctx, []names.ModelTag{
+			modelTag,
+		})
+		if err != nil {
+			return err
+		}
+		if results[0].Error != nil {
+			return results[0].Error
+		}
 
-	results, err := client.ModelInfo(ctx, []names.ModelTag{
-		modelTag,
+		modelInfo = results[0].Result
+		c.AddModel(modelInfo.Name, modelInfo.Qualifier, modelUUID, model.ModelType(modelInfo.Type))
+
+		c.Tracef(fmt.Sprintf("Retrieved model info: %s, %+v", modelUUID, modelInfo))
+		return nil
 	})
-	if err != nil {
-		return nil, err
-	}
-	if results[0].Error != nil {
-		return nil, results[0].Error
-	}
-
-	modelInfo := results[0].Result
-	c.AddModel(modelInfo.Name, modelInfo.Qualifier, modelUUID, model.ModelType(modelInfo.Type))
-
-	c.Tracef(fmt.Sprintf("Retrieved model info: %s, %+v", modelUUID, modelInfo))
-	return modelInfo, nil
+	return modelInfo, err
 }
 
 // CreateModel creates a model.
@@ -159,47 +157,49 @@ func (c *modelsClient) CreateModel(ctx context.Context, input CreateModelInput) 
 		return resp, fmt.Errorf("%q is not a valid name: model names may only contain lowercase letters, digits and hyphens", modelName)
 	}
 
-	conn, err := c.GetConnection(ctx, nil)
-	if err != nil {
-		return resp, err
-	}
-	defer func() { _ = conn.Close() }()
+	err := withConnection(ctx, c.SharedClient, nil, func(conn jujuapi.Connection) error {
+		currentUser := getCurrentJujuUser(conn)
 
-	currentUser := getCurrentJujuUser(conn)
+		cloudName := input.CloudName
+		cloudRegion := input.CloudRegion
 
-	cloudName := input.CloudName
-	cloudRegion := input.CloudRegion
+		cloudCredTag := &names.CloudCredentialTag{}
+		if input.Credential != "" {
+			var err error
+			cloudCredTag, err = GetCloudCredentialTag(cloudName, currentUser, input.Credential)
+			if err != nil {
+				return err
+			}
+		}
 
-	cloudCredTag := &names.CloudCredentialTag{}
-	if input.Credential != "" {
-		cloudCredTag, err = GetCloudCredentialTag(cloudName, currentUser, input.Credential)
+		// Casting to map[string]interface{} because of client.CreateModel
+		configValues := make(map[string]interface{})
+
+		for key, configVal := range input.Config {
+			configValues[key] = configVal
+		}
+
+		targetController := input.TargetController
+
+		var err error
+		resp, err = c.createModel(ctx, conn, modelName, currentUser, cloudName, cloudRegion, *cloudCredTag, configValues, targetController)
 		if err != nil {
-			return resp, err
+			// When we create multiple models concurrently, it can happen that Juju returns an error
+			// that the transaction was aborted. We return a specific error here,
+			// to make sure we can retry.
+			if strings.Contains(err.Error(), "transaction aborted") {
+				return TransactionError
+			}
+			return err
 		}
-	}
 
-	// Casting to map[string]interface{} because of client.CreateModel
-	configValues := make(map[string]interface{})
-
-	for key, configVal := range input.Config {
-		configValues[key] = configVal
-	}
-
-	targetController := input.TargetController
-
-	resp, err = c.createModel(ctx, conn, modelName, currentUser, cloudName, cloudRegion, *cloudCredTag, configValues, targetController)
+		// Add a model object on the client internal to the provider
+		c.AddModel(modelName, currentUser, resp.UUID, model.ModelType(resp.Type))
+		return nil
+	})
 	if err != nil {
-		// When we create multiple models concurrently, it can happen that Juju returns an error
-		// that the transaction was aborted. We return a specific error here,
-		// to make sure we can retry.
-		if strings.Contains(err.Error(), "transaction aborted") {
-			return resp, TransactionError
-		}
 		return resp, err
 	}
-
-	// Add a model object on the client internal to the provider
-	c.AddModel(modelName, currentUser, resp.UUID, model.ModelType(resp.Type))
 
 	// set constraints when required
 	if input.Constraints.String() == "" {
@@ -208,14 +208,10 @@ func (c *modelsClient) CreateModel(ctx context.Context, input CreateModelInput) 
 
 	// we have to set constraints ...
 	// establish a new connection with the created model through the modelconfig api to set constraints
-	connModel, err := c.GetConnection(ctx, &resp.UUID)
-	if err != nil {
-		return resp, err
-	}
-	defer func() { _ = connModel.Close() }()
-
-	modelClient := modelconfig.NewClient(connModel)
-	err = modelClient.SetModelConstraints(ctx, input.Constraints)
+	err = withConnection(ctx, c.SharedClient, &resp.UUID, func(connModel jujuapi.Connection) error {
+		modelClient := modelconfig.NewClient(connModel)
+		return modelClient.SetModelConstraints(ctx, input.Constraints)
+	})
 	if err != nil {
 		return resp, err
 	}
@@ -306,225 +302,209 @@ func createJujuModel(ctx context.Context, conn jujuapi.Connection,
 
 // ListModels retrieves the list of model UUIDs.
 func (c *modelsClient) ListModels(ctx context.Context) ([]string, error) {
-	conn, err := c.GetConnection(ctx, nil)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = conn.Close() }()
-
-	client := modelmanager.NewClient(conn)
-	models, err := client.ListModels(ctx, c.GetUser())
-	if err != nil {
-		return nil, err
-	}
-
-	ids := make([]string, 0, len(models))
-	for _, model := range models {
-		if model.Name == "controller" {
-			continue
+	var ids []string
+	err := withConnection(ctx, c.SharedClient, nil, func(conn jujuapi.Connection) error {
+		client := modelmanager.NewClient(conn)
+		models, err := client.ListModels(ctx, c.GetUser())
+		if err != nil {
+			return err
 		}
-		ids = append(ids, model.UUID)
-	}
 
-	return ids, nil
+		ids = make([]string, 0, len(models))
+		for _, model := range models {
+			if model.Name == "controller" {
+				continue
+			}
+			ids = append(ids, model.UUID)
+		}
+
+		return nil
+	})
+	return ids, err
 }
 
 // ReadModel retrieves model details and configuration by UUID.
 func (c *modelsClient) ReadModel(ctx context.Context, modelUUID string) (*ReadModelResponse, error) {
-	modelmanagerConn, err := c.GetConnection(ctx, nil)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = modelmanagerConn.Close() }()
-
-	modelconfigConn, err := c.GetConnection(ctx, &modelUUID)
-	if err != nil {
-		if params.IsCodeNotFound(err) {
-			return nil, errors.WithType(err, ModelNotFoundError)
+	var out *ReadModelResponse
+	err := withConnection(ctx, c.SharedClient, nil, func(modelmanagerConn jujuapi.Connection) error {
+		modelconfigConn, err := c.GetConnection(ctx, &modelUUID)
+		if err != nil {
+			if params.IsCodeNotFound(err) {
+				return errors.WithType(err, ModelNotFoundError)
+			}
+			return err
 		}
-		return nil, err
-	}
-	defer func() { _ = modelconfigConn.Close() }()
+		defer func() { _ = modelconfigConn.Close() }()
 
-	modelmanagerClient := modelmanager.NewClient(modelmanagerConn)
-	modelconfigClient := modelconfig.NewClient(modelconfigConn)
+		modelmanagerClient := modelmanager.NewClient(modelmanagerConn)
+		modelconfigClient := modelconfig.NewClient(modelconfigConn)
 
-	modelUUIDTag, modelOk := modelconfigConn.ModelTag()
-	if !modelOk {
-		return nil, errors.Errorf("Not connected to model %q", modelUUID)
-	}
-	models, err := modelmanagerClient.ModelInfo(ctx, []names.ModelTag{modelUUIDTag})
-	if err != nil {
-		return nil, err
-	}
+		modelUUIDTag, modelOk := modelconfigConn.ModelTag()
+		if !modelOk {
+			return errors.Errorf("Not connected to model %q", modelUUID)
+		}
+		models, err := modelmanagerClient.ModelInfo(ctx, []names.ModelTag{modelUUIDTag})
+		if err != nil {
+			return err
+		}
 
-	if len(models) > 1 {
-		return nil, fmt.Errorf("more than one model returned for UUID: %s", modelUUIDTag.Id())
-	}
-	if len(models) < 1 {
-		return nil, ModelNotFoundError
-	}
+		if len(models) > 1 {
+			return fmt.Errorf("more than one model returned for UUID: %s", modelUUIDTag.Id())
+		}
+		if len(models) < 1 {
+			return ModelNotFoundError
+		}
 
-	// Check if the model has an error first
-	if models[0].Error != nil {
-		return nil, models[0].Error
-	}
-	modelInfo := *models[0].Result
+		// Check if the model has an error first
+		if models[0].Error != nil {
+			return models[0].Error
+		}
+		modelInfo := *models[0].Result
 
-	modelConfig, err := modelconfigClient.ModelGet(ctx)
-	if err != nil {
-		return nil, err
-	}
+		modelConfig, err := modelconfigClient.ModelGet(ctx)
+		if err != nil {
+			return err
+		}
 
-	modelConstraints, err := modelconfigClient.GetModelConstraints(ctx)
-	if err != nil {
-		return nil, err
-	}
+		modelConstraints, err := modelconfigClient.GetModelConstraints(ctx)
+		if err != nil {
+			return err
+		}
 
-	return &ReadModelResponse{
-		ModelInfo:        modelInfo,
-		ModelConfig:      modelConfig,
-		ModelConstraints: modelConstraints,
-	}, nil
+		out = &ReadModelResponse{
+			ModelInfo:        modelInfo,
+			ModelConfig:      modelConfig,
+			ModelConstraints: modelConstraints,
+		}
+		return nil
+	})
+	return out, err
 }
 
 // ReadModelStatus retrieves the status of a model by its name.
 // It returns a ReadModelStatusResponse containing the model's status.
 // If the model is not found, it returns an error.
 func (c *modelsClient) ReadModelStatus(ctx context.Context, modelUUID string) (*ReadModelStatusResponse, error) {
-	modelmanagerConn, err := c.GetConnection(ctx, nil)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = modelmanagerConn.Close() }()
-
-	modelmanagerClient := modelmanager.NewClient(modelmanagerConn)
-	modelStatus, err := modelmanagerClient.ModelStatus(ctx, names.NewModelTag(modelUUID))
-	if err != nil {
-		return nil, err
-	}
-	if len(modelStatus) < 1 {
-		return nil, errors.WithType(errors.New("no models found"), ModelNotFoundError)
-	}
-	if len(modelStatus) > 1 {
-		return nil, fmt.Errorf("more than one model returned for UUID: %s", modelUUID)
-	}
-	if modelStatus[0].Error != nil {
-		if params.IsCodeNotFound(modelStatus[0].Error) {
-			return nil, errors.WithType(modelStatus[0].Error, ModelNotFoundError)
+	var out *ReadModelStatusResponse
+	err := withConnection(ctx, c.SharedClient, nil, func(modelmanagerConn jujuapi.Connection) error {
+		modelmanagerClient := modelmanager.NewClient(modelmanagerConn)
+		modelStatus, err := modelmanagerClient.ModelStatus(ctx, names.NewModelTag(modelUUID))
+		if err != nil {
+			return err
 		}
-		return nil, modelStatus[0].Error
-	}
+		if len(modelStatus) < 1 {
+			return errors.WithType(errors.New("no models found"), ModelNotFoundError)
+		}
+		if len(modelStatus) > 1 {
+			return fmt.Errorf("more than one model returned for UUID: %s", modelUUID)
+		}
+		if modelStatus[0].Error != nil {
+			if params.IsCodeNotFound(modelStatus[0].Error) {
+				return errors.WithType(modelStatus[0].Error, ModelNotFoundError)
+			}
+			return modelStatus[0].Error
+		}
 
-	return &ReadModelStatusResponse{
-		ModelStatus: modelStatus[0],
-	}, nil
+		out = &ReadModelStatusResponse{
+			ModelStatus: modelStatus[0],
+		}
+		return nil
+	})
+	return out, err
 }
 
 // UpdateModel updates model configuration, constraints, or credentials.
 func (c *modelsClient) UpdateModel(ctx context.Context, input UpdateModelInput) error {
-	conn, err := c.GetConnection(ctx, &input.UUID)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = conn.Close() }()
+	return withConnection(ctx, c.SharedClient, &input.UUID, func(conn jujuapi.Connection) error {
+		client := modelconfig.NewClient(conn)
 
-	client := modelconfig.NewClient(conn)
+		configMap := make(map[string]interface{})
+		for key, value := range input.Config {
+			configMap[key] = value
+		}
+		if input.Config != nil {
+			err := client.ModelSet(ctx, configMap)
+			if err != nil {
+				return err
+			}
+		}
 
-	configMap := make(map[string]interface{})
-	for key, value := range input.Config {
-		configMap[key] = value
-	}
-	if input.Config != nil {
-		err = client.ModelSet(ctx, configMap)
-		if err != nil {
-			return err
+		if input.Unset != nil {
+			err := client.ModelUnset(ctx, input.Unset...)
+			if err != nil {
+				return err
+			}
 		}
-	}
 
-	if input.Unset != nil {
-		err = client.ModelUnset(ctx, input.Unset...)
-		if err != nil {
-			return err
+		if input.Constraints != nil {
+			err := client.SetModelConstraints(ctx, *input.Constraints)
+			if err != nil {
+				return err
+			}
 		}
-	}
 
-	if input.Constraints != nil {
-		err = client.SetModelConstraints(ctx, *input.Constraints)
-		if err != nil {
-			return err
+		if input.Credential != "" {
+			cloudName := input.CloudName
+			currentUser := getCurrentJujuUser(conn)
+			cloudCredTag, err := GetCloudCredentialTag(cloudName, currentUser, input.Credential)
+			if err != nil {
+				return err
+			}
+			// open new connection to get facade versions correctly
+			if err := withConnection(ctx, c.SharedClient, nil, func(connModelManager jujuapi.Connection) error {
+				modelUUIDTag, modelOk := connModelManager.ModelTag()
+				if !modelOk {
+					return errors.Errorf("Not connected to model %q", input.Name)
+				}
+				clientModelManager := modelmanager.NewClient(connModelManager)
+				if err := clientModelManager.ChangeModelCredential(ctx, modelUUIDTag, *cloudCredTag); err != nil {
+					return err
+				}
+				return nil
+			}); err != nil {
+				return err
+			}
 		}
-	}
 
-	if input.Credential != "" {
-		cloudName := input.CloudName
-		currentUser := getCurrentJujuUser(conn)
-		cloudCredTag, err := GetCloudCredentialTag(cloudName, currentUser, input.Credential)
-		if err != nil {
-			return err
-		}
-		// open new connection to get facade versions correctly
-		connModelManager, err := c.GetConnection(ctx, nil)
-		if err != nil {
-			return err
-		}
-		defer func() { _ = connModelManager.Close() }()
-		modelUUIDTag, modelOk := connModelManager.ModelTag()
-		if !modelOk {
-			return errors.Errorf("Not connected to model %q", input.Name)
-		}
-		clientModelManager := modelmanager.NewClient(connModelManager)
-		if err := clientModelManager.ChangeModelCredential(ctx, modelUUIDTag, *cloudCredTag); err != nil {
-			return err
-		}
-	}
-
-	return nil
+		return nil
+	})
 }
 
 // DestroyModel removes the model identified by the input UUID.
 func (c *modelsClient) DestroyModel(ctx context.Context, input DestroyModelInput) error {
-	conn, err := c.GetConnection(ctx, nil)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = conn.Close() }()
+	return withConnection(ctx, c.SharedClient, nil, func(conn jujuapi.Connection) error {
+		client := modelmanager.NewClient(conn)
 
-	client := modelmanager.NewClient(conn)
+		maxWait := 10 * time.Minute
+		timeout := 30 * time.Minute
 
-	maxWait := 10 * time.Minute
-	timeout := 30 * time.Minute
+		tag := names.NewModelTag(input.UUID)
 
-	tag := names.NewModelTag(input.UUID)
+		destroyStorage := true
+		forceDestroy := false
 
-	destroyStorage := true
-	forceDestroy := false
+		err := client.DestroyModel(ctx, tag, &destroyStorage, &forceDestroy, &maxWait, &timeout)
+		if err != nil {
+			return err
+		}
 
-	err = client.DestroyModel(ctx, tag, &destroyStorage, &forceDestroy, &maxWait, &timeout)
-	if err != nil {
-		return err
-	}
-
-	c.RemoveModel(input.UUID)
-	return nil
+		c.RemoveModel(input.UUID)
+		return nil
+	})
 }
 
 // GrantModel grants access to a model for a user.
 func (c *modelsClient) GrantModel(ctx context.Context, input GrantModelInput) error {
-	conn, err := c.GetConnection(ctx, nil)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = conn.Close() }()
+	return withConnection(ctx, c.SharedClient, nil, func(conn jujuapi.Connection) error {
+		client := modelmanager.NewClient(conn)
 
-	client := modelmanager.NewClient(conn)
+		err := client.GrantModel(ctx, input.User, input.Access, input.ModelUUID)
+		if err != nil {
+			return err
+		}
 
-	err = client.GrantModel(ctx, input.User, input.Access, input.ModelUUID)
-	if err != nil {
-		return err
-	}
-
-	return nil
+		return nil
+	})
 }
 
 // UpdateAccessModel updates model access by granting or revoking users.
@@ -532,29 +512,25 @@ func (c *modelsClient) GrantModel(ctx context.Context, input GrantModelInput) er
 // If a user has had `write`, then removing that access would decrease their
 // access to `read` and the user will remain part of the model access.
 func (c *modelsClient) UpdateAccessModel(ctx context.Context, input UpdateAccessModelInput) error {
-	conn, err := c.GetConnection(ctx, nil)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = conn.Close() }()
+	return withConnection(ctx, c.SharedClient, nil, func(conn jujuapi.Connection) error {
+		client := modelmanager.NewClient(conn)
 
-	client := modelmanager.NewClient(conn)
-
-	for _, user := range input.Revoke {
-		err := client.RevokeModel(ctx, user, "read", input.ModelUUID)
-		if err != nil {
-			return err
+		for _, user := range input.Revoke {
+			err := client.RevokeModel(ctx, user, "read", input.ModelUUID)
+			if err != nil {
+				return err
+			}
 		}
-	}
 
-	for _, user := range input.Grant {
-		err := client.GrantModel(ctx, user, input.OldAccess, input.ModelUUID)
-		if err != nil {
-			return err
+		for _, user := range input.Grant {
+			err := client.GrantModel(ctx, user, input.OldAccess, input.ModelUUID)
+			if err != nil {
+				return err
+			}
 		}
-	}
 
-	return nil
+		return nil
+	})
 }
 
 // DestroyAccessModel removes model access for specified users.
@@ -562,38 +538,30 @@ func (c *modelsClient) UpdateAccessModel(ctx context.Context, input UpdateAccess
 // If a user has had `write`, then removing that access would decrease their
 // access to `read` and the user will remain part of the model access.
 func (c *modelsClient) DestroyAccessModel(ctx context.Context, input DestroyAccessModelInput) error {
-	conn, err := c.GetConnection(ctx, nil)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = conn.Close() }()
+	return withConnection(ctx, c.SharedClient, nil, func(conn jujuapi.Connection) error {
+		client := modelmanager.NewClient(conn)
 
-	client := modelmanager.NewClient(conn)
-
-	for _, user := range input.Revoke {
-		err := client.RevokeModel(ctx, user, "read", input.ModelUUID)
-		if err != nil {
-			return err
+		for _, user := range input.Revoke {
+			err := client.RevokeModel(ctx, user, "read", input.ModelUUID)
+			if err != nil {
+				return err
+			}
 		}
-	}
 
-	return nil
+		return nil
+	})
 }
 
 // SetModelDefaults sets the default model configuration for a cloud and region.
 func (c *modelsClient) SetModelDefaults(ctx context.Context, cloud string, region string, config map[string]interface{}) error {
-	conn, err := c.GetConnection(ctx, nil)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = conn.Close() }()
+	return withConnection(ctx, c.SharedClient, nil, func(conn jujuapi.Connection) error {
+		client := modelmanager.NewClient(conn)
 
-	client := modelmanager.NewClient(conn)
+		err := client.SetModelDefaults(ctx, cloud, region, config)
+		if err != nil {
+			return err
+		}
 
-	err = client.SetModelDefaults(ctx, cloud, region, config)
-	if err != nil {
-		return err
-	}
-
-	return nil
+		return nil
+	})
 }

--- a/internal/juju/offers.go
+++ b/internal/juju/offers.go
@@ -142,169 +142,184 @@ func newOffersClient(sc SharedClient) *offersClient {
 // CreateOffer creates offer managed by the offer resource.
 func (c *offersClient) CreateOffer(ctx context.Context, input *CreateOfferInput) (*CreateOfferResponse, []error) {
 	var errs []error
+	var resp *CreateOfferResponse
 
-	conn, err := c.GetConnection(ctx, nil)
-	if err != nil {
-		return nil, append(errs, err)
-	}
-	defer func() { _ = conn.Close() }()
+	err := withConnection(ctx, c.SharedClient, nil, func(conn api.Connection) error {
+		client := applicationoffers.NewClient(conn)
 
-	client := applicationoffers.NewClient(conn)
-
-	offerName := input.Name
-	if offerName == "" {
-		offerName = input.ApplicationName
-	}
-
-	// connect to the corresponding model
-	modelConn, err := c.GetConnection(ctx, &input.ModelUUID)
-	if err != nil {
-		return nil, append(errs, err)
-	}
-	defer func() { _ = modelConn.Close() }()
-	applicationClient := apiapplication.NewClient(modelConn)
-
-	// wait for the app to be available
-	ctx, cancel := context.WithTimeout(ctx, OfferAppAvailableTimeout)
-	defer cancel()
-
-	err = WaitForAppsAvailable(ctx, applicationClient, []string{input.ApplicationName}, OfferApiTickWait)
-	if err != nil {
-		return nil, append(errs, errors.New("the application was not available to be offered"))
-	}
-
-	result, err := client.Offer(ctx, input.ModelUUID, input.ApplicationName, input.Endpoints, input.OfferOwner, offerName, "")
-	if err != nil {
-		return nil, append(errs, err)
-	}
-
-	for _, v := range result {
-		var result = params.ErrorResult{}
-		if v == result {
-			continue
-		} else {
-			errs = append(errs, v.Error)
+		offerName := input.Name
+		if offerName == "" {
+			offerName = input.ApplicationName
 		}
+
+		// connect to the corresponding model
+		return withConnection(ctx, c.SharedClient, &input.ModelUUID, func(modelConn api.Connection) error {
+			applicationClient := apiapplication.NewClient(modelConn)
+
+			// wait for the app to be available
+			ctx, cancel := context.WithTimeout(ctx, OfferAppAvailableTimeout)
+			defer cancel()
+
+			err := WaitForAppsAvailable(ctx, applicationClient, []string{input.ApplicationName}, OfferApiTickWait)
+			if err != nil {
+				errs = append(errs, errors.New("the application was not available to be offered"))
+				return err
+			}
+
+			result, err := client.Offer(ctx, input.ModelUUID, input.ApplicationName, input.Endpoints, input.OfferOwner, offerName, "")
+			if err != nil {
+				errs = append(errs, err)
+				return err
+			}
+
+			for _, v := range result {
+				var result = params.ErrorResult{}
+				if v == result {
+					continue
+				} else {
+					errs = append(errs, v.Error)
+				}
+			}
+			if len(errs) != 0 {
+				return errs[0]
+			}
+
+			modelOwner, modelName, err := c.ModelOwnerAndName(ctx, input.ModelUUID)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("unable to get model name for model UUID %q: %w", input.ModelUUID, err))
+				return err
+			}
+
+			c.JujuLogger().sc.Debugf(fmt.Sprintf("listing offers to find the created offer %q in model %q owned by %q", offerName, modelName, modelOwner))
+
+			filter := crossmodel.ApplicationOfferFilter{
+				OfferName:      offerName,
+				ModelName:      modelName,
+				ModelQualifier: model.Qualifier(modelOwner),
+			}
+
+			offer, err := findCreatedOffer(ctx, client, filter, input.Endpoints, offerName)
+			if err != nil {
+				errs = append(errs, err)
+				return err
+			}
+
+			resp = &CreateOfferResponse{
+				Name:     offerName,
+				OfferURL: offer.OfferURL,
+			}
+			return nil
+		})
+	})
+
+	// If either connection could not be established the error is not
+	// captured in errs, so make sure it is surfaced to the caller.
+	if err != nil && len(errs) == 0 {
+		errs = append(errs, err)
 	}
 	if len(errs) != 0 {
 		return nil, errs
 	}
-
-	modelOwner, modelName, err := c.ModelOwnerAndName(ctx, input.ModelUUID)
-	if err != nil {
-		return nil, append(errs, fmt.Errorf("unable to get model name for model UUID %q: %w", input.ModelUUID, err))
-	}
-
-	c.JujuLogger().sc.Debugf(fmt.Sprintf("listing offers to find the created offer %q in model %q owned by %q", offerName, modelName, modelOwner))
-
-	filter := crossmodel.ApplicationOfferFilter{
-		OfferName:      offerName,
-		ModelName:      modelName,
-		ModelQualifier: model.Qualifier(modelOwner),
-	}
-
-	offer, err := findCreatedOffer(ctx, client, filter, input.Endpoints, offerName)
-	if err != nil {
-		return nil, append(errs, err)
-	}
-
-	resp := CreateOfferResponse{
-		Name:     offerName,
-		OfferURL: offer.OfferURL,
-	}
-	return &resp, nil
+	return resp, nil
 }
 
 // ReadOffer reads offer managed by the offer resource.
 func (c *offersClient) ReadOffer(ctx context.Context, input *ReadOfferInput) (*ReadOfferResponse, error) {
-	var conn api.Connection
+	var out *ReadOfferResponse
+	// readOffer performs the actual read against the given connection. It is
+	// shared between the offering-controller connection (which cannot be routed
+	// through withConnection) and the local connection.
+	readOffer := func(conn api.Connection) error {
+		client := applicationoffers.NewClient(conn)
+		result, err := client.ApplicationOffer(ctx, input.OfferURL)
+		if err != nil {
+			return err
+		}
+
+		resultURL, err := crossmodel.ParseOfferURL(result.OfferURL)
+		if err != nil {
+			return fmt.Errorf("unable to parse offer URL %q: %w", result.OfferURL, err)
+		}
+		resultURL.Source = "" // Ensure the source is empty for consistency
+
+		// If the ID used to query the resource does not match the one in the result, it can result
+		// in an unexpected value when saved to a resource, so fail early for easier diagnostics.
+		if resultURL.String() != input.OfferURL {
+			return fmt.Errorf("offer URL %q does not match the expected URL %q", result.OfferURL, input.OfferURL)
+		}
+
+		var response ReadOfferResponse
+		response.Name = result.OfferName
+		response.ApplicationName = result.ApplicationName
+		response.OfferURL = resultURL.String()
+		for _, endpoint := range result.Endpoints {
+			response.Endpoints = append(response.Endpoints, endpoint.Name)
+		}
+		response.Users = result.Users
+
+		if input.GetModelUUID {
+			response.ModelUUID, err = c.ModelUUID(ctx, resultURL.ModelName, resultURL.ModelQualifier)
+			if err != nil {
+				return fmt.Errorf("unable to get model UUID for model %q: %w", resultURL.ModelName, err)
+			}
+		}
+
+		out = &response
+		return nil
+	}
+
 	var err error
 	if input.OfferingController != "" {
-		conn, err = c.GetOfferingControllerConn(ctx, input.OfferingController)
-	} else {
-		conn, err = c.GetConnection(ctx, nil)
-	}
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = conn.Close() }()
-	client := applicationoffers.NewClient(conn)
-	result, err := client.ApplicationOffer(ctx, input.OfferURL)
-	if err != nil {
-		return nil, err
-	}
-
-	resultURL, err := crossmodel.ParseOfferURL(result.OfferURL)
-	if err != nil {
-		return nil, fmt.Errorf("unable to parse offer URL %q: %w", result.OfferURL, err)
-	}
-	resultURL.Source = "" // Ensure the source is empty for consistency
-
-	// If the ID used to query the resource does not match the one in the result, it can result
-	// in an unexpected value when saved to a resource, so fail early for easier diagnostics.
-	if resultURL.String() != input.OfferURL {
-		return nil, fmt.Errorf("offer URL %q does not match the expected URL %q", result.OfferURL, input.OfferURL)
-	}
-
-	var response ReadOfferResponse
-	response.Name = result.OfferName
-	response.ApplicationName = result.ApplicationName
-	response.OfferURL = resultURL.String()
-	for _, endpoint := range result.Endpoints {
-		response.Endpoints = append(response.Endpoints, endpoint.Name)
-	}
-	response.Users = result.Users
-
-	if input.GetModelUUID {
-		response.ModelUUID, err = c.ModelUUID(ctx, resultURL.ModelName, resultURL.ModelQualifier)
-		if err != nil {
-			return nil, fmt.Errorf("unable to get model UUID for model %q: %w", resultURL.ModelName, err)
+		// The offering controller connection cannot be routed through
+		// withConnection, so it is handled manually here.
+		conn, connErr := c.GetOfferingControllerConn(ctx, input.OfferingController)
+		if connErr != nil {
+			return nil, connErr
 		}
+		defer func() { _ = conn.Close() }()
+		err = readOffer(conn)
+	} else {
+		err = withConnection(ctx, c.SharedClient, nil, readOffer)
 	}
-
-	return &response, nil
+	return out, err
 }
 
 // DestroyOffer destroys offer managed by the offer resource.
 func (c *offersClient) DestroyOffer(ctx context.Context, input *DestroyOfferInput) error {
-	conn, err := c.GetConnection(ctx, nil)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = conn.Close() }()
+	return withConnection(ctx, c.SharedClient, nil, func(conn api.Connection) error {
+		client := applicationoffers.NewClient(conn)
+		offer, err := client.ApplicationOffer(ctx, input.OfferURL)
+		if err != nil {
+			return err
+		}
 
-	client := applicationoffers.NewClient(conn)
-	offer, err := client.ApplicationOffer(ctx, input.OfferURL)
-	if err != nil {
-		return err
-	}
-
-	forceDestroy := false
-	//This code loops until it detects 0 connections in the offer or 3 minutes elapses
-	if len(offer.Connections) > 0 {
-		end := time.Now().Add(5 * time.Minute)
-		c.Tracef(fmt.Sprintf("offer %q has %d connections, waiting for them to be removed before destroying", offer.OfferURL, len(offer.Connections)))
-		for ok := true; ok; ok = len(offer.Connections) > 0 {
-			//if we have been failing to destroy offer for 5 minutes then force destroy
-			//TODO: investigate cleaner solution (acceptance tests fail even if timeout set to 20m)
-			if time.Now().After(end) {
-				forceDestroy = true
-				break
-			}
-			time.Sleep(10 * time.Second)
-			offer, err = client.ApplicationOffer(ctx, input.OfferURL)
-			if err != nil {
-				return err
+		forceDestroy := false
+		//This code loops until it detects 0 connections in the offer or 3 minutes elapses
+		if len(offer.Connections) > 0 {
+			end := time.Now().Add(5 * time.Minute)
+			c.Tracef(fmt.Sprintf("offer %q has %d connections, waiting for them to be removed before destroying", offer.OfferURL, len(offer.Connections)))
+			for ok := true; ok; ok = len(offer.Connections) > 0 {
+				//if we have been failing to destroy offer for 5 minutes then force destroy
+				//TODO: investigate cleaner solution (acceptance tests fail even if timeout set to 20m)
+				if time.Now().After(end) {
+					forceDestroy = true
+					break
+				}
+				time.Sleep(10 * time.Second)
+				offer, err = client.ApplicationOffer(ctx, input.OfferURL)
+				if err != nil {
+					return err
+				}
 			}
 		}
-	}
 
-	err = client.DestroyOffers(ctx, forceDestroy, input.OfferURL)
-	if err != nil {
-		return err
-	}
+		err = client.DestroyOffers(ctx, forceDestroy, input.OfferURL)
+		if err != nil {
+			return err
+		}
 
-	return nil
+		return nil
+	})
 }
 
 // matchByEndpoints is returning offers that match exactly the endpoints' names provided.
@@ -390,84 +405,89 @@ func (c *offersClient) ConsumeRemoteOffer(ctx context.Context, input *ConsumeRem
 	if err != nil {
 		return nil, err
 	}
-	modelConn, err := c.GetConnection(ctx, &input.ModelUUID)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = modelConn.Close() }()
-	var conn api.Connection
-	if input.OfferingController != "" {
-		conn, err = c.GetOfferingControllerConn(ctx, input.OfferingController)
-	} else {
-		conn, err = c.GetConnection(ctx, nil)
-	}
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = conn.Close() }()
 
-	offeringControllerClient := applicationoffers.NewClient(conn)
-	consumingClient := apiapplication.NewClient(modelConn)
+	var out *ConsumeRemoteOfferResponse
+	err = withConnection(ctx, c.SharedClient, &input.ModelUUID, func(modelConn api.Connection) error {
+		// consume performs the consume against the offering controller
+		// connection (conn) and the model connection (modelConn).
+		consume := func(conn api.Connection) error {
+			offeringControllerClient := applicationoffers.NewClient(conn)
+			consumingClient := apiapplication.NewClient(modelConn)
 
-	if url.HasEndpoint() {
-		return nil, fmt.Errorf("saas offer %q shouldn't include endpoint", input.OfferURL)
-	}
-	consumeDetails, err := offeringControllerClient.GetConsumeDetails(ctx, url.AsLocal().String())
-	if err != nil {
-		return nil, err
-	}
-
-	offerURL, err := crossmodel.ParseOfferURL(consumeDetails.Offer.OfferURL)
-	if err != nil {
-		return nil, err
-	}
-	if input.OfferingController != "" {
-		offerURL.Source = input.OfferingController
-	}
-	consumeDetails.Offer.OfferURL = offerURL.String()
-
-	consumeArgs := crossmodel.ConsumeApplicationArgs{
-		Offer:            *consumeDetails.Offer,
-		ApplicationAlias: input.RemoteAppAlias,
-		Macaroon:         consumeDetails.Macaroon,
-	}
-	if consumeDetails.ControllerInfo != nil {
-		controllerTag, err := names.ParseControllerTag(consumeDetails.ControllerInfo.ControllerTag)
-		if err != nil {
-			return nil, err
-		}
-		consumeArgs.ControllerInfo = &crossmodel.ControllerInfo{
-			ControllerUUID: controllerTag.Id(),
-			Alias:          consumeDetails.ControllerInfo.Alias,
-			Addrs:          consumeDetails.ControllerInfo.Addrs,
-			CACert:         consumeDetails.ControllerInfo.CACert,
-		}
-	}
-
-	localName, err := consumingClient.Consume(ctx, consumeArgs)
-	if err != nil {
-		// Check if SAAS is already created. If so return offer response instead of error
-		// TODO: Understand why jujuerrors.AlreadyExists is not working and use
-		// the same for below condition
-		if strings.Contains(err.Error(), "saas application already exists") {
-			/* The logic to populate localName is picked from on how the juju controller
-			   derives localName in Consume request.
-			   https://github.com/juju/juju/blob/3e561add5940a510f785c83076b2bcc6994db103/api/client/application/client.go#L803
-			*/
-			localName = consumeArgs.Offer.OfferName
-			if consumeArgs.ApplicationAlias != "" {
-				localName = consumeArgs.ApplicationAlias
+			if url.HasEndpoint() {
+				return fmt.Errorf("saas offer %q shouldn't include endpoint", input.OfferURL)
 			}
-		} else {
-			return nil, err
+			consumeDetails, err := offeringControllerClient.GetConsumeDetails(ctx, url.AsLocal().String())
+			if err != nil {
+				return err
+			}
+
+			offerURL, err := crossmodel.ParseOfferURL(consumeDetails.Offer.OfferURL)
+			if err != nil {
+				return err
+			}
+			if input.OfferingController != "" {
+				offerURL.Source = input.OfferingController
+			}
+			consumeDetails.Offer.OfferURL = offerURL.String()
+
+			consumeArgs := crossmodel.ConsumeApplicationArgs{
+				Offer:            *consumeDetails.Offer,
+				ApplicationAlias: input.RemoteAppAlias,
+				Macaroon:         consumeDetails.Macaroon,
+			}
+			if consumeDetails.ControllerInfo != nil {
+				controllerTag, err := names.ParseControllerTag(consumeDetails.ControllerInfo.ControllerTag)
+				if err != nil {
+					return err
+				}
+				consumeArgs.ControllerInfo = &crossmodel.ControllerInfo{
+					ControllerUUID: controllerTag.Id(),
+					Alias:          consumeDetails.ControllerInfo.Alias,
+					Addrs:          consumeDetails.ControllerInfo.Addrs,
+					CACert:         consumeDetails.ControllerInfo.CACert,
+				}
+			}
+
+			localName, err := consumingClient.Consume(ctx, consumeArgs)
+			if err != nil {
+				// Check if SAAS is already created. If so return offer response instead of error
+				// TODO: Understand why jujuerrors.AlreadyExists is not working and use
+				// the same for below condition
+				if strings.Contains(err.Error(), "saas application already exists") {
+					/* The logic to populate localName is picked from on how the juju controller
+					   derives localName in Consume request.
+					   https://github.com/juju/juju/blob/3e561add5940a510f785c83076b2bcc6994db103/api/client/application/client.go#L803
+					*/
+					localName = consumeArgs.Offer.OfferName
+					if consumeArgs.ApplicationAlias != "" {
+						localName = consumeArgs.ApplicationAlias
+					}
+				} else {
+					return err
+				}
+			}
+
+			out = &ConsumeRemoteOfferResponse{
+				SAASName: localName,
+			}
+
+			return nil
 		}
-	}
 
-	response := ConsumeRemoteOfferResponse{
-		SAASName: localName,
-	}
-
-	return &response, nil
+		if input.OfferingController != "" {
+			// The offering controller connection cannot be routed through
+			// withConnection, so it is handled manually here.
+			conn, connErr := c.GetOfferingControllerConn(ctx, input.OfferingController)
+			if connErr != nil {
+				return connErr
+			}
+			defer func() { _ = conn.Close() }()
+			return consume(conn)
+		}
+		return withConnection(ctx, c.SharedClient, nil, consume)
+	})
+	return out, err
 }
 
 // ReadRemoteApp allows for reading details of a consumed offer
@@ -477,211 +497,195 @@ func (c *offersClient) ConsumeRemoteOffer(ctx context.Context, input *ConsumeRem
 // these objects under "application-endpoints", the API calls them RemoteApplications
 // and `juju status` shows them under the "SAAS" heading.
 func (c *offersClient) ReadRemoteApp(ctx context.Context, input *ReadRemoteAppInput) (*ReadRemoteAppResponse, error) {
-	modelConn, err := c.GetConnection(ctx, &input.ModelUUID)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = modelConn.Close() }()
+	var out *ReadRemoteAppResponse
+	err := withConnection(ctx, c.SharedClient, &input.ModelUUID, func(modelConn api.Connection) error {
+		clientAPIClient := apiclient.NewClient(modelConn, c.JujuLogger())
 
-	clientAPIClient := apiclient.NewClient(modelConn, c.JujuLogger())
-
-	status, err := clientAPIClient.Status(ctx, nil)
-	if err != nil {
-		return nil, fmt.Errorf("unable to fetch model status: %w", err)
-	}
-
-	remoteApplications := status.RemoteApplicationOfferers
-
-	if len(remoteApplications) == 0 {
-		return nil, errors.WithType(errors.New("remote app not found"), RemoteAppNotFoundError)
-	}
-
-	for appName := range remoteApplications {
-		if appName == input.RemoteAppName {
-			return &ReadRemoteAppResponse{}, nil
+		status, err := clientAPIClient.Status(ctx, nil)
+		if err != nil {
+			return fmt.Errorf("unable to fetch model status: %w", err)
 		}
-	}
 
-	return nil, errors.WithType(errors.New("remote app not found"), RemoteAppNotFoundError)
+		remoteApplications := status.RemoteApplicationOfferers
+
+		if len(remoteApplications) == 0 {
+			return errors.WithType(errors.New("remote app not found"), RemoteAppNotFoundError)
+		}
+
+		for appName := range remoteApplications {
+			if appName == input.RemoteAppName {
+				out = &ReadRemoteAppResponse{}
+				return nil
+			}
+		}
+
+		return errors.WithType(errors.New("remote app not found"), RemoteAppNotFoundError)
+	})
+	return out, err
 }
 
 // RemoveRemoteApp allows the integration resource to destroy the offers managed by the offer resource.
 func (c *offersClient) RemoveRemoteApp(ctx context.Context, input *RemoveRemoteAppInput) error {
-	conn, err := c.GetConnection(ctx, &input.ModelUUID)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = conn.Close() }()
+	return withConnection(ctx, c.SharedClient, &input.ModelUUID, func(conn api.Connection) error {
+		client := apiapplication.NewClient(conn)
+		clientAPIClient := apiclient.NewClient(conn, c.JujuLogger())
 
-	client := apiapplication.NewClient(conn)
-	clientAPIClient := apiclient.NewClient(conn, c.JujuLogger())
-
-	status, err := clientAPIClient.Status(ctx, nil)
-	if err != nil {
-		return err
-	}
-
-	remoteApplications := status.RemoteApplicationOfferers
-
-	if len(remoteApplications) == 0 {
-		return fmt.Errorf("no offers found in model")
-	}
-
-	var offerName string
-	for appName := range remoteApplications {
-		if appName == input.RemoteAppName {
-			offerName = appName
-			break
+		status, err := clientAPIClient.Status(ctx, nil)
+		if err != nil {
+			return err
 		}
-	}
 
-	if offerName == "" {
-		return fmt.Errorf("remote-app %q not found in model", input.RemoteAppName)
-	}
+		remoteApplications := status.RemoteApplicationOfferers
 
-	// This is a bulk call but we only want to remove one remote app
-	// so we expect only a single error to be returned if it fails.
-	returnErrors, err := client.DestroyConsumedApplication(ctx, apiapplication.DestroyConsumedApplicationParams{
-		SaasNames: []string{
-			offerName,
-		},
+		if len(remoteApplications) == 0 {
+			return fmt.Errorf("no offers found in model")
+		}
+
+		var offerName string
+		for appName := range remoteApplications {
+			if appName == input.RemoteAppName {
+				offerName = appName
+				break
+			}
+		}
+
+		if offerName == "" {
+			return fmt.Errorf("remote-app %q not found in model", input.RemoteAppName)
+		}
+
+		// This is a bulk call but we only want to remove one remote app
+		// so we expect only a single error to be returned if it fails.
+		returnErrors, err := client.DestroyConsumedApplication(ctx, apiapplication.DestroyConsumedApplicationParams{
+			SaasNames: []string{
+				offerName,
+			},
+		})
+		if err != nil {
+			return err
+		}
+
+		var errors []error
+		for _, v := range returnErrors {
+			if v.Error != nil {
+				errors = append(errors, v.Error)
+			}
+		}
+		return stderr.Join(errors...)
 	})
-	if err != nil {
-		return err
-	}
-
-	var errors []error
-	for _, v := range returnErrors {
-		if v.Error != nil {
-			errors = append(errors, v.Error)
-		}
-	}
-	return stderr.Join(errors...)
 }
 
 // GrantOffer adds access to an offer managed by the access offer resource.
 // No action or error is returned if the access was already granted to the user.
 func (c *offersClient) GrantOffer(ctx context.Context, input *GrantRevokeOfferInput) error {
-	conn, err := c.GetConnection(ctx, nil)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = conn.Close() }()
+	return withConnection(ctx, c.SharedClient, nil, func(conn api.Connection) error {
+		client := applicationoffers.NewClient(conn)
 
-	client := applicationoffers.NewClient(conn)
-
-	for _, user := range input.Users {
-		err = client.GrantOffer(ctx, user, input.Access, input.OfferURL)
-		if err != nil {
-			return err
+		for _, user := range input.Users {
+			err := client.GrantOffer(ctx, user, input.Access, input.OfferURL)
+			if err != nil {
+				return err
+			}
 		}
-	}
 
-	return nil
+		return nil
+	})
 }
 
 // RevokeOffer revokes access to an offer managed by the access offer resource.
 // No action or error if the access was already revoked for the user.
 // Note: revoking `ReadAccess` will remove all access levels for the offer
 func (c *offersClient) RevokeOffer(ctx context.Context, input *GrantRevokeOfferInput) error {
-	conn, err := c.GetConnection(ctx, nil)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = conn.Close() }()
+	return withConnection(ctx, c.SharedClient, nil, func(conn api.Connection) error {
+		client := applicationoffers.NewClient(conn)
 
-	client := applicationoffers.NewClient(conn)
-
-	for _, user := range input.Users {
-		err = client.RevokeOffer(ctx, user, input.Access, input.OfferURL)
-		if err != nil {
-			// ignore if user was already revoked
-			if strings.Contains(err.Error(), "not found") {
-				continue
+		for _, user := range input.Users {
+			err := client.RevokeOffer(ctx, user, input.Access, input.OfferURL)
+			if err != nil {
+				// ignore if user was already revoked
+				if strings.Contains(err.Error(), "not found") {
+					continue
+				}
+				return err
 			}
-			return err
 		}
-	}
 
-	return nil
+		return nil
+	})
 }
 
 // ListOffers lists offers, optionally filtered by model UUID or offer URL.
 func (c offersClient) ListOffers(ctx context.Context, input *ListOffersInput) ([]ListOffersOutput, error) {
-	conn, err := c.GetConnection(ctx, nil)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = conn.Close() }()
-
-	client := applicationoffers.NewClient(conn)
-
-	filter := crossmodel.ApplicationOfferFilter{}
-
-	// If ModelUUID is set, filter by model
-	if input.ModelUUID != "" {
-		modelOwner, modelName, err := c.ModelOwnerAndName(ctx, input.ModelUUID)
-		if err != nil {
-			return nil, fmt.Errorf("unable to get model name for model UUID %q: %w", input.ModelUUID, err)
-		}
-		filter.ModelName = modelName
-		filter.ModelQualifier = model.Qualifier(modelOwner)
-	}
-
-	// If OfferURL is set, parse it and use it to refine the filter
-	if input.OfferURL != "" {
-		parsedURL, err := crossmodel.ParseOfferURL(input.OfferURL)
-		if err != nil {
-			return nil, fmt.Errorf("unable to parse offer URL %q: %w", input.OfferURL, err)
-		}
-		filter.OfferName = parsedURL.Name
-		// If ModelUUID was not set, use the model from the URL
-		if input.ModelUUID == "" && parsedURL.ModelName != "" {
-			filter.ModelName = parsedURL.ModelName
-			filter.ModelQualifier = model.Qualifier(parsedURL.ModelQualifier)
-		}
-	}
-
-	offers, err := client.FindApplicationOffers(ctx, filter)
-	if err != nil {
-		return nil, err
-	}
-
 	var results []ListOffersOutput
-	for _, offer := range offers {
-		// Parse and normalize the offer URL
-		resultURL, err := crossmodel.ParseOfferURL(offer.OfferURL)
+	err := withConnection(ctx, c.SharedClient, nil, func(conn api.Connection) error {
+		client := applicationoffers.NewClient(conn)
+
+		filter := crossmodel.ApplicationOfferFilter{}
+
+		// If ModelUUID is set, filter by model
+		if input.ModelUUID != "" {
+			modelOwner, modelName, err := c.ModelOwnerAndName(ctx, input.ModelUUID)
+			if err != nil {
+				return fmt.Errorf("unable to get model name for model UUID %q: %w", input.ModelUUID, err)
+			}
+			filter.ModelName = modelName
+			filter.ModelQualifier = model.Qualifier(modelOwner)
+		}
+
+		// If OfferURL is set, parse it and use it to refine the filter
+		if input.OfferURL != "" {
+			parsedURL, err := crossmodel.ParseOfferURL(input.OfferURL)
+			if err != nil {
+				return fmt.Errorf("unable to parse offer URL %q: %w", input.OfferURL, err)
+			}
+			filter.OfferName = parsedURL.Name
+			// If ModelUUID was not set, use the model from the URL
+			if input.ModelUUID == "" && parsedURL.ModelName != "" {
+				filter.ModelName = parsedURL.ModelName
+				filter.ModelQualifier = model.Qualifier(parsedURL.ModelQualifier)
+			}
+		}
+
+		offers, err := client.FindApplicationOffers(ctx, filter)
 		if err != nil {
-			return nil, fmt.Errorf("unable to parse offer URL %q: %w", offer.OfferURL, err)
-		}
-		resultURL.Source = "" // Ensure the source is empty for consistency
-
-		// Extract endpoint names
-		var endpoints []string
-		for _, endpoint := range offer.Endpoints {
-			endpoints = append(endpoints, endpoint.Name)
+			return err
 		}
 
-		modelUUID, err := c.ModelUUID(ctx, resultURL.ModelName, resultURL.ModelQualifier)
-		if err != nil {
-			return nil, fmt.Errorf("unable to get model UUID for model %q: %w", resultURL.ModelName, err)
+		for _, offer := range offers {
+			// Parse and normalize the offer URL
+			resultURL, err := crossmodel.ParseOfferURL(offer.OfferURL)
+			if err != nil {
+				return fmt.Errorf("unable to parse offer URL %q: %w", offer.OfferURL, err)
+			}
+			resultURL.Source = "" // Ensure the source is empty for consistency
+
+			// Extract endpoint names
+			var endpoints []string
+			for _, endpoint := range offer.Endpoints {
+				endpoints = append(endpoints, endpoint.Name)
+			}
+
+			modelUUID, err := c.ModelUUID(ctx, resultURL.ModelName, resultURL.ModelQualifier)
+			if err != nil {
+				return fmt.Errorf("unable to get model UUID for model %q: %w", resultURL.ModelName, err)
+			}
+
+			output := ListOffersOutput{
+				Name:            offer.OfferName,
+				ApplicationName: offer.ApplicationName,
+				Endpoints:       endpoints,
+				OfferURL:        resultURL.String(),
+				ModelUUID:       modelUUID,
+			}
+
+			// If OfferURL filter is set, only include exact matches
+			if input.OfferURL != "" && output.OfferURL != input.OfferURL {
+				continue
+			}
+
+			results = append(results, output)
 		}
 
-		output := ListOffersOutput{
-			Name:            offer.OfferName,
-			ApplicationName: offer.ApplicationName,
-			Endpoints:       endpoints,
-			OfferURL:        resultURL.String(),
-			ModelUUID:       modelUUID,
-		}
-
-		// If OfferURL filter is set, only include exact matches
-		if input.OfferURL != "" && output.OfferURL != input.OfferURL {
-			continue
-		}
-
-		results = append(results, output)
-	}
-
-	return results, nil
+		return nil
+	})
+	return results, err
 }

--- a/internal/juju/secrets.go
+++ b/internal/juju/secrets.go
@@ -149,250 +149,239 @@ func newSecretsClient(sc SharedClient) *secretsClient {
 
 // CreateSecret creates a new secret.
 func (c *secretsClient) CreateSecret(ctx context.Context, input *CreateSecretInput) (CreateSecretOutput, error) {
-	conn, err := c.GetConnection(ctx, &input.ModelUUID)
-	if err != nil {
-		return CreateSecretOutput{}, err
-	}
-	defer func() { _ = conn.Close() }()
+	var out CreateSecretOutput
+	err := withConnection(ctx, c.SharedClient, &input.ModelUUID, func(conn api.Connection) error {
+		secretAPIClient := c.getSecretAPIClient(conn)
 
-	secretAPIClient := c.getSecretAPIClient(conn)
+		// Encode the secret values as base64
+		encodedValue := make(map[string]string, len(input.Value))
+		for k, v := range input.Value {
+			encodedValue[k] = base64.StdEncoding.EncodeToString([]byte(v))
+		}
 
-	// Encode the secret values as base64
-	encodedValue := make(map[string]string, len(input.Value))
-	for k, v := range input.Value {
-		encodedValue[k] = base64.StdEncoding.EncodeToString([]byte(v))
-	}
-
-	secretId, err := secretAPIClient.CreateSecret(ctx, input.Name, input.Info, encodedValue)
-	if err != nil {
-		return CreateSecretOutput{}, typedError(err)
-	}
-	secretURI, err := coresecrets.ParseURI(secretId)
-	if err != nil {
-		return CreateSecretOutput{}, typedError(err)
-	}
-	return CreateSecretOutput{
-		SecretId:  secretURI.ID,
-		SecretURI: secretURI.String(),
-	}, nil
+		secretId, err := secretAPIClient.CreateSecret(ctx, input.Name, input.Info, encodedValue)
+		if err != nil {
+			return typedError(err)
+		}
+		secretURI, err := coresecrets.ParseURI(secretId)
+		if err != nil {
+			return typedError(err)
+		}
+		out = CreateSecretOutput{
+			SecretId:  secretURI.ID,
+			SecretURI: secretURI.String(),
+		}
+		return nil
+	})
+	return out, err
 }
 
 // ReadSecret reads a secret.
 func (c *secretsClient) ReadSecret(ctx context.Context, input *ReadSecretInput) (ReadSecretOutput, error) {
-	conn, err := c.GetConnection(ctx, &input.ModelUUID)
-	if err != nil {
-		return ReadSecretOutput{}, err
-	}
-	defer func() { _ = conn.Close() }()
+	var out ReadSecretOutput
+	err := withConnection(ctx, c.SharedClient, &input.ModelUUID, func(conn api.Connection) error {
+		secretAPIClient := c.getSecretAPIClient(conn)
 
-	secretAPIClient := c.getSecretAPIClient(conn)
-
-	var secretURI *coresecrets.URI
-	if input.SecretId != "" {
-		secretURI, err = coresecrets.ParseURI(input.SecretId)
-		if err != nil {
-			return ReadSecretOutput{}, err
+		var secretURI *coresecrets.URI
+		if input.SecretId != "" {
+			var err error
+			secretURI, err = coresecrets.ParseURI(input.SecretId)
+			if err != nil {
+				return err
+			}
+		} else {
+			secretURI = nil
 		}
-	} else {
-		secretURI = nil
-	}
-	secretFilter := coresecrets.Filter{
-		URI:      secretURI,
-		Label:    input.Name,
-		Revision: input.Revision,
-	}
+		secretFilter := coresecrets.Filter{
+			URI:      secretURI,
+			Label:    input.Name,
+			Revision: input.Revision,
+		}
 
-	results, err := secretAPIClient.ListSecrets(ctx, true, secretFilter)
-	if err != nil {
-		return ReadSecretOutput{}, typedError(err)
-	}
-	if len(results) < 1 {
-		return ReadSecretOutput{}, &secretNotFoundError{secretId: input.SecretId}
-	}
-	if results[0].Error != "" {
-		return ReadSecretOutput{}, errors.New(results[0].Error)
-	}
+		results, err := secretAPIClient.ListSecrets(ctx, true, secretFilter)
+		if err != nil {
+			return typedError(err)
+		}
+		if len(results) < 1 {
+			return &secretNotFoundError{secretId: input.SecretId}
+		}
+		if results[0].Error != "" {
+			return errors.New(results[0].Error)
+		}
 
-	// Decode the secret values from base64
-	decodedValue, err := results[0].Value.Values()
-	if err != nil {
-		return ReadSecretOutput{}, err
-	}
+		// Decode the secret values from base64
+		decodedValue, err := results[0].Value.Values()
+		if err != nil {
+			return err
+		}
 
-	// Get applications from Access info
-	applications := getApplicationsFromAccessInfo(results[0].Access)
+		// Get applications from Access info
+		applications := getApplicationsFromAccessInfo(results[0].Access)
 
-	return ReadSecretOutput{
-		SecretId:     results[0].Metadata.URI.ID,
-		SecretURI:    results[0].Metadata.URI.String(),
-		Name:         results[0].Metadata.Label,
-		Value:        decodedValue,
-		Applications: applications,
-		Info:         results[0].Metadata.Description,
-	}, nil
+		out = ReadSecretOutput{
+			SecretId:     results[0].Metadata.URI.ID,
+			SecretURI:    results[0].Metadata.URI.String(),
+			Name:         results[0].Metadata.Label,
+			Value:        decodedValue,
+			Applications: applications,
+			Info:         results[0].Metadata.Description,
+		}
+		return nil
+	})
+	return out, err
 }
 
 // ListSecrets lists secrets in a model.
 func (c *secretsClient) ListSecrets(ctx context.Context, input *ListSecretsInput) ([]ListSecretsOutput, error) {
-	conn, err := c.GetConnection(ctx, &input.ModelUUID)
+	var output []ListSecretsOutput
+	err := withConnection(ctx, c.SharedClient, &input.ModelUUID, func(conn api.Connection) error {
+		secretAPIClient := c.getSecretAPIClient(conn)
+
+		secretFilter := coresecrets.Filter{
+			Label: input.Name,
+		}
+
+		results, err := secretAPIClient.ListSecrets(ctx, true, secretFilter)
+		if err != nil {
+			return typedError(err)
+		}
+
+		output = make([]ListSecretsOutput, 0, len(results))
+		for _, result := range results {
+			if result.Error != "" {
+				return errors.New(result.Error)
+			}
+
+			decodedValue, err := result.Value.Values()
+			if err != nil {
+				return err
+			}
+
+			applications := getApplicationsFromAccessInfo(result.Access)
+
+			output = append(output, ListSecretsOutput{
+				SecretId:     result.Metadata.URI.ID,
+				SecretURI:    result.Metadata.URI.String(),
+				Name:         result.Metadata.Label,
+				Value:        decodedValue,
+				Applications: applications,
+				Info:         result.Metadata.Description,
+			})
+		}
+
+		return nil
+	})
 	if err != nil {
 		return nil, err
 	}
-	defer func() { _ = conn.Close() }()
-
-	secretAPIClient := c.getSecretAPIClient(conn)
-
-	secretFilter := coresecrets.Filter{
-		Label: input.Name,
-	}
-
-	results, err := secretAPIClient.ListSecrets(ctx, true, secretFilter)
-	if err != nil {
-		return nil, typedError(err)
-	}
-
-	output := make([]ListSecretsOutput, 0, len(results))
-	for _, result := range results {
-		if result.Error != "" {
-			return nil, errors.New(result.Error)
-		}
-
-		decodedValue, err := result.Value.Values()
-		if err != nil {
-			return nil, err
-		}
-
-		applications := getApplicationsFromAccessInfo(result.Access)
-
-		output = append(output, ListSecretsOutput{
-			SecretId:     result.Metadata.URI.ID,
-			SecretURI:    result.Metadata.URI.String(),
-			Name:         result.Metadata.Label,
-			Value:        decodedValue,
-			Applications: applications,
-			Info:         result.Metadata.Description,
-		})
-	}
-
 	return output, nil
 }
 
 // UpdateSecret updates a secret.
 func (c *secretsClient) UpdateSecret(ctx context.Context, input *UpdateSecretInput) error {
-	conn, err := c.GetConnection(ctx, &input.ModelUUID)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = conn.Close() }()
+	return withConnection(ctx, c.SharedClient, &input.ModelUUID, func(conn api.Connection) error {
+		secretAPIClient := c.getSecretAPIClient(conn)
 
-	secretAPIClient := c.getSecretAPIClient(conn)
-
-	// Specify by ID or Name
-	if input.SecretId == "" && input.Name == nil {
-		return errors.New("must specify either secret ID or name")
-	}
-
-	// Define default values
-	var info string
-	if input.Info != nil {
-		info = *input.Info
-	} else {
-		info = ""
-	}
-	var value map[string]string
-	if input.Value != nil {
-		// Encode the secret values as base64
-		encodedValue := make(map[string]string, len(*input.Value))
-		for k, v := range *input.Value {
-			encodedValue[k] = base64.StdEncoding.EncodeToString([]byte(v))
+		// Specify by ID or Name
+		if input.SecretId == "" && input.Name == nil {
+			return errors.New("must specify either secret ID or name")
 		}
 
-		value = encodedValue
-	} else {
-		value = map[string]string{}
-	}
-
-	if input.SecretId != "" {
-		// Specify by ID
-		secretURI, err := coresecrets.ParseURI(input.SecretId)
-		if err != nil {
-			return err
+		// Define default values
+		var info string
+		if input.Info != nil {
+			info = *input.Info
+		} else {
+			info = ""
 		}
-		if input.Name == nil {
-			// Update secret without changing the name
-			err = secretAPIClient.UpdateSecret(ctx, secretURI, "", input.AutoPrune, "", info, value)
+		var value map[string]string
+		if input.Value != nil {
+			// Encode the secret values as base64
+			encodedValue := make(map[string]string, len(*input.Value))
+			for k, v := range *input.Value {
+				encodedValue[k] = base64.StdEncoding.EncodeToString([]byte(v))
+			}
+
+			value = encodedValue
+		} else {
+			value = map[string]string{}
+		}
+
+		if input.SecretId != "" {
+			// Specify by ID
+			secretURI, err := coresecrets.ParseURI(input.SecretId)
 			if err != nil {
-				return typedError(err)
+				return err
+			}
+			if input.Name == nil {
+				// Update secret without changing the name
+				err = secretAPIClient.UpdateSecret(ctx, secretURI, "", input.AutoPrune, "", info, value)
+				if err != nil {
+					return typedError(err)
+				}
+			} else {
+				// Update secret with a new name
+				err = secretAPIClient.UpdateSecret(ctx, secretURI, "", input.AutoPrune, *input.Name, info, value)
+				if err != nil {
+					return typedError(err)
+				}
 			}
 		} else {
-			// Update secret with a new name
-			err = secretAPIClient.UpdateSecret(ctx, secretURI, "", input.AutoPrune, *input.Name, info, value)
-			if err != nil {
-				return typedError(err)
-			}
+			return errors.New("updating secrets by name is not supported")
 		}
-	} else {
-		return errors.New("updating secrets by name is not supported")
-	}
 
-	return nil
+		return nil
+	})
 }
 
 // DeleteSecret deletes a secret.
 func (c *secretsClient) DeleteSecret(ctx context.Context, input *DeleteSecretInput) error {
-	conn, err := c.GetConnection(ctx, &input.ModelUUID)
-	if err != nil {
-		return err
-	}
+	return withConnection(ctx, c.SharedClient, &input.ModelUUID, func(conn api.Connection) error {
+		secretAPIClient := c.getSecretAPIClient(conn)
+		secretURI, err := coresecrets.ParseURI(input.SecretId)
+		if err != nil {
+			return err
+		}
+		// TODO: think about removing concrete revision.
+		err = secretAPIClient.RemoveSecret(ctx, secretURI, "", nil)
+		if !errors.Is(err, jujuerrors.NotFound) {
+			return typedError(err)
+		}
 
-	secretAPIClient := c.getSecretAPIClient(conn)
-	secretURI, err := coresecrets.ParseURI(input.SecretId)
-	if err != nil {
-		return err
-	}
-	// TODO: think about removing concrete revision.
-	err = secretAPIClient.RemoveSecret(ctx, secretURI, "", nil)
-	if !errors.Is(err, jujuerrors.NotFound) {
-		return typedError(err)
-	}
-
-	return nil
+		return nil
+	})
 }
 
 // UpdateAccessSecret updates access to a secret.
 func (c *secretsClient) UpdateAccessSecret(ctx context.Context, input *GrantRevokeAccessSecretInput, op AccessSecretAction) error {
-	conn, err := c.GetConnection(ctx, &input.ModelUUID)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = conn.Close() }()
+	return withConnection(ctx, c.SharedClient, &input.ModelUUID, func(conn api.Connection) error {
+		secretAPIClient := c.getSecretAPIClient(conn)
 
-	secretAPIClient := c.getSecretAPIClient(conn)
+		secretURI, err := coresecrets.ParseURI(input.SecretId)
+		if err != nil {
+			return err
+		}
 
-	secretURI, err := coresecrets.ParseURI(input.SecretId)
-	if err != nil {
-		return err
-	}
+		var results []error
+		switch op {
+		case GrantAccess:
+			results, err = secretAPIClient.GrantSecret(ctx, secretURI, "", input.Applications)
+		case RevokeAccess:
+			results, err = secretAPIClient.RevokeSecret(ctx, secretURI, "", input.Applications)
+		default:
+			return errors.New("invalid op")
+		}
 
-	var results []error
-	switch op {
-	case GrantAccess:
-		results, err = secretAPIClient.GrantSecret(ctx, secretURI, "", input.Applications)
-	case RevokeAccess:
-		results, err = secretAPIClient.RevokeSecret(ctx, secretURI, "", input.Applications)
-	default:
-		return errors.New("invalid op")
-	}
+		if err != nil {
+			return typedError(err)
+		}
 
-	if err != nil {
-		return typedError(err)
-	}
+		if len(results) > 0 && results[0] != nil {
+			return errors.Join(results...)
+		}
 
-	if len(results) > 0 && results[0] != nil {
-		return errors.Join(results...)
-	}
-
-	return nil
+		return nil
+	})
 }
 
 // getApplicationsFromAccessInfo returns a list of applications from the access info.

--- a/internal/juju/spaces.go
+++ b/internal/juju/spaces.go
@@ -80,101 +80,89 @@ func newSpacesClient(sc SharedClient) *spacesClient {
 
 // CreateSpace creates a space without assigning any subnets at creation time.
 func (c *spacesClient) CreateSpace(ctx context.Context, input *CreateSpaceInput) error {
-	conn, err := c.GetConnection(ctx, &input.ModelUUID)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = conn.Close() }()
-
-	spaceClient := c.getSpacesAPIClient(conn)
-	// The public argument isn't actually implemented server side, and defaults to true
-	// in the client - so we do too.
-	if err := spaceClient.CreateSpace(ctx, input.Name, nil, true); err != nil {
-		return errors.Annotate(err, "creating space")
-	}
-	return nil
+	return withConnection(ctx, c.SharedClient, &input.ModelUUID, func(conn api.Connection) error {
+		spaceClient := c.getSpacesAPIClient(conn)
+		// The public argument isn't actually implemented server side, and defaults to true
+		// in the client - so we do too.
+		if err := spaceClient.CreateSpace(ctx, input.Name, nil, true); err != nil {
+			return errors.Annotate(err, "creating space")
+		}
+		return nil
+	})
 }
 
 // ReadSpace reads a space by name.
 func (c *spacesClient) ReadSpace(ctx context.Context, input *ReadSpaceInput) (*ReadSpaceOutput, error) {
-	conn, err := c.GetConnection(ctx, &input.ModelUUID)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = conn.Close() }()
-
-	spaceClient := c.getSpacesAPIClient(conn)
-	result, err := spaceClient.ShowSpace(ctx, input.Name)
-	if err != nil {
-		// The client doesn't type the error when the space cannot be found.
-		// We require the typing because we need to check it isn't found
-		// when waiting for the deletion of the space.
-		if strings.Contains(err.Error(), "not found") {
-			err = errors.WithType(err, errors.NotFound)
+	var output *ReadSpaceOutput
+	err := withConnection(ctx, c.SharedClient, &input.ModelUUID, func(conn api.Connection) error {
+		spaceClient := c.getSpacesAPIClient(conn)
+		result, err := spaceClient.ShowSpace(ctx, input.Name)
+		if err != nil {
+			// The client doesn't type the error when the space cannot be found.
+			// We require the typing because we need to check it isn't found
+			// when waiting for the deletion of the space.
+			if strings.Contains(err.Error(), "not found") {
+				err = errors.WithType(err, errors.NotFound)
+			}
+			return errors.Annotate(err, "reading space")
 		}
-		return nil, errors.Annotate(err, "reading space")
-	}
 
-	return &ReadSpaceOutput{
-		ID:      result.Space.Id,
-		Name:    result.Space.Name,
-		Subnets: result.Space.Subnets,
-	}, nil
+		output = &ReadSpaceOutput{
+			ID:      result.Space.Id,
+			Name:    result.Space.Name,
+			Subnets: result.Space.Subnets,
+		}
+		return nil
+	})
+	return output, err
 }
 
 // ListSpaces lists all spaces in a model.
 func (c *spacesClient) ListSpaces(ctx context.Context, input *ListSpacesInput) ([]ListSpacesOutput, error) {
-	conn, err := c.GetConnection(ctx, &input.ModelUUID)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = conn.Close() }()
-
-	spaceClient := c.getSpacesAPIClient(conn)
-	spaces, err := spaceClient.ListSpaces(ctx)
-	if err != nil {
-		return nil, errors.Annotate(err, "listing spaces")
-	}
-
-	result := make([]ListSpacesOutput, len(spaces))
-	for i, space := range spaces {
-		result[i] = ListSpacesOutput{
-			ID:      space.Id,
-			Name:    space.Name,
-			Subnets: space.Subnets,
+	var result []ListSpacesOutput
+	err := withConnection(ctx, c.SharedClient, &input.ModelUUID, func(conn api.Connection) error {
+		spaceClient := c.getSpacesAPIClient(conn)
+		spaces, err := spaceClient.ListSpaces(ctx)
+		if err != nil {
+			return errors.Annotate(err, "listing spaces")
 		}
-	}
 
-	return result, nil
+		result = make([]ListSpacesOutput, len(spaces))
+		for i, space := range spaces {
+			result[i] = ListSpacesOutput{
+				ID:      space.Id,
+				Name:    space.Name,
+				Subnets: space.Subnets,
+			}
+		}
+
+		return nil
+	})
+	return result, err
 }
 
 // DeleteSpace removes a space.
 func (c *spacesClient) DeleteSpace(ctx context.Context, input *DeleteSpaceInput) error {
-	conn, err := c.GetConnection(ctx, &input.ModelUUID)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = conn.Close() }()
+	return withConnection(ctx, c.SharedClient, &input.ModelUUID, func(conn api.Connection) error {
+		spaceClient := c.getSpacesAPIClient(conn)
 
-	spaceClient := c.getSpacesAPIClient(conn)
-
-	// Due to a Juju bug in 3.6, deleting a space with subnets leaves the subnet "undiscoverable"
-	// and isn't moving them back to the alpha space. As such we manually move all subnets into
-	// alpha before deleting the space.
-	// See issue here https://github.com/juju/juju/issues/22567.
-	if err := moveAllSubnetsToAlpha(ctx, spaceClient, input.Name, c.getSubnetsAPIClient(conn)); err != nil {
-		return err
-	}
-
-	_, err = spaceClient.RemoveSpace(ctx, input.Name, false, false)
-	if err != nil {
-		if strings.Contains(err.Error(), "not found") {
-			err = errors.WithType(err, errors.NotFound)
+		// Due to a Juju bug in 3.6, deleting a space with subnets leaves the subnet "undiscoverable"
+		// and isn't moving them back to the alpha space. As such we manually move all subnets into
+		// alpha before deleting the space.
+		// See issue here https://github.com/juju/juju/issues/22567.
+		if err := moveAllSubnetsToAlpha(ctx, spaceClient, input.Name, c.getSubnetsAPIClient(conn)); err != nil {
+			return err
 		}
-		return errors.Annotate(err, "deleting space")
-	}
 
-	return nil
+		_, err := spaceClient.RemoveSpace(ctx, input.Name, false, false)
+		if err != nil {
+			if strings.Contains(err.Error(), "not found") {
+				err = errors.WithType(err, errors.NotFound)
+			}
+			return errors.Annotate(err, "deleting space")
+		}
+		return nil
+	})
 }
 
 // MoveSubnetToSpace moves one CIDR into the requested space.
@@ -183,37 +171,33 @@ func (c *spacesClient) MoveSubnetToSpace(ctx context.Context, input *MoveSubnetT
 		return errors.NotValidf("cidr")
 	}
 
-	conn, err := c.GetConnection(ctx, &input.ModelUUID)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = conn.Close() }()
+	return withConnection(ctx, c.SharedClient, &input.ModelUUID, func(conn api.Connection) error {
+		subnetsClient := c.getSubnetsAPIClient(conn)
+		subnetResults, err := subnetsClient.SubnetsByCIDR(ctx, []string{input.CIDR})
+		if err != nil {
+			return errors.Annotate(err, "looking up subnet IDs by CIDR")
+		}
 
-	subnetsClient := c.getSubnetsAPIClient(conn)
-	subnetResults, err := subnetsClient.SubnetsByCIDR(ctx, []string{input.CIDR})
-	if err != nil {
-		return errors.Annotate(err, "looking up subnet IDs by CIDR")
-	}
+		// Find the CIDR in the returned list, we expect 1 result
+		subnetID, err := findSubnetIDByCIDR(subnetResults, input.CIDR)
+		if err != nil {
+			return err
+		}
 
-	// Find the CIDR in the returned list, we expect 1 result
-	subnetID, err := findSubnetIDByCIDR(subnetResults, input.CIDR)
-	if err != nil {
-		return err
-	}
+		subnetTags := []names.SubnetTag{names.NewSubnetTag(subnetID)}
 
-	subnetTags := []names.SubnetTag{names.NewSubnetTag(subnetID)}
-
-	spaceClient := c.getSpacesAPIClient(conn)
-	_, err = spaceClient.MoveSubnets(
-		ctx,
-		names.NewSpaceTag(input.SpaceName),
-		subnetTags,
-		false,
-	)
-	if err != nil {
-		return errors.Annotate(err, "moving subnets")
-	}
-	return nil
+		spaceClient := c.getSpacesAPIClient(conn)
+		_, err = spaceClient.MoveSubnets(
+			ctx,
+			names.NewSpaceTag(input.SpaceName),
+			subnetTags,
+			false,
+		)
+		if err != nil {
+			return errors.Annotate(err, "moving subnets")
+		}
+		return nil
+	})
 }
 
 func findSubnetIDByCIDR(subnetResults []params.SubnetsResult, cidr string) (string, error) {

--- a/internal/juju/sshKeys.go
+++ b/internal/juju/sshKeys.go
@@ -86,147 +86,138 @@ func newSSHKeysClient(sc SharedClient) *sshKeysClient {
 func (c *sshKeysClient) CreateSSHKey(ctx context.Context, input *CreateSSHKeyInput) error {
 	c.KeyLock.Lock()
 	defer c.KeyLock.Unlock()
-	conn, err := c.GetConnection(ctx, &input.ModelUUID)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = conn.Close() }()
+	return withConnection(ctx, c.SharedClient, &input.ModelUUID, func(conn api.Connection) error {
+		client := c.getKeyManagerClient(conn)
 
-	client := c.getKeyManagerClient(conn)
-
-	// NOTE: In Juju 3.6 ssh keys are not associated with user - they are global per model. We pass in
-	// the logged-in user for completeness. In Juju 4 ssh keys will be associated with users.
-	params, err := client.AddKeys(ctx, input.Username, input.Payload)
-	if err != nil {
-		return err
-	}
-	if len(params) != 0 {
-		messages := make([]string, 0)
-		for _, e := range params {
-			if e.Error != nil {
-				messages = append(messages, e.Error.Message)
+		// NOTE: In Juju 3.6 ssh keys are not associated with user - they are global per model. We pass in
+		// the logged-in user for completeness. In Juju 4 ssh keys will be associated with users.
+		params, err := client.AddKeys(ctx, input.Username, input.Payload)
+		if err != nil {
+			return err
+		}
+		if len(params) != 0 {
+			messages := make([]string, 0)
+			for _, e := range params {
+				if e.Error != nil {
+					messages = append(messages, e.Error.Message)
+				}
 			}
+			if len(messages) == 0 {
+				return nil
+			}
+			err = fmt.Errorf("%s", messages)
+			return err
 		}
-		if len(messages) == 0 {
-			return nil
-		}
-		err = fmt.Errorf("%s", messages)
-		return err
-	}
 
-	return nil
+		return nil
+	})
 }
 
 // ReadSSHKey retrieves an SSH key by identifier.
 func (c *sshKeysClient) ReadSSHKey(ctx context.Context, input *ReadSSHKeyInput) (*ReadSSHKeyOutput, error) {
 	c.KeyLock.RLock()
 	defer c.KeyLock.RUnlock()
-	conn, err := c.GetConnection(ctx, &input.ModelUUID)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = conn.Close() }()
+	var output *ReadSSHKeyOutput
+	err := withConnection(ctx, c.SharedClient, &input.ModelUUID, func(conn api.Connection) error {
+		client := keymanager.NewClient(conn)
 
-	client := keymanager.NewClient(conn)
+		// NOTE: In Juju 3.6 ssh keys are not associated with user - they are global per model. We pass in
+		// the logged-in user for completeness. In Juju 4 ssh keys are associated with users.
+		returnedKeys, err := client.ListKeys(ctx, jujussh.FullKeys, input.Username)
+		if err != nil {
+			return err
+		}
 
-	// NOTE: In Juju 3.6 ssh keys are not associated with user - they are global per model. We pass in
-	// the logged-in user for completeness. In Juju 4 ssh keys are associated with users.
-	returnedKeys, err := client.ListKeys(ctx, jujussh.FullKeys, input.Username)
-	if err != nil {
-		return nil, err
-	}
+		inputKey, _, err := jujussh.KeyFingerprint(input.Payload)
+		if err != nil {
+			return fmt.Errorf("error getting fingerprint for input ssh key: %w", err)
+		}
 
-	inputKey, _, err := jujussh.KeyFingerprint(input.Payload)
-	if err != nil {
-		return nil, fmt.Errorf("error getting fingerprint for input ssh key: %w", err)
-	}
-
-	for _, res := range returnedKeys {
-		for _, k := range res.Result {
-			fingerprint, _, err := jujussh.KeyFingerprint(k)
-			if err != nil {
-				return nil, fmt.Errorf("error getting fingerprint for ssh key: %w", err)
-			}
-			if inputKey == fingerprint {
-				return &ReadSSHKeyOutput{
-					Payload: k,
-				}, nil
+		for _, res := range returnedKeys {
+			for _, k := range res.Result {
+				fingerprint, _, err := jujussh.KeyFingerprint(k)
+				if err != nil {
+					return fmt.Errorf("error getting fingerprint for ssh key: %w", err)
+				}
+				if inputKey == fingerprint {
+					output = &ReadSSHKeyOutput{
+						Payload: k,
+					}
+					return nil
+				}
 			}
 		}
-	}
 
-	return nil, NewSSHKeyNotFoundError(input.Payload)
+		return NewSSHKeyNotFoundError(input.Payload)
+	})
+	return output, err
 }
 
 // DeleteSSHKey removes an SSH key from the specified model.
 func (c *sshKeysClient) DeleteSSHKey(ctx context.Context, input *DeleteSSHKeyInput) error {
 	c.KeyLock.Lock()
 	defer c.KeyLock.Unlock()
-	conn, err := c.GetConnection(ctx, &input.ModelUUID)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = conn.Close() }()
+	return withConnection(ctx, c.SharedClient, &input.ModelUUID, func(conn api.Connection) error {
+		client := c.getKeyManagerClient(conn)
+		isJIMMController := c.IsJAAS(ctx, false)
 
-	client := c.getKeyManagerClient(conn)
-	isJIMMController := c.IsJAAS(ctx, false)
-
-	controllerVersion := semversion.Number{}
-	if !isJIMMController {
-		controllerVersion, err = c.GetControllerVersion(ctx)
-		if err != nil {
-			return err
-		}
-	}
-
-	deleteKeyIdentifiers, err := sshKeyDeleteIdentifiers(input.Payload, controllerVersion, isJIMMController)
-	if err != nil {
-		return fmt.Errorf("generating delete identifiers for ssh key: %w", err)
-	}
-
-	// NOTE: In Juju 3.6 ssh keys are not associated with user - they are global per model. We pass in
-	// the logged-in user for completeness. In Juju 4, keys are associated per user per model, but note, it isn't the user passed in
-	// via the user argument but rather the API authenticated user.
-	params, err := client.DeleteKeys(ctx, input.Username, deleteKeyIdentifiers...)
-	if len(params) != 0 {
-		messages := make([]string, 0, len(params))
-		// Return an error if all the results are errors.
-		for _, e := range params {
-			if e.Error == nil {
-				// if any delete was successful, we consider the process a success.
-				return nil
+		controllerVersion := semversion.Number{}
+		if !isJIMMController {
+			var err error
+			controllerVersion, err = c.GetControllerVersion(ctx)
+			if err != nil {
+				return err
 			}
-			messages = append(messages, e.Error.Message)
 		}
-		return fmt.Errorf("%s", strings.Join(messages, "; "))
-	}
-	return err
+
+		deleteKeyIdentifiers, err := sshKeyDeleteIdentifiers(input.Payload, controllerVersion, isJIMMController)
+		if err != nil {
+			return fmt.Errorf("generating delete identifiers for ssh key: %w", err)
+		}
+
+		// NOTE: In Juju 3.6 ssh keys are not associated with user - they are global per model. We pass in
+		// the logged-in user for completeness. In Juju 4, keys are associated per user per model, but note, it isn't the user passed in
+		// via the user argument but rather the API authenticated user.
+		params, err := client.DeleteKeys(ctx, input.Username, deleteKeyIdentifiers...)
+		if len(params) != 0 {
+			messages := make([]string, 0, len(params))
+			// Return an error if all the results are errors.
+			for _, e := range params {
+				if e.Error == nil {
+					// if any delete was successful, we consider the process a success.
+					return nil
+				}
+				messages = append(messages, e.Error.Message)
+			}
+			return fmt.Errorf("%s", strings.Join(messages, "; "))
+		}
+		return err
+	})
 }
 
 // ListKeys returns the authorised ssh keys for the specified users.
 func (c *sshKeysClient) ListKeys(ctx context.Context, input ListSSHKeysInput) ([]string, error) {
-	conn, err := c.GetConnection(ctx, &input.ModelUUID)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = conn.Close() }()
+	var keys []string
+	err := withConnection(ctx, c.SharedClient, &input.ModelUUID, func(conn api.Connection) error {
+		client := c.getKeyManagerClient(conn)
 
-	client := c.getKeyManagerClient(conn)
+		// NOTE: In Juju 3.6 ssh keys are not associated with user - they are global per model. We pass in
+		// the logged-in user for completeness. In Juju 4 ssh keys will be associated with users.
+		results, err := client.ListKeys(ctx, jujussh.FullKeys, input.Username)
+		if err != nil {
+			return err
+		}
 
-	// NOTE: In Juju 3.6 ssh keys are not associated with user - they are global per model. We pass in
-	// the logged-in user for completeness. In Juju 4 ssh keys will be associated with users.
-	results, err := client.ListKeys(ctx, jujussh.FullKeys, input.Username)
-	if err != nil {
-		return nil, err
-	}
+		// Incase this looks strange, the Juju CLI does the same and takes [0].
+		result := results[0]
+		if result.Error != nil {
+			return result.Error
+		}
 
-	// Incase this looks strange, the Juju CLI does the same and takes [0].
-	result := results[0]
-	if result.Error != nil {
-		return nil, result.Error
-	}
-
-	return result.Result, nil
+		keys = result.Result
+		return nil
+	})
+	return keys, err
 }
 
 // sshKeyDeleteIdentifiers generates a list of identifiers to attempt to delete the SSH key with, based on the

--- a/internal/juju/storage.go
+++ b/internal/juju/storage.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/client/storage"
 	"github.com/juju/juju/rpc/params"
 )
@@ -73,83 +74,69 @@ func newStorageClient(sc SharedClient) *storageClient {
 
 // CreatePool creates pool with specified parameters.
 func (c *storageClient) CreatePool(ctx context.Context, input CreateStoragePoolInput) error {
-	conn, err := c.GetConnection(ctx, &input.ModelUUID)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = conn.Close() }()
+	return withConnection(ctx, c.SharedClient, &input.ModelUUID, func(conn api.Connection) error {
+		client := storage.NewClient(conn)
 
-	client := storage.NewClient(conn)
-
-	return client.CreatePool(ctx, input.PoolName, input.Provider, input.Attrs)
+		return client.CreatePool(ctx, input.PoolName, input.Provider, input.Attrs)
+	})
 }
 
 // UpdatePool updates a pool with specified parameters.
 func (c *storageClient) UpdatePool(ctx context.Context, modeluuid, pname, provider string, attrs map[string]interface{}) error {
-	conn, err := c.GetConnection(ctx, &modeluuid)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = conn.Close() }()
+	return withConnection(ctx, c.SharedClient, &modeluuid, func(conn api.Connection) error {
+		client := storage.NewClient(conn)
 
-	client := storage.NewClient(conn)
-
-	return client.UpdatePool(ctx, pname, provider, attrs)
+		return client.UpdatePool(ctx, pname, provider, attrs)
+	})
 }
 
 // RemovePool removes the named pool.
 func (c *storageClient) RemovePool(ctx context.Context, input RemoveStoragePoolInput) error {
-	conn, err := c.GetConnection(ctx, &input.ModelUUID)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = conn.Close() }()
+	return withConnection(ctx, c.SharedClient, &input.ModelUUID, func(conn api.Connection) error {
+		client := storage.NewClient(conn)
 
-	client := storage.NewClient(conn)
-
-	return client.RemovePool(ctx, input.PoolName)
+		return client.RemovePool(ctx, input.PoolName)
+	})
 }
 
 // GetPool gets a pool by name.
 func (c *storageClient) GetPool(ctx context.Context, input GetStoragePoolInput) (GetStoragePoolResponse, error) {
-	conn, err := c.GetConnection(ctx, &input.ModelUUID)
-	if err != nil {
-		return GetStoragePoolResponse{}, err
-	}
-	defer func() { _ = conn.Close() }()
+	var out GetStoragePoolResponse
+	err := withConnection(ctx, c.SharedClient, &input.ModelUUID, func(conn api.Connection) error {
+		client := storage.NewClient(conn)
 
-	client := storage.NewClient(conn)
+		pools, err := client.ListPools(ctx, []string{}, []string{input.PoolName})
+		if err != nil {
+			return err
+		}
+		if len(pools) == 0 {
+			return ErrStoragePoolNotFound
+		}
 
-	pools, err := client.ListPools(ctx, []string{}, []string{input.PoolName})
-	if err != nil {
-		return GetStoragePoolResponse{}, err
-	}
-	if len(pools) == 0 {
-		return GetStoragePoolResponse{}, ErrStoragePoolNotFound
-	}
-
-	return GetStoragePoolResponse{Pool: pools[0]}, nil
+		out = GetStoragePoolResponse{Pool: pools[0]}
+		return nil
+	})
+	return out, err
 }
 
 // ListPools lists pools, optionally filtered by provider and/or name.
 func (c *storageClient) ListPools(ctx context.Context, input ListStoragePoolsInput) ([]ListStoragePoolsOutput, error) {
-	conn, err := c.GetConnection(ctx, &input.ModelUUID)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = conn.Close() }()
+	var out []ListStoragePoolsOutput
+	err := withConnection(ctx, c.SharedClient, &input.ModelUUID, func(conn api.Connection) error {
+		client := storage.NewClient(conn)
 
-	client := storage.NewClient(conn)
+		pools, err := client.ListPools(ctx, input.Providers, input.Names)
+		if err != nil {
+			return err
+		}
 
-	pools, err := client.ListPools(ctx, input.Providers, input.Names)
-	if err != nil {
-		return nil, err
-	}
+		result := make([]ListStoragePoolsOutput, 0, len(pools))
+		for _, pool := range pools {
+			result = append(result, ListStoragePoolsOutput{Pool: pool})
+		}
 
-	result := make([]ListStoragePoolsOutput, 0, len(pools))
-	for _, pool := range pools {
-		result = append(result, ListStoragePoolsOutput{Pool: pool})
-	}
-
-	return result, nil
+		out = result
+		return nil
+	})
+	return out, err
 }

--- a/internal/juju/subnets.go
+++ b/internal/juju/subnets.go
@@ -68,57 +68,54 @@ func newSubnetsClient(sc SharedClient) *subnetsClient {
 
 // ListSubnets fetches all model subnets matching optional space/zone filters.
 func (c *subnetsClient) ListSubnets(ctx context.Context, input *ListSubnetsInput) ([]SubnetInfo, error) {
-	conn, err := c.GetConnection(ctx, &input.ModelUUID)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = conn.Close() }()
+	var result []SubnetInfo
+	err := withConnection(ctx, c.SharedClient, &input.ModelUUID, func(conn api.Connection) error {
+		var spaceTag *names.SpaceTag
+		if input.SpaceName != "" {
+			tag := names.NewSpaceTag(input.SpaceName)
+			spaceTag = &tag
+		}
 
-	var spaceTag *names.SpaceTag
-	if input.SpaceName != "" {
-		tag := names.NewSpaceTag(input.SpaceName)
-		spaceTag = &tag
-	}
+		subnetsClient := c.getSubnetsAPIClient(conn)
+		subnets, err := subnetsClient.ListSubnets(ctx, spaceTag, input.Zone)
+		if err != nil {
+			return errors.Annotate(err, "listing subnets")
+		}
 
-	subnetsClient := c.getSubnetsAPIClient(conn)
-	subnets, err := subnetsClient.ListSubnets(ctx, spaceTag, input.Zone)
-	if err != nil {
-		return nil, errors.Annotate(err, "listing subnets")
-	}
+		result = make([]SubnetInfo, len(subnets))
+		for i, subnet := range subnets {
+			result[i] = subnetFromParamsSubnet(subnet)
+		}
 
-	result := make([]SubnetInfo, len(subnets))
-	for i, subnet := range subnets {
-		result[i] = subnetFromParamsSubnet(subnet)
-	}
-
-	return result, nil
+		return nil
+	})
+	return result, err
 }
 
 // ReadSubnet fetches a single subnet by CIDR.
 func (c *subnetsClient) ReadSubnet(ctx context.Context, input *ReadSubnetInput) (*SubnetInfo, error) {
-	conn, err := c.GetConnection(ctx, &input.ModelUUID)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = conn.Close() }()
-
-	subnetsClient := c.getSubnetsAPIClient(conn)
-	results, err := subnetsClient.SubnetsByCIDR(ctx, []string{input.CIDR})
-	if err != nil {
-		return nil, errors.Annotate(err, "reading subnet")
-	}
-	if len(results) == 0 {
-		return nil, NewSubnetNotFoundError(input.CIDR)
-	}
-
-	for _, subnet := range results[0].Subnets {
-		if subnet.CIDR != input.CIDR {
-			continue
+	var output *SubnetInfo
+	err := withConnection(ctx, c.SharedClient, &input.ModelUUID, func(conn api.Connection) error {
+		subnetsClient := c.getSubnetsAPIClient(conn)
+		results, err := subnetsClient.SubnetsByCIDR(ctx, []string{input.CIDR})
+		if err != nil {
+			return errors.Annotate(err, "reading subnet")
 		}
-		info := subnetFromParamsSubnetV2(subnet)
-		return &info, nil
-	}
-	return nil, NewSubnetNotFoundError(input.CIDR)
+		if len(results) == 0 {
+			return NewSubnetNotFoundError(input.CIDR)
+		}
+
+		for _, subnet := range results[0].Subnets {
+			if subnet.CIDR != input.CIDR {
+				continue
+			}
+			info := subnetFromParamsSubnetV2(subnet)
+			output = &info
+			return nil
+		}
+		return NewSubnetNotFoundError(input.CIDR)
+	})
+	return output, err
 }
 
 func subnetFromParamsSubnet(subnet params.Subnet) SubnetInfo {

--- a/internal/juju/users.go
+++ b/internal/juju/users.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/client/usermanager"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/names/v6"
@@ -66,108 +67,98 @@ func newUsersClient(sc SharedClient) *usersClient {
 
 // CreateUser creates a new user.
 func (c *usersClient) CreateUser(ctx context.Context, input CreateUserInput) (*CreateUserResponse, error) {
-	conn, err := c.GetConnection(ctx, nil)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = conn.Close() }()
+	var out *CreateUserResponse
+	err := withConnection(ctx, c.SharedClient, nil, func(conn api.Connection) error {
+		client := usermanager.NewClient(conn)
 
-	client := usermanager.NewClient(conn)
+		userTag, userSecret, err := client.AddUser(ctx, input.Name, input.DisplayName, input.Password)
+		if err != nil {
+			return err
+		}
 
-	userTag, userSecret, err := client.AddUser(ctx, input.Name, input.DisplayName, input.Password)
-	if err != nil {
-		return nil, err
-	}
-
-	return &CreateUserResponse{UserTag: userTag, Secret: userSecret}, nil
+		out = &CreateUserResponse{UserTag: userTag, Secret: userSecret}
+		return nil
+	})
+	return out, err
 }
 
 // ReadUser retrieves details for the named user.
 func (c *usersClient) ReadUser(ctx context.Context, name string) (*ReadUserResponse, error) {
-	usermanagerConn, err := c.GetConnection(ctx, nil)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = usermanagerConn.Close() }()
+	var out *ReadUserResponse
+	err := withConnection(ctx, c.SharedClient, nil, func(usermanagerConn api.Connection) error {
+		usermanagerClient := usermanager.NewClient(usermanagerConn)
 
-	usermanagerClient := usermanager.NewClient(usermanagerConn)
+		users, err := usermanagerClient.UserInfo(ctx, []string{name}, usermanager.IncludeDisabled(false)) //don't list disabled users
+		if err != nil {
+			return err
+		}
 
-	users, err := usermanagerClient.UserInfo(ctx, []string{name}, usermanager.IncludeDisabled(false)) //don't list disabled users
-	if err != nil {
-		return nil, err
-	}
+		if len(users) > 1 {
+			return fmt.Errorf("more than one user returned for user name: %s", name)
+		}
+		if len(users) < 1 {
+			return fmt.Errorf("no user returned for user name: %s", name)
+		}
 
-	if len(users) > 1 {
-		return nil, fmt.Errorf("more than one user returned for user name: %s", name)
-	}
-	if len(users) < 1 {
-		return nil, fmt.Errorf("no user returned for user name: %s", name)
-	}
+		userInfo := users[0]
 
-	userInfo := users[0]
-
-	return &ReadUserResponse{
-		UserInfo: userInfo,
-	}, nil
+		out = &ReadUserResponse{
+			UserInfo: userInfo,
+		}
+		return nil
+	})
+	return out, err
 }
 
 // ModelUserInfo lists users and access for the specified model.
 func (c *usersClient) ModelUserInfo(ctx context.Context, modelUUID string) (*ReadModelUserResponse, error) {
-	usermanagerConn, err := c.GetConnection(ctx, nil)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = usermanagerConn.Close() }()
-	usermanagerClient := usermanager.NewClient(usermanagerConn)
+	var out *ReadModelUserResponse
+	err := withConnection(ctx, c.SharedClient, nil, func(usermanagerConn api.Connection) error {
+		usermanagerClient := usermanager.NewClient(usermanagerConn)
 
-	users, err := usermanagerClient.ModelUserInfo(ctx, modelUUID)
-	if err != nil {
-		return nil, err
-	}
+		users, err := usermanagerClient.ModelUserInfo(ctx, modelUUID)
+		if err != nil {
+			return err
+		}
 
-	if len(users) < 1 {
-		return nil, fmt.Errorf("no users returned for model (%s)", modelUUID)
-	}
+		if len(users) < 1 {
+			return fmt.Errorf("no users returned for model (%s)", modelUUID)
+		}
 
-	return &ReadModelUserResponse{
-		ModelUserInfo: users,
-	}, nil
+		out = &ReadModelUserResponse{
+			ModelUserInfo: users,
+		}
+		return nil
+	})
+	return out, err
 }
 
 // UpdateUser updates user fields such as password.
 func (c *usersClient) UpdateUser(ctx context.Context, input UpdateUserInput) error {
-	conn, err := c.GetConnection(ctx, nil)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = conn.Close() }()
+	return withConnection(ctx, c.SharedClient, nil, func(conn api.Connection) error {
+		client := usermanager.NewClient(conn)
 
-	client := usermanager.NewClient(conn)
-
-	if input.Password != "" {
-		err = client.SetPassword(ctx, input.Name, input.Password)
-		if err != nil {
-			return err
+		if input.Password != "" {
+			err := client.SetPassword(ctx, input.Name, input.Password)
+			if err != nil {
+				return err
+			}
 		}
-	}
 
-	return nil
+		return nil
+	})
 }
 
 // DestroyUser removes a user.
 func (c *usersClient) DestroyUser(ctx context.Context, input DestroyUserInput) error {
-	conn, err := c.GetConnection(ctx, nil)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = conn.Close() }()
+	return withConnection(ctx, c.SharedClient, nil, func(conn api.Connection) error {
+		client := usermanager.NewClient(conn)
 
-	client := usermanager.NewClient(conn)
+		err := client.RemoveUser(ctx, input.Name)
+		if err != nil {
+			return err
+		}
 
-	err = client.RemoveUser(ctx, input.Name)
-	if err != nil {
-		return err
-	}
-
-	return nil
+		return nil
+	})
 }


### PR DESCRIPTION
## Description

Replace the repeated GetConnection + `defer conn.Close()` pattern across the internal/juju clients with a single withConnection helper. Close errors are now logged via Errorf instead of being discarded, and the helper guarantees the connection is closed (fixing a leak in DeleteSecret that never closed its connection).

## Type of change

- Other (please describe): refactoring
