### PR TITLE
feat: IdP groups access

### DIFF
--- a/.github/workflows/test_integration_cross_controller_jaas.yml
+++ b/.github/workflows/test_integration_cross_controller_jaas.yml
@@ -42,11 +42,11 @@ jobs:
         uses: docker/setup-compose-action@v1
 
       - name: Setup JAAS
-        uses: canonical/jimm/.github/actions/test-server@feature/juju-4
+        uses: canonical/jimm/.github/actions/test-server@v3
         id: jaas
         with:
-          juju-channel: 4.0/edge
-          jimm-version: v3.4.0-alpha3
+          juju-channel: 4.0/stable
+          jimm-version: v4.0.0-alpha1
           ghcr-pat: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup the main controller

--- a/.github/workflows/test_integration_jaas.yaml
+++ b/.github/workflows/test_integration_jaas.yaml
@@ -45,8 +45,8 @@ jobs:
           - jimm_version: v3.4.1
             juju_channel: 3/stable
             label: "jimm-3-juju-3"
-          - jimm_version: v4.0.0-alpha
-            juju_channel: 4.0/edge
+          - jimm_version: v4.0.0-alpha1
+            juju_channel: 4.0/stable
             label: "jimm-4-juju-4"
     timeout-minutes: 90
     steps:

--- a/.github/workflows/test_integration_jaas.yaml
+++ b/.github/workflows/test_integration_jaas.yaml
@@ -42,7 +42,7 @@ jobs:
       fail-fast: false
       matrix:
         jaas:
-          - jimm_version: v3.4.0
+          - jimm_version: v3.4.1
             juju_channel: 3/stable
             label: "jimm-3-juju-3"
           - jimm_version: v4.0.0-alpha

--- a/.github/workflows/test_integration_jaas.yaml
+++ b/.github/workflows/test_integration_jaas.yaml
@@ -69,7 +69,7 @@ jobs:
         uses: docker/setup-compose-action@v1
       # Starting JAAS will start the JIMM controller and dependencies and create a Juju controller on LXD and connect it to JIMM.
       - name: Setup JAAS
-        uses: canonical/jimm/.github/actions/test-server@feature/juju-4
+        uses: canonical/jimm/.github/actions/test-server@v3
         id: jaas
         with:
           juju-channel: ${{ matrix.jaas.juju_channel }}

--- a/docs-rtd/reference/terraform-provider/resources/jaas_access_cloud.md
+++ b/docs-rtd/reference/terraform-provider/resources/jaas_access_cloud.md
@@ -18,6 +18,7 @@ resource "juju_jaas_access_cloud" "development" {
   access           = "can_addmodel"
   users            = ["foo@domain.com"]
   groups           = [juju_jaas_group.development.uuid]
+  idp_groups       = ["engineering"]
   service_accounts = ["Client-ID-1", "Client-ID-2"]
 }
 ```
@@ -33,6 +34,7 @@ resource "juju_jaas_access_cloud" "development" {
 ### Optional
 
 - `groups` (Set of String) List of groups to grant access. A valid group ID is the group's UUID.
+- `idp_groups` (Set of String) List of identity provider groups to grant access. IdP groups have no provider-side format restriction.
 - `roles` (Set of String) List of roles UUIDs to grant access.
 - `service_accounts` (Set of String) List of service accounts to grant access. A valid service account is the service account's name.
 - `users` (Set of String) List of users to grant access. A valid user is the user's name or email.

--- a/docs-rtd/reference/terraform-provider/resources/jaas_access_controller.md
+++ b/docs-rtd/reference/terraform-provider/resources/jaas_access_controller.md
@@ -17,6 +17,7 @@ resource "juju_jaas_access_controller" "development" {
   access           = "administrator"
   users            = ["foo@domain.com"]
   groups           = [juju_jaas_group.development.uuid]
+  idp_groups       = ["engineering"]
   service_accounts = ["Client-ID-1", "Client-ID-2"]
 }
 ```
@@ -31,6 +32,7 @@ resource "juju_jaas_access_controller" "development" {
 ### Optional
 
 - `groups` (Set of String) List of groups to grant access. A valid group ID is the group's UUID.
+- `idp_groups` (Set of String) List of identity provider groups to grant access. IdP groups have no provider-side format restriction.
 - `roles` (Set of String) List of roles UUIDs to grant access.
 - `service_accounts` (Set of String) List of service accounts to grant access. A valid service account is the service account's name.
 - `users` (Set of String) List of users to grant access. A valid user is the user's name or email.

--- a/docs-rtd/reference/terraform-provider/resources/jaas_access_model.md
+++ b/docs-rtd/reference/terraform-provider/resources/jaas_access_model.md
@@ -18,6 +18,7 @@ resource "juju_jaas_access_model" "development" {
   access           = "administrator"
   users            = ["foo@domain.com"]
   groups           = [juju_jaas_group.development.uuid]
+  idp_groups       = ["engineering"]
   service_accounts = ["Client-ID-1", "Client-ID-2"]
 }
 ```
@@ -33,6 +34,7 @@ resource "juju_jaas_access_model" "development" {
 ### Optional
 
 - `groups` (Set of String) List of groups to grant access. A valid group ID is the group's UUID.
+- `idp_groups` (Set of String) List of identity provider groups to grant access. IdP groups have no provider-side format restriction.
 - `roles` (Set of String) List of roles UUIDs to grant access.
 - `service_accounts` (Set of String) List of service accounts to grant access. A valid service account is the service account's name.
 - `users` (Set of String) List of users to grant access. A valid user is the user's name or email.

--- a/docs-rtd/reference/terraform-provider/resources/jaas_access_offer.md
+++ b/docs-rtd/reference/terraform-provider/resources/jaas_access_offer.md
@@ -18,6 +18,7 @@ resource "juju_jaas_access_offer" "development" {
   access           = "consumer"
   users            = ["foo@domain.com"]
   groups           = [juju_jaas_group.development.uuid]
+  idp_groups       = ["engineering"]
   service_accounts = ["Client-ID-1", "Client-ID-2"]
 }
 ```
@@ -33,6 +34,7 @@ resource "juju_jaas_access_offer" "development" {
 ### Optional
 
 - `groups` (Set of String) List of groups to grant access. A valid group ID is the group's UUID.
+- `idp_groups` (Set of String) List of identity provider groups to grant access. IdP groups have no provider-side format restriction.
 - `roles` (Set of String) List of roles UUIDs to grant access.
 - `service_accounts` (Set of String) List of service accounts to grant access. A valid service account is the service account's name.
 - `users` (Set of String) List of users to grant access. A valid user is the user's name or email.

--- a/docs-rtd/reference/terraform-provider/resources/jaas_access_role.md
+++ b/docs-rtd/reference/terraform-provider/resources/jaas_access_role.md
@@ -18,6 +18,7 @@ resource "juju_jaas_access_role" "development" {
   access           = "assignee"
   users            = ["foo@domain.com"]
   roles            = [juju_jaas_role.development.uuid]
+  idp_groups       = ["engineering"]
   service_accounts = ["Client-ID-1", "Client-ID-2"]
 }
 ```
@@ -33,6 +34,7 @@ resource "juju_jaas_access_role" "development" {
 ### Optional
 
 - `groups` (Set of String) List of groups to grant access. A valid group ID is the group's UUID.
+- `idp_groups` (Set of String) List of identity provider groups to grant access. IdP groups have no provider-side format restriction.
 - `service_accounts` (Set of String) List of service accounts to grant access. A valid service account is the service account's name.
 - `users` (Set of String) List of users to grant access. A valid user is the user's name or email.
 

--- a/docs/resources/jaas_access_cloud.md
+++ b/docs/resources/jaas_access_cloud.md
@@ -18,6 +18,7 @@ resource "juju_jaas_access_cloud" "development" {
   access           = "can_addmodel"
   users            = ["foo@domain.com"]
   groups           = [juju_jaas_group.development.uuid]
+  idp_groups       = ["engineering"]
   service_accounts = ["Client-ID-1", "Client-ID-2"]
 }
 ```
@@ -33,6 +34,7 @@ resource "juju_jaas_access_cloud" "development" {
 ### Optional
 
 - `groups` (Set of String) List of groups to grant access. A valid group ID is the group's UUID.
+- `idp_groups` (Set of String) List of identity provider groups to grant access. IdP groups have no provider-side format restriction.
 - `roles` (Set of String) List of roles UUIDs to grant access.
 - `service_accounts` (Set of String) List of service accounts to grant access. A valid service account is the service account's name.
 - `users` (Set of String) List of users to grant access. A valid user is the user's name or email.

--- a/docs/resources/jaas_access_controller.md
+++ b/docs/resources/jaas_access_controller.md
@@ -17,6 +17,7 @@ resource "juju_jaas_access_controller" "development" {
   access           = "administrator"
   users            = ["foo@domain.com"]
   groups           = [juju_jaas_group.development.uuid]
+  idp_groups       = ["engineering"]
   service_accounts = ["Client-ID-1", "Client-ID-2"]
 }
 ```
@@ -31,6 +32,7 @@ resource "juju_jaas_access_controller" "development" {
 ### Optional
 
 - `groups` (Set of String) List of groups to grant access. A valid group ID is the group's UUID.
+- `idp_groups` (Set of String) List of identity provider groups to grant access. IdP groups have no provider-side format restriction.
 - `roles` (Set of String) List of roles UUIDs to grant access.
 - `service_accounts` (Set of String) List of service accounts to grant access. A valid service account is the service account's name.
 - `users` (Set of String) List of users to grant access. A valid user is the user's name or email.

--- a/docs/resources/jaas_access_model.md
+++ b/docs/resources/jaas_access_model.md
@@ -18,6 +18,7 @@ resource "juju_jaas_access_model" "development" {
   access           = "administrator"
   users            = ["foo@domain.com"]
   groups           = [juju_jaas_group.development.uuid]
+  idp_groups       = ["engineering"]
   service_accounts = ["Client-ID-1", "Client-ID-2"]
 }
 ```
@@ -33,6 +34,7 @@ resource "juju_jaas_access_model" "development" {
 ### Optional
 
 - `groups` (Set of String) List of groups to grant access. A valid group ID is the group's UUID.
+- `idp_groups` (Set of String) List of identity provider groups to grant access. IdP groups have no provider-side format restriction.
 - `roles` (Set of String) List of roles UUIDs to grant access.
 - `service_accounts` (Set of String) List of service accounts to grant access. A valid service account is the service account's name.
 - `users` (Set of String) List of users to grant access. A valid user is the user's name or email.

--- a/docs/resources/jaas_access_offer.md
+++ b/docs/resources/jaas_access_offer.md
@@ -18,6 +18,7 @@ resource "juju_jaas_access_offer" "development" {
   access           = "consumer"
   users            = ["foo@domain.com"]
   groups           = [juju_jaas_group.development.uuid]
+  idp_groups       = ["engineering"]
   service_accounts = ["Client-ID-1", "Client-ID-2"]
 }
 ```
@@ -33,6 +34,7 @@ resource "juju_jaas_access_offer" "development" {
 ### Optional
 
 - `groups` (Set of String) List of groups to grant access. A valid group ID is the group's UUID.
+- `idp_groups` (Set of String) List of identity provider groups to grant access. IdP groups have no provider-side format restriction.
 - `roles` (Set of String) List of roles UUIDs to grant access.
 - `service_accounts` (Set of String) List of service accounts to grant access. A valid service account is the service account's name.
 - `users` (Set of String) List of users to grant access. A valid user is the user's name or email.

--- a/docs/resources/jaas_access_role.md
+++ b/docs/resources/jaas_access_role.md
@@ -18,6 +18,7 @@ resource "juju_jaas_access_role" "development" {
   access           = "assignee"
   users            = ["foo@domain.com"]
   roles            = [juju_jaas_role.development.uuid]
+  idp_groups       = ["engineering"]
   service_accounts = ["Client-ID-1", "Client-ID-2"]
 }
 ```
@@ -33,6 +34,7 @@ resource "juju_jaas_access_role" "development" {
 ### Optional
 
 - `groups` (Set of String) List of groups to grant access. A valid group ID is the group's UUID.
+- `idp_groups` (Set of String) List of identity provider groups to grant access. IdP groups have no provider-side format restriction.
 - `service_accounts` (Set of String) List of service accounts to grant access. A valid service account is the service account's name.
 - `users` (Set of String) List of users to grant access. A valid user is the user's name or email.
 

--- a/examples/resources/juju_jaas_access_cloud/resource.tf
+++ b/examples/resources/juju_jaas_access_cloud/resource.tf
@@ -3,5 +3,6 @@ resource "juju_jaas_access_cloud" "development" {
   access           = "can_addmodel"
   users            = ["foo@domain.com"]
   groups           = [juju_jaas_group.development.uuid]
+  idp_groups       = ["engineering"]
   service_accounts = ["Client-ID-1", "Client-ID-2"]
 }

--- a/examples/resources/juju_jaas_access_controller/resource.tf
+++ b/examples/resources/juju_jaas_access_controller/resource.tf
@@ -2,5 +2,6 @@ resource "juju_jaas_access_controller" "development" {
   access           = "administrator"
   users            = ["foo@domain.com"]
   groups           = [juju_jaas_group.development.uuid]
+  idp_groups       = ["engineering"]
   service_accounts = ["Client-ID-1", "Client-ID-2"]
 }

--- a/examples/resources/juju_jaas_access_model/resource.tf
+++ b/examples/resources/juju_jaas_access_model/resource.tf
@@ -3,5 +3,6 @@ resource "juju_jaas_access_model" "development" {
   access           = "administrator"
   users            = ["foo@domain.com"]
   groups           = [juju_jaas_group.development.uuid]
+  idp_groups       = ["engineering"]
   service_accounts = ["Client-ID-1", "Client-ID-2"]
 }

--- a/examples/resources/juju_jaas_access_offer/resource.tf
+++ b/examples/resources/juju_jaas_access_offer/resource.tf
@@ -3,5 +3,6 @@ resource "juju_jaas_access_offer" "development" {
   access           = "consumer"
   users            = ["foo@domain.com"]
   groups           = [juju_jaas_group.development.uuid]
+  idp_groups       = ["engineering"]
   service_accounts = ["Client-ID-1", "Client-ID-2"]
 }

--- a/examples/resources/juju_jaas_access_role/resource.tf
+++ b/examples/resources/juju_jaas_access_role/resource.tf
@@ -3,5 +3,6 @@ resource "juju_jaas_access_role" "development" {
   access           = "assignee"
   users            = ["foo@domain.com"]
   roles            = [juju_jaas_role.development.uuid]
+  idp_groups       = ["engineering"]
   service_accounts = ["Client-ID-1", "Client-ID-2"]
 }

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 )
 
 require (
-	github.com/canonical/jimm-go-sdk/v3 v3.3.12
+	github.com/canonical/jimm-go-sdk/v3 v3.4.0
 	github.com/dustin/go-humanize v1.0.1
 	github.com/hashicorp/terraform-json v0.27.2
 	github.com/hashicorp/terraform-plugin-framework v1.19.0

--- a/go.sum
+++ b/go.sum
@@ -83,6 +83,8 @@ github.com/canonical/go-dqlite/v3 v3.0.3 h1:JkdMD+f21yuPcS+r6gzO57lBkU5U76xmWyk8
 github.com/canonical/go-dqlite/v3 v3.0.3/go.mod h1:6O+E6MiYesijRUOECyywp16iT+N4QOrvjDWWiMJ/xF0=
 github.com/canonical/jimm-go-sdk/v3 v3.3.12 h1:6/HvibmscAizHoeN28WeB+Gx0OQTlHqOWKXwuZA5arI=
 github.com/canonical/jimm-go-sdk/v3 v3.3.12/go.mod h1:xcJrWTpLHSw3Z16/1Zcvh31awlwIzjXdrYUYCVZhc5s=
+github.com/canonical/jimm-go-sdk/v3 v3.4.0 h1:Ej9MxSMxe1SR00jAsuRlke0vj6C6E0BIkI3wKZ/1Awc=
+github.com/canonical/jimm-go-sdk/v3 v3.4.0/go.mod h1:xcJrWTpLHSw3Z16/1Zcvh31awlwIzjXdrYUYCVZhc5s=
 github.com/canonical/lxd v0.0.0-20251125210512-b190d213bd11 h1:QOyXTFkf5zh/UezMurmpjobnOxefsrHxyYZpl8mfWbs=
 github.com/canonical/lxd v0.0.0-20251125210512-b190d213bd11/go.mod h1:vE1tA6TE1rvEzMcFKUfqh7BMhGH0vlkhYDy4YzeLHbM=
 github.com/canonical/sqlair v0.0.0-20260218132926-bd54c4999dea h1:m9TQ00PXBFNgp11bl7CFz7vnywKEcmWd+o325Ff7PfY=

--- a/internal/provider/resource_access_generic.go
+++ b/internal/provider/resource_access_generic.go
@@ -67,6 +67,7 @@ type objectsWithAccess struct {
 	Users           types.Set    `tfsdk:"users"`
 	ServiceAccounts types.Set    `tfsdk:"service_accounts"`
 	Groups          types.Set    `tfsdk:"groups"`
+	IdPGroups       types.Set    `tfsdk:"idp_groups"`
 	Roles           types.Set    `tfsdk:"roles"`
 	Access          types.String `tfsdk:"access"`
 
@@ -81,6 +82,7 @@ func (r *genericJAASAccessResource) ConfigValidators(ctx context.Context) []reso
 		resourcevalidator.AtLeastOneOf(
 			path.MatchRoot("users"),
 			path.MatchRoot("groups"),
+			path.MatchRoot("idp_groups"),
 			path.MatchRoot("roles"),
 			path.MatchRoot("service_accounts"),
 		),
@@ -251,20 +253,24 @@ func (resource *genericJAASAccessResource) Update(ctx context.Context, req resou
 func diffModels(plan, state objectsWithAccess, diag *diag.Diagnostics) (toAdd, toRemove objectsWithAccess) {
 	newUsers := diffStringSets(plan.Users, state.Users, diag)
 	newGroups := diffStringSets(plan.Groups, state.Groups, diag)
+	newIdPGroups := diffStringSets(plan.IdPGroups, state.IdPGroups, diag)
 	newRoles := diffStringSets(plan.Roles, state.Roles, diag)
 	newServiceAccounts := diffStringSets(plan.ServiceAccounts, state.ServiceAccounts, diag)
 	toAdd.Users = newUsers
 	toAdd.Groups = newGroups
+	toAdd.IdPGroups = newIdPGroups
 	toAdd.Roles = newRoles
 	toAdd.ServiceAccounts = newServiceAccounts
 	toAdd.Access = plan.Access
 
 	removedUsers := diffStringSets(state.Users, plan.Users, diag)
 	removedGroups := diffStringSets(state.Groups, plan.Groups, diag)
+	removedIdPGroups := diffStringSets(state.IdPGroups, plan.IdPGroups, diag)
 	removedRoles := diffStringSets(state.Roles, plan.Roles, diag)
 	removedServiceAccounts := diffStringSets(state.ServiceAccounts, plan.ServiceAccounts, diag)
 	toRemove.Users = removedUsers
 	toRemove.Groups = removedGroups
+	toRemove.IdPGroups = removedIdPGroups
 	toRemove.Roles = removedRoles
 	toRemove.ServiceAccounts = removedServiceAccounts
 	toRemove.Access = plan.Access
@@ -334,11 +340,13 @@ func modelToTuples(ctx context.Context, targetTag names.Tag, model objectsWithAc
 	var (
 		users           []string
 		groups          []string
+		idpGroups       []string
 		roles           []string
 		serviceAccounts []string
 	)
 	diag.Append(getSetIfKnown(ctx, model.Users, &users)...)
 	diag.Append(getSetIfKnown(ctx, model.Groups, &groups)...)
+	diag.Append(getSetIfKnown(ctx, model.IdPGroups, &idpGroups)...)
 	diag.Append(getSetIfKnown(ctx, model.Roles, &roles)...)
 	diag.Append(getSetIfKnown(ctx, model.ServiceAccounts, &serviceAccounts)...)
 	if diag.HasError() {
@@ -348,9 +356,10 @@ func modelToTuples(ctx context.Context, targetTag names.Tag, model objectsWithAc
 		Target:   targetTag.String(),
 		Relation: model.Access.ValueString(),
 	}
-	tuples := make([]juju.JaasTuple, 0, 4)
+	tuples := make([]juju.JaasTuple, 0, 5)
 	userNameToTagf := func(s string) string { return names.NewUserTag(s).String() }
 	groupIDToTagf := func(s string) string { return jimmnames.NewGroupTag(s).String() + "#member" }
+	idPGroupIDToTagf := func(s string) string { return jimmnames.NewIdPGroupTag(s).String() }
 	roleIDToTagf := func(s string) string { return jimmnames.NewRoleTag(s).String() + "#assignee" }
 	// Note that service accounts are treated as users but with an @serviceaccount domain.
 	// We add the @serviceaccount domain by calling `EnsureValidServiceAccountId` so that the user writing the plan doesn't have to.
@@ -361,6 +370,7 @@ func modelToTuples(ctx context.Context, targetTag names.Tag, model objectsWithAc
 	}
 	tuples = append(tuples, assignTupleObject(baseTuple, users, userNameToTagf)...)
 	tuples = append(tuples, assignTupleObject(baseTuple, groups, groupIDToTagf)...)
+	tuples = append(tuples, assignTupleObject(baseTuple, idpGroups, idPGroupIDToTagf)...)
 	tuples = append(tuples, assignTupleObject(baseTuple, roles, roleIDToTagf)...)
 	tuples = append(tuples, assignTupleObject(baseTuple, serviceAccounts, serviceAccIDToTagf)...)
 	return tuples
@@ -371,6 +381,7 @@ func tuplesToModel(ctx context.Context, tuples []juju.JaasTuple, diag *diag.Diag
 	var (
 		users           []string
 		groups          []string
+		idpGroups       []string
 		roles           []string
 		serviceAccounts []string
 	)
@@ -396,6 +407,8 @@ func tuplesToModel(ctx context.Context, tuples []juju.JaasTuple, diag *diag.Diag
 			}
 		case jimmnames.GroupTagKind:
 			groups = append(groups, strings.ReplaceAll(tag.Id(), "#member", ""))
+		case jimmnames.IdPGroupTagKind:
+			idpGroups = append(idpGroups, tag.Id())
 		case jimmnames.RoleTagKind:
 			roles = append(roles, strings.ReplaceAll(tag.Id(), "#assignee", ""))
 		}
@@ -404,6 +417,8 @@ func tuplesToModel(ctx context.Context, tuples []juju.JaasTuple, diag *diag.Diag
 	diag.Append(errDiag...)
 	groupSet, errDiag := basetypes.NewSetValueFrom(ctx, types.StringType, groups)
 	diag.Append(errDiag...)
+	idPGroupSet, errDiag := basetypes.NewSetValueFrom(ctx, types.StringType, idpGroups)
+	diag.Append(errDiag...)
 	roleSet, errDiag := basetypes.NewSetValueFrom(ctx, types.StringType, roles)
 	diag.Append(errDiag...)
 	serviceAccountSet, errDiag := basetypes.NewSetValueFrom(ctx, types.StringType, serviceAccounts)
@@ -411,6 +426,7 @@ func tuplesToModel(ctx context.Context, tuples []juju.JaasTuple, diag *diag.Diag
 	var model objectsWithAccess
 	model.Users = userSet
 	model.Groups = groupSet
+	model.IdPGroups = idPGroupSet
 	model.Roles = roleSet
 	model.ServiceAccounts = serviceAccountSet
 	return model

--- a/internal/provider/resource_access_generic.go
+++ b/internal/provider/resource_access_generic.go
@@ -178,6 +178,7 @@ func (resource *genericJAASAccessResource) Read(ctx context.Context, req resourc
 
 	state.Users = newModel.Users
 	state.Groups = newModel.Groups
+	state.IdPGroups = newModel.IdPGroups
 	state.Roles = newModel.Roles
 	state.ServiceAccounts = newModel.ServiceAccounts
 	state.Access = basetypes.NewStringValue(access)
@@ -359,7 +360,7 @@ func modelToTuples(ctx context.Context, targetTag names.Tag, model objectsWithAc
 	tuples := make([]juju.JaasTuple, 0, 5)
 	userNameToTagf := func(s string) string { return names.NewUserTag(s).String() }
 	groupIDToTagf := func(s string) string { return jimmnames.NewGroupTag(s).String() + "#member" }
-	idPGroupIDToTagf := func(s string) string { return jimmnames.NewIdPGroupTag(s).String() }
+	idPGroupIDToTagf := func(s string) string { return jimmnames.NewIdPGroupTag(s).String() + "#member" }
 	roleIDToTagf := func(s string) string { return jimmnames.NewRoleTag(s).String() + "#assignee" }
 	// Note that service accounts are treated as users but with an @serviceaccount domain.
 	// We add the @serviceaccount domain by calling `EnsureValidServiceAccountId` so that the user writing the plan doesn't have to.
@@ -408,7 +409,7 @@ func tuplesToModel(ctx context.Context, tuples []juju.JaasTuple, diag *diag.Diag
 		case jimmnames.GroupTagKind:
 			groups = append(groups, strings.ReplaceAll(tag.Id(), "#member", ""))
 		case jimmnames.IdPGroupTagKind:
-			idpGroups = append(idpGroups, tag.Id())
+			idpGroups = append(idpGroups, strings.ReplaceAll(tag.Id(), "#member", ""))
 		case jimmnames.RoleTagKind:
 			roles = append(roles, strings.ReplaceAll(tag.Id(), "#assignee", ""))
 		}

--- a/internal/provider/resource_access_generic_schema.go
+++ b/internal/provider/resource_access_generic_schema.go
@@ -45,6 +45,11 @@ func baseAccessSchema() genericSchema {
 				setvalidator.ValueStringsAre(ValidatorMatchString(jimmnames.IsValidGroupId, "group ID must be valid")),
 			},
 		},
+		"idp_groups": schema.SetAttribute{
+			Description: "List of identity provider groups to grant access. IdP groups have no provider-side format restriction.",
+			Optional:    true,
+			ElementType: types.StringType,
+		},
 		"service_accounts": schema.SetAttribute{
 			Description: "List of service accounts to grant access. A valid service account is the service account's name.",
 			Optional:    true,

--- a/internal/provider/resource_access_jaas_cloud.go
+++ b/internal/provider/resource_access_jaas_cloud.go
@@ -42,6 +42,7 @@ func (j cloudInfo) Info(ctx context.Context, getter Getter, diag *diag.Diagnosti
 		ID:              cloudAccess.ID,
 		Users:           cloudAccess.Users,
 		Groups:          cloudAccess.Groups,
+		IdPGroups:       cloudAccess.IdPGroups,
 		Roles:           cloudAccess.Roles,
 		ServiceAccounts: cloudAccess.ServiceAccounts,
 		Access:          cloudAccess.Access,
@@ -61,6 +62,7 @@ func (j cloudInfo) Save(ctx context.Context, setter Setter, info objectsWithAcce
 		ID:              info.ID,
 		Users:           info.Users,
 		Groups:          info.Groups,
+		IdPGroups:       info.IdPGroups,
 		Roles:           info.Roles,
 		ServiceAccounts: info.ServiceAccounts,
 		Access:          info.Access,
@@ -91,6 +93,7 @@ type jaasAccessCloudResourceCloud struct {
 	Users           types.Set    `tfsdk:"users"`
 	ServiceAccounts types.Set    `tfsdk:"service_accounts"`
 	Groups          types.Set    `tfsdk:"groups"`
+	IdPGroups       types.Set    `tfsdk:"idp_groups"`
 	Roles           types.Set    `tfsdk:"roles"`
 	Access          types.String `tfsdk:"access"`
 

--- a/internal/provider/resource_access_jaas_cloud_test.go
+++ b/internal/provider/resource_access_jaas_cloud_test.go
@@ -19,7 +19,8 @@ import (
 )
 
 // This file has bare minimum tests for cloud access
-// verifying that users, service accounts and groups
+// verifying that users, service accounts, groups, roles
+// and IdP groups
 // can access a cloud. More extensive tests for
 // generic jaas access are available in
 // resource_access_jaas_model_test.go
@@ -41,6 +42,7 @@ func TestAcc_ResourceJaasAccessCloud(t *testing.T) {
 	user := "foo@domain.com"
 	group := acctest.RandomWithPrefix("myGroup")
 	role := acctest.RandomWithPrefix("role1")
+	idpGroup := acctest.RandomWithPrefix("idp-group")
 	svcAcc := "test"
 	svcAccWithDomain := svcAcc + "@serviceaccount"
 
@@ -50,11 +52,12 @@ func TestAcc_ResourceJaasAccessCloud(t *testing.T) {
 	roleRelationF := func(s string) string { return jimmnames.NewRoleTag(s).String() + "#assignee" }
 	roleCheck := newCheckAttribute(roleResourcename, "uuid", roleRelationF)
 	userTag := names.NewUserTag(user).String()
+	idpGroupTag := jimmnames.NewIdPGroupTag(idpGroup).String() + "#member"
 	svcAccTag := names.NewUserTag(svcAccWithDomain).String()
 	cloudTag := names.NewCloudTag(cloudName).String()
 
 	// Test 0: Test an invalid access string.
-	// Test 1: Test adding a valid set user, group and service account.
+	// Test 1: Test adding a valid set of users, groups, roles, IdP groups and service accounts.
 	// Test 2: Test importing works.
 	// Destroy: Test access is removed.
 	resource.ParallelTest(t, resource.TestCase{
@@ -64,20 +67,22 @@ func TestAcc_ResourceJaasAccessCloud(t *testing.T) {
 			testAccCheckJaasResourceAccess(ctx, accessSuccess, &userTag, &cloudTag, false),
 			testAccCheckJaasResourceAccess(ctx, accessSuccess, groupCheck.tag, &cloudTag, false),
 			testAccCheckJaasResourceAccess(ctx, accessSuccess, roleCheck.tag, &cloudTag, false),
+			testAccCheckJaasResourceAccess(ctx, accessSuccess, &idpGroupTag, &cloudTag, false),
 			testAccCheckJaasResourceAccess(ctx, accessSuccess, &svcAccTag, &cloudTag, false),
 		),
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccResourceJaasAccessCloud(cloudName, accessFail, user, group, svcAcc, role),
+				Config:      testAccResourceJaasAccessCloud(cloudName, accessFail, user, group, svcAcc, role, idpGroup),
 				ExpectError: regexp.MustCompile(fmt.Sprintf("(?s)unknown.*relation %s", accessFail)),
 			},
 			{
-				Config: testAccResourceJaasAccessCloud(cloudName, accessSuccess, user, group, svcAcc, role),
+				Config: testAccResourceJaasAccessCloud(cloudName, accessSuccess, user, group, svcAcc, role, idpGroup),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAttributeNotEmpty(groupCheck),
 					testAccCheckAttributeNotEmpty(roleCheck),
 					testAccCheckJaasResourceAccess(ctx, accessSuccess, &userTag, &cloudTag, true),
 					testAccCheckJaasResourceAccess(ctx, accessSuccess, groupCheck.tag, &cloudTag, true),
+					testAccCheckJaasResourceAccess(ctx, accessSuccess, &idpGroupTag, &cloudTag, true),
 					testAccCheckJaasResourceAccess(ctx, accessSuccess, &svcAccTag, &cloudTag, true),
 					testAccCheckJaasResourceAccess(ctx, accessSuccess, roleCheck.tag, &cloudTag, true),
 					resource.TestCheckResourceAttr(cloudAccessResourceName, "access", accessSuccess),
@@ -88,6 +93,8 @@ func TestAcc_ResourceJaasAccessCloud(t *testing.T) {
 						return resource.TestCheckTypeSetElemAttr(cloudAccessResourceName, "groups.*", *groupCheck.resourceID)(s)
 					},
 					resource.TestCheckResourceAttr(cloudAccessResourceName, "groups.#", "1"),
+					resource.TestCheckTypeSetElemAttr(cloudAccessResourceName, "idp_groups.*", idpGroup),
+					resource.TestCheckResourceAttr(cloudAccessResourceName, "idp_groups.#", "1"),
 					resource.TestCheckTypeSetElemAttr(cloudAccessResourceName, "service_accounts.*", svcAcc),
 					resource.TestCheckResourceAttr(cloudAccessResourceName, "service_accounts.#", "1"),
 				),
@@ -145,7 +152,7 @@ func TestAcc_ResourceJaasAccessCloudImportState(t *testing.T) {
 	})
 }
 
-func testAccResourceJaasAccessCloud(cloudName, access, user, group, svcAcc, role string) string {
+func testAccResourceJaasAccessCloud(cloudName, access, user, group, svcAcc, role, idpGroup string) string {
 	return internaltesting.GetStringFromTemplateWithData(
 		"testAccResourceJaasAccessCloud",
 		`
@@ -163,15 +170,17 @@ resource "juju_jaas_access_cloud" "test" {
   users               = ["{{.User}}"]
   groups              = [juju_jaas_group.test.uuid]
   roles              = [juju_jaas_role.test.uuid]
+  idp_groups          = ["{{.IdPGroup}}"]
   service_accounts    = ["{{.SvcAcc}}"]
 }
 `, internaltesting.TemplateData{
-			"Cloud":  cloudName,
-			"Access": access,
-			"User":   user,
-			"Group":  group,
-			"Role":   role,
-			"SvcAcc": svcAcc,
+			"Cloud":    cloudName,
+			"Access":   access,
+			"User":     user,
+			"Group":    group,
+			"Role":     role,
+			"SvcAcc":   svcAcc,
+			"IdPGroup": idpGroup,
 		})
 }
 

--- a/internal/provider/resource_access_jaas_controller.go
+++ b/internal/provider/resource_access_jaas_controller.go
@@ -67,6 +67,7 @@ type jaasAccessControllerResourceController struct {
 	Users           types.Set    `tfsdk:"users"`
 	ServiceAccounts types.Set    `tfsdk:"service_accounts"`
 	Groups          types.Set    `tfsdk:"groups"`
+	IdPGroups       types.Set    `tfsdk:"idp_groups"`
 	Roles           types.Set    `tfsdk:"roles"`
 	Access          types.String `tfsdk:"access"`
 

--- a/internal/provider/resource_access_jaas_controller_test.go
+++ b/internal/provider/resource_access_jaas_controller_test.go
@@ -20,7 +20,8 @@ import (
 )
 
 // This file has bare minimum tests for controller access
-// verifying that users, service accounts and groups
+// verifying that users, service accounts, groups, roles
+// and IdP groups
 // can access a controller. More extensive tests for
 // generic jaas access are available in
 // resource_access_jaas_model_test.go
@@ -38,6 +39,7 @@ func TestAcc_ResourceJaasAccessController(t *testing.T) {
 	user := "foo@domain.com"
 	group := acctest.RandomWithPrefix("myGroup")
 	role := acctest.RandomWithPrefix("role1")
+	idpGroup := acctest.RandomWithPrefix("idp-group")
 	svcAcc := "test"
 	svcAccWithDomain := svcAcc + "@serviceaccount"
 
@@ -49,11 +51,12 @@ func TestAcc_ResourceJaasAccessController(t *testing.T) {
 	}
 	roleCheck := newCheckAttribute(roleResourcename, "uuid", roleRelationF)
 	userTag := names.NewUserTag(user).String()
+	idpGroupTag := jimmnames.NewIdPGroupTag(idpGroup).String() + "#member"
 	svcAccTag := names.NewUserTag(svcAccWithDomain).String()
 	controllerTag := names.NewControllerTag("jimm").String()
 
 	// Test 0: Test an invalid access string.
-	// Test 1: Test adding a valid set user, group and service account.
+	// Test 1: Test adding a valid set of users, groups, roles, IdP groups and service accounts.
 	// Test 2: Test importing works.
 	// Destroy: Test access is removed.
 	resource.ParallelTest(t, resource.TestCase{
@@ -63,20 +66,22 @@ func TestAcc_ResourceJaasAccessController(t *testing.T) {
 			testAccCheckJaasResourceAccess(ctx, accessSuccess, &userTag, &controllerTag, false),
 			testAccCheckJaasResourceAccess(ctx, accessSuccess, groupCheck.tag, &controllerTag, false),
 			testAccCheckJaasResourceAccess(ctx, accessSuccess, roleCheck.tag, &controllerTag, false),
+			testAccCheckJaasResourceAccess(ctx, accessSuccess, &idpGroupTag, &controllerTag, false),
 			testAccCheckJaasResourceAccess(ctx, accessSuccess, &svcAccTag, &controllerTag, false),
 		),
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccResourceJaasAccessController(accessFail, user, group, svcAcc, role),
+				Config:      testAccResourceJaasAccessController(accessFail, user, group, svcAcc, role, idpGroup),
 				ExpectError: regexp.MustCompile(fmt.Sprintf("(?s)unknown.*relation %s", accessFail)),
 			},
 			{
-				Config: testAccResourceJaasAccessController(accessSuccess, user, group, svcAcc, role),
+				Config: testAccResourceJaasAccessController(accessSuccess, user, group, svcAcc, role, idpGroup),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAttributeNotEmpty(groupCheck),
 					testAccCheckAttributeNotEmpty(roleCheck),
 					testAccCheckJaasResourceAccess(ctx, accessSuccess, &userTag, &controllerTag, true),
 					testAccCheckJaasResourceAccess(ctx, accessSuccess, groupCheck.tag, &controllerTag, true),
+					testAccCheckJaasResourceAccess(ctx, accessSuccess, &idpGroupTag, &controllerTag, true),
 					testAccCheckJaasResourceAccess(ctx, accessSuccess, &svcAccTag, &controllerTag, true),
 					testAccCheckJaasResourceAccess(ctx, accessSuccess, roleCheck.tag, &controllerTag, true),
 					resource.TestCheckResourceAttr(controllerAccessResourceName, "access", accessSuccess),
@@ -87,6 +92,8 @@ func TestAcc_ResourceJaasAccessController(t *testing.T) {
 						return resource.TestCheckTypeSetElemAttr(controllerAccessResourceName, "groups.*", *groupCheck.resourceID)(s)
 					},
 					resource.TestCheckResourceAttr(controllerAccessResourceName, "groups.#", "1"),
+					resource.TestCheckTypeSetElemAttr(controllerAccessResourceName, "idp_groups.*", idpGroup),
+					resource.TestCheckResourceAttr(controllerAccessResourceName, "idp_groups.#", "1"),
 					resource.TestCheckTypeSetElemAttr(controllerAccessResourceName, "service_accounts.*", svcAcc),
 					resource.TestCheckResourceAttr(controllerAccessResourceName, "service_accounts.#", "1"),
 				),
@@ -144,7 +151,7 @@ func TestAcc_ResourceJaasAccessControllerImportState(t *testing.T) {
 	})
 }
 
-func testAccResourceJaasAccessController(access, user, group, svcAcc, role string) string {
+func testAccResourceJaasAccessController(access, user, group, svcAcc, role, idpGroup string) string {
 	return internaltesting.GetStringFromTemplateWithData(
 		"testAccResourceJaasAccessController",
 		`
@@ -161,14 +168,16 @@ resource "juju_jaas_access_controller" "test" {
   users               = ["{{.User}}"]
   groups              = [juju_jaas_group.test.uuid]
   roles               = [juju_jaas_role.test.uuid]
+  idp_groups          = ["{{.IdPGroup}}"]
   service_accounts    = ["{{.SvcAcc}}"]
 }
 `, internaltesting.TemplateData{
-			"Access": access,
-			"User":   user,
-			"Group":  group,
-			"Role":   role,
-			"SvcAcc": svcAcc,
+			"Access":   access,
+			"User":     user,
+			"Group":    group,
+			"Role":     role,
+			"SvcAcc":   svcAcc,
+			"IdPGroup": idpGroup,
 		})
 }
 

--- a/internal/provider/resource_access_jaas_group.go
+++ b/internal/provider/resource_access_jaas_group.go
@@ -118,6 +118,8 @@ func (r *jaasAccessGroupResource) ConfigValidators(ctx context.Context) []resour
 // Schema defines the schema for the JAAS group access resource.
 func (a *jaasAccessGroupResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	attributes := baseAccessSchema()
+	// IdP groups cannot be granted membership to a regular group.
+	delete(attributes, "idp_groups")
 	attributes["group_id"] = schema.StringAttribute{
 		Description: "The ID of the group for access management. If this is changed the resource will be deleted and a new resource will be created.",
 		Required:    true,

--- a/internal/provider/resource_access_jaas_group_test.go
+++ b/internal/provider/resource_access_jaas_group_test.go
@@ -24,6 +24,9 @@ import (
 // can access a group. More extensive tests for
 // generic jaas access are available in
 // resource_access_jaas_model_test.go
+//
+// IdP groups are intentionally excluded because they cannot be
+// granted membership to a regular group.
 
 func TestAcc_ResourceJaasAccessGroup(t *testing.T) {
 	ctx := t.Context()
@@ -120,6 +123,24 @@ func TestAcc_ResourceJaasAccessGroup(t *testing.T) {
 	})
 }
 
+func TestAcc_ResourceJaasAccessGroupRejectsIdPGroups(t *testing.T) {
+	OnlyTestAgainstJAAS(t)
+
+	groupName := acctest.RandomWithPrefix("group1")
+	idpGroup := acctest.RandomWithPrefix("idp-group")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: frameworkProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccResourceJaasAccessGroupWithIdPGroup(groupName, "member", idpGroup),
+				ExpectError: regexp.MustCompile(`(?s)Unsupported argument.*idp_groups`),
+			},
+		},
+	})
+}
+
 func testAccResourceJaasAccessGroup(groupName, access, groupWithAccess, svcAcc string, users []string) string {
 	usersStr := "[]"
 	if len(users) > 0 {
@@ -149,5 +170,25 @@ resource "juju_jaas_access_group" "test" {
 			"Users":           usersStr,
 			"GroupWithAccess": groupWithAccess,
 			"SvcAcc":          svcAcc,
+		})
+}
+
+func testAccResourceJaasAccessGroupWithIdPGroup(groupName, access, idpGroup string) string {
+	return internaltesting.GetStringFromTemplateWithData(
+		"testAccResourceJaasAccessGroupWithIdPGroup",
+		`
+resource "juju_jaas_group" "test" {
+  name = "{{ .Group }}"
+}
+
+resource "juju_jaas_access_group" "test" {
+  group_id      = juju_jaas_group.test.uuid
+  access        = "{{.Access}}"
+  idp_groups    = ["{{.IdPGroup}}"]
+}
+`, internaltesting.TemplateData{
+			"Group":    groupName,
+			"Access":   access,
+			"IdPGroup": idpGroup,
 		})
 }

--- a/internal/provider/resource_access_jaas_model.go
+++ b/internal/provider/resource_access_jaas_model.go
@@ -42,6 +42,7 @@ func (j modelInfo) Info(ctx context.Context, getter Getter, diag *diag.Diagnosti
 		ID:              modelAccess.ID,
 		Users:           modelAccess.Users,
 		Groups:          modelAccess.Groups,
+		IdPGroups:       modelAccess.IdPGroups,
 		Roles:           modelAccess.Roles,
 		ServiceAccounts: modelAccess.ServiceAccounts,
 		Access:          modelAccess.Access,
@@ -56,6 +57,7 @@ func (j modelInfo) Save(ctx context.Context, setter Setter, info objectsWithAcce
 		ID:              info.ID,
 		Users:           info.Users,
 		Groups:          info.Groups,
+		IdPGroups:       info.IdPGroups,
 		Roles:           info.Roles,
 		ServiceAccounts: info.ServiceAccounts,
 		Access:          info.Access,
@@ -86,6 +88,7 @@ type jaasAccessModelResourceModel struct {
 	Users           types.Set    `tfsdk:"users"`
 	ServiceAccounts types.Set    `tfsdk:"service_accounts"`
 	Groups          types.Set    `tfsdk:"groups"`
+	IdPGroups       types.Set    `tfsdk:"idp_groups"`
 	Roles           types.Set    `tfsdk:"roles"`
 	Access          types.String `tfsdk:"access"`
 

--- a/internal/provider/resource_access_jaas_model_test.go
+++ b/internal/provider/resource_access_jaas_model_test.go
@@ -90,7 +90,7 @@ func TestAcc_ResourceJaasAccessModel(t *testing.T) {
 }
 
 // TestAcc_ResourceJaasAccessModelAllTypes tests that all types
-// i.e. users, groups and services accounts can successfully
+// i.e. users, groups, IdP groups, service accounts and roles can successfully
 // receive access to a model.
 func TestAcc_ResourceJaasAccessModelAllTypes(t *testing.T) {
 	ctx := t.Context()
@@ -108,6 +108,7 @@ func TestAcc_ResourceJaasAccessModelAllTypes(t *testing.T) {
 	svcAccWithDomain := svcAcc + "@serviceaccount"
 	group := acctest.RandomWithPrefix("myGroup")
 	role := acctest.RandomWithPrefix("role1")
+	idpGroup := acctest.RandomWithPrefix("idp-group")
 
 	// Objects for checking access
 	newModelTagF := func(s string) string { return names.NewModelTag(s).String() }
@@ -117,6 +118,7 @@ func TestAcc_ResourceJaasAccessModelAllTypes(t *testing.T) {
 	roleRelationF := func(s string) string { return jimmnames.NewRoleTag(s).String() + "#assignee" }
 	roleCheck := newCheckAttribute(roleResourcename, "uuid", roleRelationF)
 	userTag := names.NewUserTag(user).String()
+	idpGroupTag := jimmnames.NewIdPGroupTag(idpGroup).String() + "#member"
 	svcAccTag := names.NewUserTag(svcAccWithDomain).String()
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -124,18 +126,20 @@ func TestAcc_ResourceJaasAccessModelAllTypes(t *testing.T) {
 		ProtoV6ProviderFactories: frameworkProviderFactories,
 		CheckDestroy: resource.ComposeTestCheckFunc(
 			testAccCheckJaasResourceAccess(ctx, access, &userTag, modelCheck.tag, false),
+			testAccCheckJaasResourceAccess(ctx, access, &idpGroupTag, modelCheck.tag, false),
 			testAccCheckJaasResourceAccess(ctx, access, &svcAccTag, modelCheck.tag, false),
 			testAccCheckJaasResourceAccess(ctx, access, roleCheck.tag, modelCheck.tag, false),
 			testAccCheckJaasResourceAccess(ctx, access, groupCheck.tag, modelCheck.tag, false),
 		),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceJaasAccessModelAllTypes(modelName, access, user, group, svcAcc, role),
+				Config: testAccResourceJaasAccessModelAllTypes(modelName, access, user, group, svcAcc, role, idpGroup),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAttributeNotEmpty(modelCheck),
 					testAccCheckAttributeNotEmpty(roleCheck),
 					testAccCheckAttributeNotEmpty(groupCheck),
 					testAccCheckJaasResourceAccess(ctx, access, &userTag, modelCheck.tag, true),
+					testAccCheckJaasResourceAccess(ctx, access, &idpGroupTag, modelCheck.tag, true),
 					testAccCheckJaasResourceAccess(ctx, access, &svcAccTag, modelCheck.tag, true),
 					testAccCheckJaasResourceAccess(ctx, access, groupCheck.tag, modelCheck.tag, true),
 					testAccCheckJaasResourceAccess(ctx, access, roleCheck.tag, modelCheck.tag, true),
@@ -147,6 +151,8 @@ func TestAcc_ResourceJaasAccessModelAllTypes(t *testing.T) {
 						return resource.TestCheckTypeSetElemAttr(modelResourceName, "groups.*", *groupCheck.resourceID)(s)
 					},
 					resource.TestCheckResourceAttr(modelResourceName, "groups.#", "1"),
+					resource.TestCheckTypeSetElemAttr(modelResourceName, "idp_groups.*", idpGroup),
+					resource.TestCheckResourceAttr(modelResourceName, "idp_groups.#", "1"),
 					resource.TestCheckTypeSetElemAttr(modelResourceName, "service_accounts.*", svcAcc),
 					resource.TestCheckResourceAttr(modelResourceName, "service_accounts.#", "1"),
 				),
@@ -413,7 +419,7 @@ resource "juju_jaas_access_model" "test" {
 		})
 }
 
-func testAccResourceJaasAccessModelAllTypes(modelName, access, user, group, svcAcc, role string) string {
+func testAccResourceJaasAccessModelAllTypes(modelName, access, user, group, svcAcc, role, idpGroup string) string {
 	return internaltesting.GetStringFromTemplateWithData(
 		"testAccResourceJaasAccessModelTwoUsers",
 		`
@@ -434,7 +440,8 @@ resource "juju_jaas_access_model" "test" {
   access              = "{{.Access}}"
   users               = ["{{.User}}"]
   groups              = [juju_jaas_group.test.uuid]
-  roles              = [juju_jaas_role.test.uuid]
+  roles               = [juju_jaas_role.test.uuid]
+  idp_groups          = ["{{.IdPGroup}}"]
   service_accounts    = ["{{.SvcAcc}}"]
 }
 `, internaltesting.TemplateData{
@@ -444,6 +451,7 @@ resource "juju_jaas_access_model" "test" {
 			"User":      user,
 			"SvcAcc":    svcAcc,
 			"Role":      role,
+			"IdPGroup":  idpGroup,
 		})
 }
 

--- a/internal/provider/resource_access_jaas_offer.go
+++ b/internal/provider/resource_access_jaas_offer.go
@@ -42,6 +42,7 @@ func (j offerInfo) Info(ctx context.Context, getter Getter, diag *diag.Diagnosti
 		ID:              offerResource.ID,
 		Users:           offerResource.Users,
 		Groups:          offerResource.Groups,
+		IdPGroups:       offerResource.IdPGroups,
 		Roles:           offerResource.Roles,
 		ServiceAccounts: offerResource.ServiceAccounts,
 		Access:          offerResource.Access,
@@ -61,6 +62,7 @@ func (j offerInfo) Save(ctx context.Context, setter Setter, info objectsWithAcce
 		ID:              info.ID,
 		Users:           info.Users,
 		Groups:          info.Groups,
+		IdPGroups:       info.IdPGroups,
 		Roles:           info.Roles,
 		ServiceAccounts: info.ServiceAccounts,
 		Access:          info.Access,
@@ -88,6 +90,7 @@ type jaasAccessOfferResourceOffer struct {
 	Users           types.Set    `tfsdk:"users"`
 	ServiceAccounts types.Set    `tfsdk:"service_accounts"`
 	Groups          types.Set    `tfsdk:"groups"`
+	IdPGroups       types.Set    `tfsdk:"idp_groups"`
 	Roles           types.Set    `tfsdk:"roles"`
 	Access          types.String `tfsdk:"access"`
 

--- a/internal/provider/resource_access_jaas_offer_test.go
+++ b/internal/provider/resource_access_jaas_offer_test.go
@@ -18,7 +18,8 @@ import (
 )
 
 // This file has bare minimum tests for offer access
-// verifying that users, service accounts and groups
+// verifying that users, service accounts, groups, roles
+// and IdP groups
 // can access an offer. More extensive tests for
 // generic jaas access are available in
 // resource_access_jaas_model_test.go
@@ -37,6 +38,7 @@ func TestAcc_ResourceJaasAccessOffer(t *testing.T) {
 	user := "foo@domain.com"
 	group := acctest.RandomWithPrefix("myGroup")
 	role := acctest.RandomWithPrefix("role1")
+	idpGroup := acctest.RandomWithPrefix("idp-group")
 	svcAcc := "test"
 	svcAccWithDomain := svcAcc + "@serviceaccount"
 
@@ -48,10 +50,11 @@ func TestAcc_ResourceJaasAccessOffer(t *testing.T) {
 	offerRelationF := func(s string) string { return names.NewApplicationOfferTag(s).String() }
 	offerCheck := newCheckAttribute(offerAccessResourceName, "offer_url", offerRelationF)
 	userTag := names.NewUserTag(user).String()
+	idpGroupTag := jimmnames.NewIdPGroupTag(idpGroup).String() + "#member"
 	svcAccTag := names.NewUserTag(svcAccWithDomain).String()
 
 	// Test 0: Test an invalid access string.
-	// Test 1: Test adding a valid set user, group and service account.
+	// Test 1: Test adding a valid set of users, groups, roles, IdP groups and service accounts.
 	// Test 2: Test importing works.
 	// Destroy: Test access is removed.
 	resource.ParallelTest(t, resource.TestCase{
@@ -61,21 +64,23 @@ func TestAcc_ResourceJaasAccessOffer(t *testing.T) {
 			testAccCheckJaasResourceAccess(ctx, accessSuccess, &userTag, offerCheck.tag, false),
 			testAccCheckJaasResourceAccess(ctx, accessSuccess, groupCheck.tag, offerCheck.tag, false),
 			testAccCheckJaasResourceAccess(ctx, accessSuccess, roleCheck.tag, offerCheck.tag, false),
+			testAccCheckJaasResourceAccess(ctx, accessSuccess, &idpGroupTag, offerCheck.tag, false),
 			testAccCheckJaasResourceAccess(ctx, accessSuccess, &svcAccTag, offerCheck.tag, false),
 		),
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccResourceJaasAccessOffer(modelName, accessFail, user, group, svcAcc, role),
+				Config:      testAccResourceJaasAccessOffer(modelName, accessFail, user, group, svcAcc, role, idpGroup),
 				ExpectError: regexp.MustCompile(fmt.Sprintf("(?s)unknown.*relation %s", accessFail)),
 			},
 			{
-				Config: testAccResourceJaasAccessOffer(modelName, accessSuccess, user, group, svcAcc, role),
+				Config: testAccResourceJaasAccessOffer(modelName, accessSuccess, user, group, svcAcc, role, idpGroup),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAttributeNotEmpty(groupCheck),
 					testAccCheckAttributeNotEmpty(roleCheck),
 					testAccCheckAttributeNotEmpty(offerCheck),
 					testAccCheckJaasResourceAccess(ctx, accessSuccess, &userTag, offerCheck.tag, true),
 					testAccCheckJaasResourceAccess(ctx, accessSuccess, groupCheck.tag, offerCheck.tag, true),
+					testAccCheckJaasResourceAccess(ctx, accessSuccess, &idpGroupTag, offerCheck.tag, true),
 					testAccCheckJaasResourceAccess(ctx, accessSuccess, &svcAccTag, offerCheck.tag, true),
 					testAccCheckJaasResourceAccess(ctx, accessSuccess, roleCheck.tag, offerCheck.tag, true),
 					resource.TestCheckResourceAttr(offerAccessResourceName, "access", accessSuccess),
@@ -86,6 +91,8 @@ func TestAcc_ResourceJaasAccessOffer(t *testing.T) {
 						return resource.TestCheckTypeSetElemAttr(offerAccessResourceName, "groups.*", *groupCheck.resourceID)(s)
 					},
 					resource.TestCheckResourceAttr(offerAccessResourceName, "groups.#", "1"),
+					resource.TestCheckTypeSetElemAttr(offerAccessResourceName, "idp_groups.*", idpGroup),
+					resource.TestCheckResourceAttr(offerAccessResourceName, "idp_groups.#", "1"),
 					resource.TestCheckTypeSetElemAttr(offerAccessResourceName, "service_accounts.*", svcAcc),
 					resource.TestCheckResourceAttr(offerAccessResourceName, "service_accounts.#", "1"),
 				),
@@ -99,7 +106,7 @@ func TestAcc_ResourceJaasAccessOffer(t *testing.T) {
 	})
 }
 
-func testAccResourceJaasAccessOffer(modelName, access, user, group, svcAcc, role string) string {
+func testAccResourceJaasAccessOffer(modelName, access, user, group, svcAcc, role, idpGroup string) string {
 	return internaltesting.GetStringFromTemplateWithData(
 		"testAccResourceJaasAccessoffer",
 		`
@@ -137,6 +144,7 @@ resource "juju_jaas_access_offer" "test" {
   users               = ["{{.User}}"]
   groups              = [juju_jaas_group.test.uuid]
   roles              = [juju_jaas_role.test.uuid]
+  idp_groups          = ["{{.IdPGroup}}"]
   service_accounts    = ["{{.SvcAcc}}"]
 }
 `, internaltesting.TemplateData{
@@ -146,5 +154,6 @@ resource "juju_jaas_access_offer" "test" {
 			"Group":     group,
 			"SvcAcc":    svcAcc,
 			"Role":      role,
+			"IdPGroup":  idpGroup,
 		})
 }

--- a/internal/provider/resource_access_jaas_role.go
+++ b/internal/provider/resource_access_jaas_role.go
@@ -45,6 +45,7 @@ func (j roleInfo) Info(ctx context.Context, getter Getter, diag *diag.Diagnostic
 		ID:              roleAccess.ID,
 		Users:           roleAccess.Users,
 		Groups:          roleAccess.Groups,
+		IdPGroups:       roleAccess.IdPGroups,
 		ServiceAccounts: roleAccess.ServiceAccounts,
 		Access:          roleAccess.Access,
 	}
@@ -63,6 +64,7 @@ func (j roleInfo) Save(ctx context.Context, setter Setter, info objectsWithAcces
 		ID:              info.ID,
 		Users:           info.Users,
 		Groups:          info.Groups,
+		IdPGroups:       info.IdPGroups,
 		ServiceAccounts: info.ServiceAccounts,
 		Access:          info.Access,
 	}
@@ -92,6 +94,7 @@ type jaasAccessModelResourceRole struct {
 	Users           types.Set    `tfsdk:"users"`
 	ServiceAccounts types.Set    `tfsdk:"service_accounts"`
 	Groups          types.Set    `tfsdk:"groups"`
+	IdPGroups       types.Set    `tfsdk:"idp_groups"`
 	Access          types.String `tfsdk:"access"`
 
 	// ID required for imports
@@ -110,6 +113,7 @@ func (r *jaasAccessRoleResource) ConfigValidators(ctx context.Context) []resourc
 		resourcevalidator.AtLeastOneOf(
 			path.MatchRoot("users"),
 			path.MatchRoot("groups"),
+			path.MatchRoot("idp_groups"),
 			path.MatchRoot("service_accounts"),
 		),
 	}

--- a/internal/provider/resource_access_jaas_role_test.go
+++ b/internal/provider/resource_access_jaas_role_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 // This file has bare minimum tests for role access
-// verifying that users, service accounts and roles
+// verifying that users, service accounts and IdP groups
 // can access a role. More extensive tests for
 // generic jaas access are available in
 // resource_access_jaas_model_test.go
@@ -34,6 +34,7 @@ func TestAcc_ResourceJaasAccessRole(t *testing.T) {
 	accessFail := "bogus"
 	user := "foo@domain.com"
 	roleOneName := acctest.RandomWithPrefix("role1")
+	idpGroup := acctest.RandomWithPrefix("idp-group")
 	svcAcc := "test"
 	svcAccWithDomain := svcAcc + "@serviceaccount"
 
@@ -41,10 +42,11 @@ func TestAcc_ResourceJaasAccessRole(t *testing.T) {
 	RoleRelationF := func(s string) string { return jimmnames.NewRoleTag(s).String() }
 	roleOneCheck := newCheckAttribute(roleOneResourceName, "uuid", RoleRelationF)
 	UserTag := names.NewUserTag(user).String()
+	idpGroupTag := jimmnames.NewIdPGroupTag(idpGroup).String() + "#member"
 	svcAccTag := names.NewUserTag(svcAccWithDomain).String()
 
 	// Step 0: Test an invalid access string.
-	// Step 1: Test adding a valid set user, role and service account.
+	// Step 1: Test adding a valid set of users, IdP groups and service accounts.
 	// Step 2: Test importing works.
 	// Destroy: Test access is removed.
 	resource.ParallelTest(t, resource.TestCase{
@@ -52,22 +54,26 @@ func TestAcc_ResourceJaasAccessRole(t *testing.T) {
 		ProtoV6ProviderFactories: frameworkProviderFactories,
 		CheckDestroy: resource.ComposeTestCheckFunc(
 			testAccCheckJaasResourceAccess(ctx, accessSuccess, &UserTag, roleOneCheck.tag, false),
+			testAccCheckJaasResourceAccess(ctx, accessSuccess, &idpGroupTag, roleOneCheck.tag, false),
 			testAccCheckJaasResourceAccess(ctx, accessSuccess, &svcAccTag, roleOneCheck.tag, false),
 		),
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccResourceJaasAccessRole(roleOneName, accessFail, user, svcAcc),
+				Config:      testAccResourceJaasAccessRole(roleOneName, accessFail, user, svcAcc, idpGroup),
 				ExpectError: regexp.MustCompile(fmt.Sprintf("(?s)unknown.*relation %s", accessFail)),
 			},
 			{
-				Config: testAccResourceJaasAccessRole(roleOneName, accessSuccess, user, svcAcc),
+				Config: testAccResourceJaasAccessRole(roleOneName, accessSuccess, user, svcAcc, idpGroup),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAttributeNotEmpty(roleOneCheck),
 					testAccCheckJaasResourceAccess(ctx, accessSuccess, &UserTag, roleOneCheck.tag, true),
+					testAccCheckJaasResourceAccess(ctx, accessSuccess, &idpGroupTag, roleOneCheck.tag, true),
 					testAccCheckJaasResourceAccess(ctx, accessSuccess, &svcAccTag, roleOneCheck.tag, true),
 					resource.TestCheckResourceAttr(RoleAccessResourceName, "access", accessSuccess),
 					resource.TestCheckTypeSetElemAttr(RoleAccessResourceName, "users.*", user),
 					resource.TestCheckResourceAttr(RoleAccessResourceName, "users.#", "1"),
+					resource.TestCheckTypeSetElemAttr(RoleAccessResourceName, "idp_groups.*", idpGroup),
+					resource.TestCheckResourceAttr(RoleAccessResourceName, "idp_groups.#", "1"),
 					resource.TestCheckTypeSetElemAttr(RoleAccessResourceName, "service_accounts.*", svcAcc),
 					resource.TestCheckResourceAttr(RoleAccessResourceName, "service_accounts.#", "1"),
 				),
@@ -81,7 +87,7 @@ func TestAcc_ResourceJaasAccessRole(t *testing.T) {
 	})
 }
 
-func testAccResourceJaasAccessRole(roleName, access, user, svcAcc string) string {
+func testAccResourceJaasAccessRole(roleName, access, user, svcAcc, idpGroup string) string {
 	return internaltesting.GetStringFromTemplateWithData(
 		"testAccResourceJaasAccessRole",
 		`
@@ -93,12 +99,14 @@ resource "juju_jaas_access_role" "test" {
   role_id            = juju_jaas_role.test.uuid
   access              = "{{.Access}}"
   users               = ["{{.User}}"]
+  idp_groups          = ["{{.IdPGroup}}"]
   service_accounts    = ["{{.SvcAcc}}"]
 }
 `, internaltesting.TemplateData{
-			"Role":   roleName,
-			"Access": access,
-			"User":   user,
-			"SvcAcc": svcAcc,
+			"Role":     roleName,
+			"Access":   access,
+			"User":     user,
+			"SvcAcc":   svcAcc,
+			"IdPGroup": idpGroup,
 		})
 }


### PR DESCRIPTION
## Description
This change adds support for the newly introduced `idp_group` tag to all `juju_jaas_access` resources. This allows a plan author to grant an idp-group with access to resources. Note that an idp-group is forbidden from being granted membership to a traditional group.

Fixes: [JUJU-10037](https://warthogs.atlassian.net/browse/JUJU-10037)

## Type of change

- Change existing resource


[JUJU-10037]: https://warthogs.atlassian.net/browse/JUJU-10037?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ