### PR TITLE
fix: testing's CompareVersions

### DIFF
--- a/internal/testing/versioncomparer.go
+++ b/internal/testing/versioncomparer.go
@@ -4,34 +4,23 @@
 package testing
 
 import (
-	"strconv"
-	"strings"
+	version "github.com/juju/version/v2"
 )
 
-// CompareVersions compares two versions in the format "X.Y.Z" and returns:
+// CompareVersions compares two Juju versions and returns:
 // -1 if version1 is less than version2
 // 0 if version1 is equal to version2
 // 1 if version1 is greater than version2
 func CompareVersions(version1, version2 string) int {
-	v1Parts := strings.Split(version1, ".")
-	v2Parts := strings.Split(version2, ".")
-
-	for i := 0; i < 3; i++ {
-		v1, err := strconv.Atoi(v1Parts[i])
-		if err != nil {
-			panic(err)
-		}
-		v2, err := strconv.Atoi(v2Parts[i])
-		if err != nil {
-			panic(err)
-		}
-
-		if v1 < v2 {
-			return -1
-		} else if v1 > v2 {
-			return 1
-		}
+	v1, err := version.Parse(version1)
+	if err != nil {
+		panic(err)
 	}
 
-	return 0
+	v2, err := version.Parse(version2)
+	if err != nil {
+		panic(err)
+	}
+
+	return v1.Compare(v2)
 }

--- a/internal/testing/versioncomparer_test.go
+++ b/internal/testing/versioncomparer_test.go
@@ -1,0 +1,65 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the Apache License, Version 2.0, see LICENCE file for details.
+
+package testing
+
+import goTesting "testing"
+
+func TestCompareVersions(t *goTesting.T) {
+	testCases := []struct {
+		name     string
+		version1 string
+		version2 string
+		expected int
+	}{
+		{
+			name:     "equal stable versions",
+			version1: "4.0.12",
+			version2: "4.0.12",
+			expected: 0,
+		},
+		{
+			name:     "stable less than stable",
+			version1: "4.0.12",
+			version2: "4.1.0",
+			expected: -1,
+		},
+		{
+			name:     "prerelease less than stable",
+			version1: "4.1-beta1",
+			version2: "4.1.0",
+			expected: -1,
+		},
+		{
+			name:     "stable greater than prerelease",
+			version1: "4.1.0",
+			version2: "4.1-beta1",
+			expected: 1,
+		},
+		{
+			name:     "later prerelease greater than earlier stable minor",
+			version1: "4.1-beta1",
+			version2: "4.0.12",
+			expected: 1,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *goTesting.T) {
+			result := CompareVersions(tc.version1, tc.version2)
+			if result != tc.expected {
+				t.Fatalf("expected %d, got %d", tc.expected, result)
+			}
+		})
+	}
+}
+
+func TestCompareVersionsPanicsOnInvalidVersion(t *goTesting.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected panic for invalid version")
+		}
+	}()
+
+	CompareVersions("4.1.0-beta1", "4.1.0")
+}


### PR DESCRIPTION
## Description

Fix testing's CompareVersions to handle beta channel versions.

## Type of change

- Change in tests (one or several tests have been changed)
- Bug fix (non-breaking change which fixes an issue)

## Environment

- Juju controller version: `4.1-beta1`

## QA steps

Run `TestAcc_ResourceApplication`.