### PR TITLE
feat: add model upgrade support

### DIFF
--- a/.github/workflows/test_integration_jaas.yaml
+++ b/.github/workflows/test_integration_jaas.yaml
@@ -42,10 +42,10 @@ jobs:
       fail-fast: false
       matrix:
         jaas:
-          - jimm_version: v3.3.26
+          - jimm_version: v3.4.0
             juju_channel: 3/stable
             label: "jimm-3-juju-3"
-          - jimm_version: v3.4.0-alpha3
+          - jimm_version: v4.0.0-alpha
             juju_channel: 4.0/edge
             label: "jimm-4-juju-4"
     timeout-minutes: 90

--- a/docs-rtd/reference/terraform-provider/resources/model.md
+++ b/docs-rtd/reference/terraform-provider/resources/model.md
@@ -42,6 +42,7 @@ resource "juju_model" "this" {
 
 ### Optional
 
+- `agent_version` (String) The model's Juju agent version. This is computed from the controller and can be set on an existing model to request an upgrade.
 - `annotations` (Map of String) Annotations for the model
 - `cloud` (Block List) Juju Cloud where the model will operate. Changing this value will cause the model to be destroyed and recreated by terraform. (see [below for nested schema](#nestedblock--cloud))
 - `config` (Map of String) Override default model configuration

--- a/docs/resources/model.md
+++ b/docs/resources/model.md
@@ -42,6 +42,7 @@ resource "juju_model" "this" {
 
 ### Optional
 
+- `agent_version` (String) The model's Juju agent version. This is computed from the controller and can be set on an existing model to request an upgrade.
 - `annotations` (Map of String) Annotations for the model
 - `cloud` (Block List) Juju Cloud where the model will operate. Changing this value will cause the model to be destroyed and recreated by terraform. (see [below for nested schema](#nestedblock--cloud))
 - `config` (Map of String) Override default model configuration

--- a/internal/juju/models.go
+++ b/internal/juju/models.go
@@ -16,8 +16,10 @@ import (
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/client/modelconfig"
 	"github.com/juju/juju/api/client/modelmanager"
+	"github.com/juju/juju/api/client/modelupgrader"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/model"
+	"github.com/juju/juju/core/semversion"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/names/v6"
 )
@@ -480,6 +482,19 @@ func (c *modelsClient) UpdateModel(ctx context.Context, input UpdateModelInput) 
 	}
 
 	return nil
+}
+
+// UpgradeModel upgrades the model identified by modelUUID to targetVersion.
+func (c *modelsClient) UpgradeModel(ctx context.Context, modelUUID string, targetVersion semversion.Number) error {
+	conn, err := c.GetConnection(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = conn.Close() }()
+
+	client := modelupgrader.NewClient(conn)
+	_, err = client.UpgradeModel(ctx, modelUUID, targetVersion, "", false, false)
+	return err
 }
 
 // DestroyModel removes the model identified by the input UUID.

--- a/internal/provider/modifier_model_agent_version.go
+++ b/internal/provider/modifier_model_agent_version.go
@@ -1,0 +1,42 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the Apache License, Version 2.0, see LICENCE file for details.
+
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+// AgentVersionCreateOnlyModifier blocks agent_version from being configured
+// during model creation while still allowing updates on existing resources.
+func AgentVersionCreateOnlyModifier() planmodifier.String {
+	return agentVersionCreateOnlyModifier{}
+}
+
+type agentVersionCreateOnlyModifier struct{}
+
+func (m agentVersionCreateOnlyModifier) Description(_ context.Context) string {
+	return "Prevents agent_version from being configured when creating a model"
+}
+
+func (m agentVersionCreateOnlyModifier) MarkdownDescription(_ context.Context) string {
+	return "Prevents `agent_version` from being configured when creating a model"
+}
+
+func (m agentVersionCreateOnlyModifier) PlanModifyString(_ context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	if !req.State.Raw.IsNull() {
+		return
+	}
+
+	if req.ConfigValue.IsNull() {
+		return
+	}
+
+	resp.Diagnostics.AddAttributeError(
+		req.Path,
+		"Invalid agent_version for model creation",
+		"agent_version cannot be set when creating a model. Juju creates new models at the controller version; set this attribute only after the model exists to request an upgrade.",
+	)
+}

--- a/internal/provider/modifier_model_agent_version.go
+++ b/internal/provider/modifier_model_agent_version.go
@@ -17,14 +17,17 @@ func AgentVersionCreateOnlyModifier() planmodifier.String {
 
 type agentVersionCreateOnlyModifier struct{}
 
+// Description returns a description of the modifier.
 func (m agentVersionCreateOnlyModifier) Description(_ context.Context) string {
 	return "Prevents agent_version from being configured when creating a model"
 }
 
+// MarkdownDescription returns a markdown description of the modifier.
 func (m agentVersionCreateOnlyModifier) MarkdownDescription(_ context.Context) string {
 	return "Prevents `agent_version` from being configured when creating a model"
 }
 
+// PlanModifyString modifies the plan for a string attribute.
 func (m agentVersionCreateOnlyModifier) PlanModifyString(_ context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
 	if !req.State.Raw.IsNull() {
 		return

--- a/internal/provider/resource_model.go
+++ b/internal/provider/resource_model.go
@@ -26,6 +26,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/juju/clock"
 	"github.com/juju/juju/core/constraints"
+	"github.com/juju/juju/core/semversion"
+	envconfig "github.com/juju/juju/environs/config"
 	"github.com/juju/names/v5"
 
 	"github.com/juju/terraform-provider-juju/internal/juju"
@@ -60,6 +62,7 @@ type modelResourceModel struct {
 	Annotations      types.Map    `tfsdk:"annotations"`
 	Credential       types.String `tfsdk:"credential"`
 	Type             types.String `tfsdk:"type"`
+	AgentVersion     types.String `tfsdk:"agent_version"`
 	UUID             types.String `tfsdk:"uuid"`
 	// ID required by the testing framework
 	ID types.String `tfsdk:"id"`
@@ -141,6 +144,15 @@ func (r *modelResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 				Description: "Type of the model. Set by the Juju's API server",
 				Computed:    true,
 				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"agent_version": schema.StringAttribute{
+				Description: "The model's Juju agent version. This is computed from the controller and can be set on an existing model to request an upgrade.",
+				Optional:    true,
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					AgentVersionCreateOnlyModifier(),
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
@@ -338,6 +350,26 @@ func (r *modelResource) Create(ctx context.Context, req resource.CreateRequest, 
 	plan.Credential = types.StringValue(response.CloudCredentialName)
 	plan.Type = types.StringValue(response.Type)
 	plan.UUID = types.StringValue(response.UUID)
+
+	// Avoid returning early below, since we already created
+	// the model and should save it to state.
+	modelResponse, err := r.client.Models.ReadModel(ctx, response.UUID)
+	if err != nil {
+		resp.Diagnostics.AddWarning(
+			"Unable to read model agent_version",
+			fmt.Sprintf("Model %q was created, but agent_version could not be read from model config: %s", modelName, err),
+		)
+		plan.AgentVersion = types.StringNull()
+	} else {
+		plan.AgentVersion, err = modelAgentVersionFromConfig(modelResponse.ModelConfig)
+		if err != nil {
+			resp.Diagnostics.AddWarning(
+				"Unable to read model agent_version",
+				fmt.Sprintf("Model %q was created, but agent_version could not be read from model config: %s", modelName, err),
+			)
+			plan.AgentVersion = types.StringNull()
+		}
+	}
 	plan.ID = types.StringValue(response.UUID)
 
 	r.trace(fmt.Sprintf("model resource created: %q", modelName))
@@ -424,6 +456,11 @@ func (r *modelResource) Read(ctx context.Context, req resource.ReadRequest, resp
 		if resp.Diagnostics.HasError() {
 			return
 		}
+	}
+	state.AgentVersion, err = modelAgentVersionFromConfig(response.ModelConfig)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read model agent_version, got error: %s", err))
+		return
 	}
 
 	annotations, err := r.client.Annotations.GetAnnotations(ctx, &juju.GetAnnotationsInput{
@@ -522,6 +559,20 @@ func (r *modelResource) Update(ctx context.Context, req resource.UpdateRequest, 
 		}
 	}
 
+	var targetAgentVersion *semversion.Number
+	if !plan.AgentVersion.Equal(state.AgentVersion) {
+		parsedVersion, err := semversion.Parse(plan.AgentVersion.ValueString())
+		if err != nil {
+			resp.Diagnostics.AddAttributeError(
+				path.Root("agent_version"),
+				"Invalid agent_version value",
+				fmt.Sprintf("Unable to parse model agent_version %q: %s", plan.AgentVersion.ValueString(), err),
+			)
+			return
+		}
+		targetAgentVersion = &parsedVersion
+	}
+
 	if modelUpdate {
 		var clouds []nestedCloud
 		resp.Diagnostics.Append(plan.Cloud.ElementsAs(ctx, &clouds, false)...)
@@ -549,6 +600,16 @@ func (r *modelResource) Update(ctx context.Context, req resource.UpdateRequest, 
 		}
 
 		r.trace(fmt.Sprintf("Updated model resource: %q", plan.Name.ValueString()))
+	}
+
+	if targetAgentVersion != nil {
+		err = r.client.Models.UpgradeModel(ctx, plan.UUID.ValueString(), *targetAgentVersion)
+		if err != nil {
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to upgrade model to agent version %q, got error: %s", plan.AgentVersion.ValueString(), err))
+			return
+		}
+
+		r.trace(fmt.Sprintf("Upgraded model %q to agent version %q", plan.Name.ValueString(), plan.AgentVersion.ValueString()))
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
@@ -621,6 +682,20 @@ func handleModelNotFoundError(ctx context.Context, err error, st *tfsdk.State) d
 	var diags diag.Diagnostics
 	diags.AddError("Client Error", err.Error())
 	return diags
+}
+
+func modelAgentVersionFromConfig(config map[string]interface{}) (types.String, error) {
+	cfg, err := envconfig.New(envconfig.NoDefaults, config)
+	if err != nil {
+		return types.StringNull(), fmt.Errorf("unable to parse model config: %w", err)
+	}
+
+	agentVersion, ok := cfg.AgentVersion()
+	if !ok {
+		return types.StringNull(), nil
+	}
+
+	return types.StringValue(agentVersion.String()), nil
 }
 
 func (r *modelResource) trace(msg string, additionalFields ...map[string]interface{}) {

--- a/internal/provider/resource_model_test.go
+++ b/internal/provider/resource_model_test.go
@@ -6,6 +6,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"os"
 	"regexp"
 	"testing"
 
@@ -21,6 +22,8 @@ import (
 	"github.com/juju/juju/rpc/params"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	internaljuju "github.com/juju/terraform-provider-juju/internal/juju"
 )
 
 var validUUID = regexp.MustCompile(`[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}`)
@@ -383,6 +386,55 @@ func TestAcc_ResourceModel_WaitForDelete(t *testing.T) {
 	})
 }
 
+func TestAcc_ResourceModel_UpgradeAgentVersion(t *testing.T) {
+	SkipAgainstJuju4(t)
+	testAccPreCheck(t)
+
+	targetAgentVersion := os.Getenv(TestJujuAgentVersion)
+	if targetAgentVersion == "" {
+		t.Skipf("%s is not set", TestJujuAgentVersion)
+	}
+
+	modelName := acctest.RandomWithPrefix("tf-test-model")
+	resourceName := "juju_model.model"
+	ctx := t.Context()
+
+	modelResp, err := TestClient.Models.CreateModel(ctx, internaljuju.CreateModelInput{
+		Name:        modelName,
+		CloudName:   testingCloud.CloudName(),
+		CloudRegion: "localhost",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		_ = TestClient.Models.DestroyModel(ctx, internaljuju.DestroyModelInput{UUID: modelResp.UUID})
+	})
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: frameworkProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:             testAccResourceModel(modelName, testingCloud.CloudName(), "INFO"),
+				ImportState:        true,
+				ImportStateId:      modelResp.UUID,
+				ImportStatePersist: true,
+				ResourceName:       resourceName,
+			},
+			{
+				Config: testAccResourceModelWithAgentVersion(modelName, testingCloud.CloudName(), targetAgentVersion),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", modelName),
+					resource.TestMatchResourceAttr(resourceName, "uuid", validUUID),
+					resource.TestCheckResourceAttr(resourceName, "agent_version", targetAgentVersion),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckDevelopmentConfigIsUnset(ctx context.Context, resourceID string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceID]
@@ -438,6 +490,20 @@ resource "juju_model" "model" {
     logging-config = "<root>=%s"
   }
 }`, modelName, cloudName, logLevel)
+}
+
+func testAccResourceModelWithAgentVersion(modelName string, cloudName string, agentVersion string) string {
+	return fmt.Sprintf(`
+resource "juju_model" "model" {
+	name = %q
+
+	cloud {
+	 name   = %q
+	 region = "localhost"
+	}
+
+	agent_version = %q
+}`, modelName, cloudName, agentVersion)
 }
 
 func testAccConstraintsModel(modelName string, cloudName string, constraints string) string {

--- a/internal/provider/resource_model_test.go
+++ b/internal/provider/resource_model_test.go
@@ -395,6 +395,11 @@ func TestAcc_ResourceModel_UpgradeAgentVersion(t *testing.T) {
 		t.Skipf("%s is not set", TestJujuAgentVersion)
 	}
 
+	initialAgentVersion := "3.6.23"
+	if targetAgentVersion == initialAgentVersion {
+		t.Fatalf("%s is set to the same value as the initial agent version (%s), please set it to a different version for testing", TestJujuAgentVersion, initialAgentVersion)
+	}
+
 	modelName := acctest.RandomWithPrefix("tf-test-model")
 	resourceName := "juju_model.model"
 	ctx := t.Context()
@@ -403,14 +408,15 @@ func TestAcc_ResourceModel_UpgradeAgentVersion(t *testing.T) {
 		Name:        modelName,
 		CloudName:   testingCloud.CloudName(),
 		CloudRegion: "localhost",
+		Config: map[string]string{
+			"agent-version": initialAgentVersion,
+		},
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	t.Cleanup(func() {
-		_ = TestClient.Models.DestroyModel(ctx, internaljuju.DestroyModelInput{UUID: modelResp.UUID})
-	})
+	// Skip cleanup since the provider framework will destroy the model.
+	// Destroying it here too will cause a delay failing to connect to the model.
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -422,6 +428,18 @@ func TestAcc_ResourceModel_UpgradeAgentVersion(t *testing.T) {
 				ImportStateId:      modelResp.UUID,
 				ImportStatePersist: true,
 				ResourceName:       resourceName,
+				ImportStateCheck: func(states []*terraform.InstanceState) error {
+					if len(states) != 1 {
+						return fmt.Errorf("expected 1 imported state, got %d", len(states))
+					}
+
+					got := states[0].Attributes["agent_version"]
+					if got != initialAgentVersion {
+						return fmt.Errorf("expected imported agent_version to be %q before upgrade, got %q", initialAgentVersion, got)
+					}
+
+					return nil
+				},
 			},
 			{
 				Config: testAccResourceModelWithAgentVersion(modelName, testingCloud.CloudName(), targetAgentVersion),

--- a/internal/provider/resource_model_test.go
+++ b/internal/provider/resource_model_test.go
@@ -9,11 +9,18 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/juju/juju/api/client/modelconfig"
 	"github.com/juju/juju/rpc/params"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var validUUID = regexp.MustCompile(`[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}`)
@@ -22,6 +29,7 @@ func TestAcc_ResourceModel(t *testing.T) {
 	modelName := acctest.RandomWithPrefix("tf-test-model")
 	logLevelInfo := "INFO"
 	logLevelDebug := "DEBUG"
+	validVersion := regexp.MustCompile(`\d+\.\d+\.\d+`)
 
 	resourceName := "juju_model.model"
 	resource.ParallelTest(t, resource.TestCase{
@@ -34,6 +42,7 @@ func TestAcc_ResourceModel(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", modelName),
 					resource.TestCheckResourceAttr(resourceName, "config.logging-config", fmt.Sprintf("<root>=%s", logLevelInfo)),
 					resource.TestMatchResourceAttr(resourceName, "uuid", validUUID),
+					resource.TestMatchResourceAttr(resourceName, "agent_version", validVersion),
 				),
 			},
 			{
@@ -454,4 +463,54 @@ resource "juju_model" "testmodel" {
 	%q = %q
   }
 }`, modelName, annotationKey, annotationValue)
+}
+
+func TestAgentVersionCreateOnlyModifier(t *testing.T) {
+	tests := []struct {
+		name        string
+		stateRaw    tftypes.Value
+		configValue types.String
+		wantError   bool
+	}{
+		{
+			name:        "create with null config",
+			stateRaw:    tftypes.NewValue(tftypes.String, nil),
+			configValue: types.StringNull(),
+			wantError:   false,
+		},
+		{
+			name:        "create with configured value",
+			stateRaw:    tftypes.NewValue(tftypes.String, nil),
+			configValue: types.StringValue("4.0.0"),
+			wantError:   true,
+		},
+		{
+			name:        "update with configured value",
+			stateRaw:    tftypes.NewValue(tftypes.String, "existing"),
+			configValue: types.StringValue("4.0.0"),
+			wantError:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			modifier := AgentVersionCreateOnlyModifier()
+			request := planmodifier.StringRequest{
+				Path:        path.Root("agent_version"),
+				ConfigValue: tt.configValue,
+				State: tfsdk.State{
+					Raw: tt.stateRaw,
+				},
+			}
+			response := planmodifier.StringResponse{}
+
+			modifier.PlanModifyString(t.Context(), request, &response)
+
+			assert.Equal(t, tt.wantError, response.Diagnostics.HasError())
+			if tt.wantError {
+				require.Len(t, response.Diagnostics.Errors(), 1)
+				assert.Equal(t, "Invalid agent_version for model creation", response.Diagnostics.Errors()[0].Summary())
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Description

This change adds a new field `agent_version` to the model resource. This field tracks the model's agent version and by changing it, supports model upgrades directly from the TF provider. Note that in Juju 3, a user could set the agent version at model creation time i.e. `juju add-model foo --agent-version=...` but in Juju 4 this will not be supported, see https://github.com/juju/juju/issues/22578 so I have made a plan modifier to forbid setting `agent_version` at creation time.

Once the model has been created, the agent_version can be updated if the controller's agent version has changed, triggering a model upgrade. This is particularly tricky to test in our CI as we would need a controller running an N-1 version of Juju. For that reason, I've only added QA steps to this PR. 

Also note that this change does not yet work with Juju 4. The provider connects to the controller API to make the UpgradeModel call but this method was moved to a model scoped call in early Juju 4 and then moved back to a controller level call in https://github.com/juju/juju/pull/22488 due for release in 4.0.12. So rather than supporting both, we simply support the latest path going forward.

Fixes: [JUJU-10038](https://warthogs.atlassian.net/browse/JUJU-10038)

## Type of change

- Change existing resource


## QA steps

Manual QA steps should be done to test this PR.

1. Run `terraform apply` against a Juju 3 controller bootstrapped with `--agent-version=3.6.23`
```tf
provider "juju" {}

resource "juju_model" "model" {
  name = "test-model"
}
```

2. Then upgrade the controller with `juju upgrade-controller`.
3. Update the Terraform plan to specify the agent_version

```tf
resource "juju_model" "model" {
  agent_version = "3.6.24"
  name = "test-model"
}
```

4. Run `terraform apply`
5. Check the model's agent_version with `juju status` or `juju show-model`.


[JUJU-10038]: https://warthogs.atlassian.net/browse/JUJU-10038?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ