### PR TITLE
test: remove TestAcc_ResourceOffer test skip

### DIFF
--- a/internal/provider/resource_offer_test.go
+++ b/internal/provider/resource_offer_test.go
@@ -12,14 +12,6 @@ import (
 )
 
 func TestAcc_ResourceOffer(t *testing.T) {
-	t.Skip(`See https://github.com/juju/juju/issues/22238.
-	
-	Removing test step 1 i.e. config 'testAccResourceOffer' makes the test pass.
-	Removing test step 2 i.e. config 'testAccResourceOfferXIntegration' makes the test pass.
-	
-	Running both steps together causes the test to fail. Keeping this test as-is but marking
-	as skipped to allow for investigation into the underlying issue.`)
-
 	if testingCloud != LXDCloudTesting {
 		t.Skip(t.Name() + " only runs with LXD")
 	}


### PR DESCRIPTION
## Description

This PR removes a test skip for `TestAcc_ResourceOffer` now that the referenced issue is resolved.
The only remaining skip due to a Juju issue is `TestAcc_CharmUpdateBase` which states, `Waiting on issue 21717 for LXD, and PR 22237 for K8s to be resolved`.