### PR TITLE
feat: add secret_uri to secret data source

### DIFF
--- a/docs-rtd/howto/manage-secrets.md
+++ b/docs-rtd/howto/manage-secrets.md
@@ -27,7 +27,14 @@ data "juju_secret" "my_secret_data_source" {
 }
 ```
 
-> See more: [`juju_offer` (data source)](../reference/terraform-provider/data-sources/offer)
+The data source exposes two attributes for referencing the secret:
+
+- `secret_id` — the bare secret ID (e.g. `coj8mulh8b41e8nv6p90`).
+- `secret_uri` — the full URI form (e.g. `secret:coj8mulh8b41e8nv6p90`), which is what Juju requires when passing a secret as a charm configuration value.
+
+When setting a charm config option, it's more convenient to use `secret_uri`. This avoids having to prepend `"secret:"` to `secret_id`.
+
+> See more: [`juju_secret` (data source)](../reference/terraform-provider/data-sources/secret)
 
 
 ## Add a secret

--- a/docs-rtd/reference/terraform-provider/data-sources/secret.md
+++ b/docs-rtd/reference/terraform-provider/data-sources/secret.md
@@ -31,7 +31,7 @@ resource "juju_application" "ubuntu" {
   }
 
   config = {
-    secret = data.juju_secret.my_secret_data_source.secret_id
+    secret = data.juju_secret.my_secret_data_source.secret_uri
   }
 }
 
@@ -54,4 +54,5 @@ resource "juju_access_secret" "my_secret_access" {
 
 ### Read-Only
 
-- `secret_id` (String) The ID of the secret.
+- `secret_id` (String) The ID of the secret. E.g. coj8mulh8b41e8nv6p90
+- `secret_uri` (String) The URI of the secret. E.g. secret:coj8mulh8b41e8nv6p90

--- a/docs/data-sources/secret.md
+++ b/docs/data-sources/secret.md
@@ -54,5 +54,5 @@ resource "juju_access_secret" "my_secret_access" {
 
 ### Read-Only
 
-- `secret_id` (String) The ID of the secret.
-- `secret_uri` (String) The URI of the secret.
+- `secret_id` (String) The ID of the secret. E.g. coj8mulh8b41e8nv6p90
+- `secret_uri` (String) The URI of the secret. E.g. secret:coj8mulh8b41e8nv6p90

--- a/docs/data-sources/secret.md
+++ b/docs/data-sources/secret.md
@@ -31,7 +31,7 @@ resource "juju_application" "ubuntu" {
   }
 
   config = {
-    secret = data.juju_secret.my_secret_data_source.secret_id
+    secret = data.juju_secret.my_secret_data_source.secret_uri
   }
 }
 
@@ -55,3 +55,4 @@ resource "juju_access_secret" "my_secret_access" {
 ### Read-Only
 
 - `secret_id` (String) The ID of the secret.
+- `secret_uri` (String) The URI of the secret.

--- a/examples/data-sources/juju_secret/data-source.tf
+++ b/examples/data-sources/juju_secret/data-source.tf
@@ -16,7 +16,7 @@ resource "juju_application" "ubuntu" {
   }
 
   config = {
-    secret = data.juju_secret.my_secret_data_source.secret_id
+    secret = data.juju_secret.my_secret_data_source.secret_uri
   }
 }
 

--- a/internal/provider/data_source_secrets.go
+++ b/internal/provider/data_source_secrets.go
@@ -41,6 +41,8 @@ type secretDataSourceModel struct {
 	Name types.String `tfsdk:"name"`
 	// SecretId is the ID of the secret.
 	SecretId types.String `tfsdk:"secret_id"`
+	// SecretURI is the URI of the secret e.g. `secret:coj8mulh8b41e8nv6p90`.
+	SecretURI types.String `tfsdk:"secret_uri"`
 }
 
 // Metadata returns the full data source name as used in terraform plans.
@@ -65,7 +67,11 @@ func (d *secretDataSource) Schema(_ context.Context, _ datasource.SchemaRequest,
 				Required:    true,
 			},
 			"secret_id": schema.StringAttribute{
-				Description: "The ID of the secret.",
+				Description: "The ID of the secret. E.g. coj8mulh8b41e8nv6p90",
+				Computed:    true,
+			},
+			"secret_uri": schema.StringAttribute{
+				Description: "The URI of the secret. E.g. secret:coj8mulh8b41e8nv6p90",
 				Computed:    true,
 			},
 		},
@@ -126,6 +132,7 @@ func (d *secretDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 	d.trace(fmt.Sprintf("read secret data source %q", data.SecretId))
 
 	data.SecretId = types.StringValue(readSecretOutput.SecretId)
+	data.SecretURI = types.StringValue(readSecretOutput.SecretURI)
 
 	// Save state into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/internal/provider/data_source_secrets_test.go
+++ b/internal/provider/data_source_secrets_test.go
@@ -39,7 +39,8 @@ func TestAcc_DataSourceSecret(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair("data.juju_secret.secret_data_source", "model_uuid", "juju_model."+modelName, "uuid"),
 					resource.TestCheckResourceAttr("data.juju_secret.secret_data_source", "name", secretName),
-					resource.TestCheckResourceAttrPair("data.juju_secret.secret_data_source", "secretID", "juju_secret.secret_resource", "secretID"),
+					resource.TestCheckResourceAttrPair("data.juju_secret.secret_data_source", "secret_id", "juju_secret.secret_resource", "secret_id"),
+					resource.TestCheckResourceAttrPair("data.juju_secret.secret_data_source", "secret_uri", "juju_secret.secret_resource", "secret_uri"),
 				),
 			},
 		},


### PR DESCRIPTION
## Description

Adds secret_uri as a computed attribute to the juju_secret data source, matching the attribute on the resource.

Without this, users referencing a data-source secret as a charm config value had to manually prepend `"secret:" to the secret_id.


## Type of change

- Change existing resource
- Change in tests (one or several tests have been changed)
- Requires a documentation update

## QA steps

```tf
terraform {
  required_providers {
    juju = {
      source  = "juju/juju"
      version = "2.1"
    }
  }
}

provider "juju" {}

resource "juju_model" "qa" {
  name = "qa-secret-uri"
}

resource "juju_secret" "my_secret" {
  model_uuid = juju_model.qa.uuid
  name       = "my-secret"
  value = {
    key = "supersecret"
  }
}

data "juju_secret" "my_secret" {
  model_uuid = juju_model.qa.uuid
  name       = "my-secret"

  depends_on = [juju_secret.my_secret]
}

output "secret_id" {
  value = data.juju_secret.my_secret.secret_id
}

output "secret_uri" {
  value = data.juju_secret.my_secret.secret_uri
}
```

Run:
1. terraform init
2. terraform apply
3. terraform output

Check that the output has the expected prefix and lack thereof, like:
```
secret_id = "b2sen7jv6ouhtbqnin90"
secret_uri = "secret:b2sen7jv6ouhtbqnin90"
```

