### PR TITLE
Docs migrate 023

### DIFF
--- a/docs-rtd/.sphinx/_static/js/overwrite_links.js
+++ b/docs-rtd/.sphinx/_static/js/overwrite_links.js
@@ -1,0 +1,37 @@
+// Replace oldDomain with newDomain
+const oldDomain = 'canonical-terraform-provider-juju-1.readthedocs-hosted.com';
+const newDomain = 'canonical.com/juju/docs/terraform-provider-juju';
+
+function escapeRegExp(value) {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function overwriteMatchingAnchorUrls(container) {
+    if (!container) return;
+
+    const anchors = container.querySelectorAll('a[href], link[href]');
+    const oldDomainRegex = new RegExp(escapeRegExp(oldDomain), 'g');
+
+    anchors.forEach(anchor => {
+        anchor.href = anchor.href.replace(oldDomainRegex, newDomain);
+    });
+}
+
+overwriteMatchingAnchorUrls(document.querySelector('header'));
+
+// Use a MutationObserver to wait for the RTD flyout element to appear in the DOM
+const observer = new MutationObserver(function(mutations, obs) {
+    const rtdFlyout = document.querySelector('readthedocs-flyout');
+    if (!rtdFlyout) return;
+
+    obs.disconnect();
+
+    rtdFlyout.addEventListener('click', function() {
+        const shadowRoot = rtdFlyout.shadowRoot;
+        if (!shadowRoot) return;
+
+        overwriteMatchingAnchorUrls(shadowRoot);
+    });
+});
+
+observer.observe(document.body, { childList: true, subtree: true });

--- a/docs-rtd/.sphinx/_templates/header.html
+++ b/docs-rtd/.sphinx/_templates/header.html
@@ -1,5 +1,28 @@
 <header id="header" class="p-navigation">
 
+
+  </script>
+
+  <!-- Google Tag Manager -->
+  <script>
+    (function(w, d, s, l, i) {
+      w[l] = w[l] || [];
+      w[l].push({
+        'gtm.start': new Date().getTime(),
+        event: 'gtm.js'
+      });
+      var f = d.getElementsByTagName(s)[0];
+      var j = d.createElement(s);
+      var dl = '';
+      if (l != 'dataLayer') {
+          dl = '&l=' + l;
+      }
+      j.async = true;
+      j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
+      f.parentNode.insertBefore(j, f);
+    })(window, document, 'script', 'dataLayer', 'GTM-KNX3CJC');
+  </script>
+
   <div class="p-navigation__nav" role="menubar">
 
     <ul class="p-navigation__links" role="menu">

--- a/docs-rtd/conf.py
+++ b/docs-rtd/conf.py
@@ -322,6 +322,10 @@ rediraffe_redirects = "redirects.txt"
 
 exclude_patterns = [
     "doc-cheat-sheet*",
+    "_build",
+    ".venv",
+    ".sphinx/venv",
+    ".sphinx/.doctrees",
 ]
 
 # Adds custom CSS files, located under 'html_static_path'

--- a/docs-rtd/conf.py
+++ b/docs-rtd/conf.py
@@ -181,11 +181,7 @@ html_baseurl = f'https://canonical.com/juju/docs/terraform-provider-juju/{versio
 # URL scheme. Add language and version scheme elements.
 # When configured with RTD variables, check for RTD environment so manual runs succeed:
 
-if 'READTHEDOCS_VERSION' in os.environ:
-    version = os.environ["READTHEDOCS_VERSION"]
-    sitemap_url_scheme = '{version}{link}'
-else:
-    sitemap_url_scheme = 'MANUAL/{link}'
+sitemap_url_scheme = '{link}'
 
 sitemap_filename = "doc-sitemap.xml"
 

--- a/docs-rtd/conf.py
+++ b/docs-rtd/conf.py
@@ -71,7 +71,8 @@ copyright = "%s CC-BY-SA, %s" % (datetime.date.today().year, author)
 # NOTE: The Open Graph Protocol (OGP) enhances page display in a social graph
 #       and is used by social media platforms; see https://ogp.me/
 
-ogp_site_url = "https://canonical-terraform-provider-juju.readthedocs-hosted.com/"
+version_slug = f"{os.environ.get('READTHEDOCS_VERSION', 'local')}"
+ogp_site_url = f"https://canonical.com/juju/docs/terraform-provider-juju/{version_slug}/"
 
 
 # Preview name of the documentation website
@@ -167,7 +168,7 @@ html_context = {
 # TODO: If your documentation is hosted on https://docs.ubuntu.com/,
 #       uncomment and update as needed.
 
-slug = 'terraform-provider-juju'
+slug = 'juju/docs/terraform-provider-juju'
 
 #######################
 # Sitemap configuration: https://sphinx-sitemap.readthedocs.io/
@@ -175,7 +176,7 @@ slug = 'terraform-provider-juju'
 
 # Base URL of RTD hosted project
 
-html_baseurl = 'https://documentation.ubuntu.com/terraform-provider-juju/'
+html_baseurl = f'https://canonical.com/juju/docs/terraform-provider-juju/{version_slug}/'
 
 # URL scheme. Add language and version scheme elements.
 # When configured with RTD variables, check for RTD environment so manual runs succeed:
@@ -185,6 +186,8 @@ if 'READTHEDOCS_VERSION' in os.environ:
     sitemap_url_scheme = '{version}{link}'
 else:
     sitemap_url_scheme = 'MANUAL/{link}'
+
+sitemap_filename = "doc-sitemap.xml"
 
 # Include `lastmod` dates in the sitemap:
 
@@ -334,6 +337,7 @@ html_css_files = [
 # Adds custom JavaScript files, located under 'html_static_path'
 html_js_files = [
 	'js/bundle.js',
+	'js/overwrite_links.js',
 ]
 
 # Specifies a reST snippet to be appended to each .rst file

--- a/docs-rtd/howto/manage-models.md
+++ b/docs-rtd/howto/manage-models.md
@@ -161,7 +161,7 @@ This means that, if you modify your plan in a way that causes recreation of the 
 
 Migrating models to a JAAS environment requires some updates to your Terraform plan when cross-model relations are involved, even if both models in the relation are migrated.
 
-When a model is migrated to JAAS, the model's name and offer URLs will change. The JAAS documention on [model management](https://documentation.ubuntu.com/jaas/latest/howto/manage-models/) provides more detail.
+When a model is migrated to JAAS, the model's name and offer URLs will change. The JAAS documentation on [model management](https://documentation.ubuntu.com/jaas/latest/howto/manage-models/) provides more detail.
 
 Our recommended way of resolving your Terraform state for this scenario is described below.
 
@@ -219,7 +219,7 @@ To resolve this error we suggest one of 2 options:
 
 The simplest solution is to recreate the relation. Replace the URL in the data source with the new offer URL and allow Terraform to recreate the relation. Note that issue https://github.com/juju/juju/issues/20630 highlights a bug that causes issues for integrations on migrated models.
 
-If the application cannot tolerate any downtime, we suggest modifying the plan to hardcode the offer URL into the integration resource and recreate the relation during a maintenance window.
+If the application cannot tolerate any downtime, we suggest modifying the plan to hard-code the offer URL into the integration resource and recreate the relation during a maintenance window.
 
 Example:
 

--- a/docs-rtd/index.md
+++ b/docs-rtd/index.md
@@ -75,6 +75,6 @@ The Terraform Provider for Juju is a member of the Ubuntu family. It’s an open
 
 * [Contribute](https://github.com/juju/terraform-provider-juju/blob/main/CONTRIBUTING.md)
 
-* [Visit our careers page](https://juju.is/careers)
+* [Visit our careers page](https://canonical.com/careers/engineering)
 
 Thinking about using Juju for your next project? [Get in touch!](https://canonical.com/contact-us)


### PR DESCRIPTION
Part of our docs migration to canonical.com/juju/docs/terraform-provider-juju

For reference see https://canonical-rtd-proxy.readthedocs-hosted.com/how-to/migrate/ 

PS The changes to the content files are small typo fixes to help the CI tests pass.