### PR TITLE
Docs migrate 21

### DIFF
--- a/docs-rtd/.sphinx/_static/js/overwrite_links.js
+++ b/docs-rtd/.sphinx/_static/js/overwrite_links.js
@@ -1,0 +1,37 @@
+// Replace oldDomain with newDomain
+const oldDomain = 'canonical-terraform-provider-juju-1.readthedocs-hosted.com';
+const newDomain = 'canonical.com/juju/docs/terraform-provider-juju';
+
+function escapeRegExp(value) {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function overwriteMatchingAnchorUrls(container) {
+    if (!container) return;
+
+    const anchors = container.querySelectorAll('a[href], link[href]');
+    const oldDomainRegex = new RegExp(escapeRegExp(oldDomain), 'g');
+
+    anchors.forEach(anchor => {
+        anchor.href = anchor.href.replace(oldDomainRegex, newDomain);
+    });
+}
+
+overwriteMatchingAnchorUrls(document.querySelector('header'));
+
+// Use a MutationObserver to wait for the RTD flyout element to appear in the DOM
+const observer = new MutationObserver(function(mutations, obs) {
+    const rtdFlyout = document.querySelector('readthedocs-flyout');
+    if (!rtdFlyout) return;
+
+    obs.disconnect();
+
+    rtdFlyout.addEventListener('click', function() {
+        const shadowRoot = rtdFlyout.shadowRoot;
+        if (!shadowRoot) return;
+
+        overwriteMatchingAnchorUrls(shadowRoot);
+    });
+});
+
+observer.observe(document.body, { childList: true, subtree: true });

--- a/docs-rtd/.sphinx/_templates/header.html
+++ b/docs-rtd/.sphinx/_templates/header.html
@@ -1,5 +1,28 @@
 <header id="header" class="p-navigation">
 
+
+  </script>
+
+  <!-- Google Tag Manager -->
+  <script>
+    (function(w, d, s, l, i) {
+      w[l] = w[l] || [];
+      w[l].push({
+        'gtm.start': new Date().getTime(),
+        event: 'gtm.js'
+      });
+      var f = d.getElementsByTagName(s)[0];
+      var j = d.createElement(s);
+      var dl = '';
+      if (l != 'dataLayer') {
+          dl = '&l=' + l;
+      }
+      j.async = true;
+      j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
+      f.parentNode.insertBefore(j, f);
+    })(window, document, 'script', 'dataLayer', 'GTM-KNX3CJC');
+  </script>
+
   <div class="p-navigation__nav" role="menubar">
 
     <ul class="p-navigation__links" role="menu">

--- a/docs-rtd/conf.py
+++ b/docs-rtd/conf.py
@@ -71,7 +71,8 @@ copyright = "%s CC-BY-SA, %s" % (datetime.date.today().year, author)
 # NOTE: The Open Graph Protocol (OGP) enhances page display in a social graph
 #       and is used by social media platforms; see https://ogp.me/
 
-ogp_site_url = "https://canonical-terraform-provider-juju.readthedocs-hosted.com/"
+version_slug = f"{os.environ.get('READTHEDOCS_VERSION', 'local')}"
+ogp_site_url = f"https://canonical.com/juju/docs/terraform-provider-juju/{version_slug}/"
 
 
 # Preview name of the documentation website
@@ -168,7 +169,7 @@ html_context = {
 # TODO: If your documentation is hosted on https://docs.ubuntu.com/,
 #       uncomment and update as needed.
 
-slug = 'terraform-provider-juju'
+slug = 'juju/docs/terraform-provider-juju'
 
 #######################
 # Sitemap configuration: https://sphinx-sitemap.readthedocs.io/
@@ -176,11 +177,13 @@ slug = 'terraform-provider-juju'
 
 # Use RTD canonical URL to ensure duplicate pages have a specific canonical URL
 
-html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "/")
+html_baseurl = f'https://canonical.com/juju/docs/terraform-provider-juju/{version_slug}/'
 
 # sphinx-sitemap uses html_baseurl to generate the full URL for each page:
 
 sitemap_url_scheme = '{link}'
+
+sitemap_filename = "doc-sitemap.xml"
 
 # Include `lastmod` dates in the sitemap:
 
@@ -345,6 +348,7 @@ html_css_files = [
 # Adds custom JavaScript files, located under 'html_static_path'
 html_js_files = [
     'js/bundle.js',
+    'js/overwrite_links.js',
 ]
 
 # Specifies a reST snippet to be appended to each .rst file

--- a/docs-rtd/conf.py
+++ b/docs-rtd/conf.py
@@ -307,12 +307,12 @@ extensions = [
 # Extension configs:
 # - sphinx.ext.intersphinx:
 intersphinx_mapping = {
-    'juju': ('https://documentation.ubuntu.com/juju/3.6', None),
+    'juju': ('https://canonical.com/juju/docs/juju-cli/latest', None),
     # 'tfjuju': ('https://documentation.ubuntu.com/terraform-provider-juju/latest/', None)
     'pyjuju': ('https://pythonlibjuju.readthedocs.io/en/latest/', None),
-    'jaas': ('https://documentation.ubuntu.com/jaas/latest/', None),
+    'jaas': ('https://canonical.com/juju/docs/jaas/v3', None),
     'charmcraft': ('https://documentation.ubuntu.com/charmcraft/stable/', None),
-    'ops': ('https://documentation.ubuntu.com/ops/latest/', None),
+    'ops': ('https://canonical.com/juju/docs/ops/latest', None),
 }
 # - sphinx_new_tab_link:
 new_tab_link_show_external_link_icon = True

--- a/docs-rtd/howto/manage-models.md
+++ b/docs-rtd/howto/manage-models.md
@@ -167,7 +167,7 @@ This means that, if you modify your plan in a way that causes recreation of the 
 
 Migrating models to a JAAS environment requires some updates to your Terraform plan when cross-model relations are involved, even if both models in the relation are migrated.
 
-When a model is migrated to JAAS, the model's name and offer URLs will change. The JAAS documentation on [model management](https://canonical.com/juju/docs/jaas/v3/howto/manage-models/) provides more detail.
+When a model is migrated to JAAS, the model's name and offer URLs will change. The JAAS documentation on {external+jaas:ref}`manage-models` provides more detail.
 
 Our recommended way of resolving your Terraform state for this scenario is described below.
 
@@ -545,7 +545,7 @@ Importing it is harmless, but attempting to destroy it via Terraform will result
 juju_storage_pool.all_storage_pools_3: Destroying... [id=c1cecf1e-fe66-4589-8585-e579edd6f58b:loop]
 ╷
 │ Error: Client Error
-│ 
+│
 │ Unable to delete storage pool resource, got error: storage pool "loop" not found
 ╵
 ```

--- a/docs-rtd/howto/manage-models.md
+++ b/docs-rtd/howto/manage-models.md
@@ -167,7 +167,7 @@ This means that, if you modify your plan in a way that causes recreation of the 
 
 Migrating models to a JAAS environment requires some updates to your Terraform plan when cross-model relations are involved, even if both models in the relation are migrated.
 
-When a model is migrated to JAAS, the model's name and offer URLs will change. The JAAS documentation on [model management](https://documentation.ubuntu.com/jaas/latest/howto/manage-models/) provides more detail.
+When a model is migrated to JAAS, the model's name and offer URLs will change. The JAAS documentation on [model management](https://canonical.com/juju/docs/jaas/v3/howto/manage-models/) provides more detail.
 
 Our recommended way of resolving your Terraform state for this scenario is described below.
 


### PR DESCRIPTION
When we prepared the repo for the docs migration work (see, e.g., https://github.com/juju/terraform-provider-juju/pull/1266 ), I forgot to add the change to `main`, and this affected sitemaps for `2.1` when it was created too. This PR fixes that.

Also updated the intersphinx links and fixed a linkcheck issue.

## QA

Verify that the RTD's `/docs-sitemap.xml` shows a sitemap with URLs based on the new domain (`canonical.com/juju/docs/terraform-provider-juju/`): https://canonical-terraform-provider-juju-1--1287.com.readthedocs.build/1287/doc-sitemap.xml

## No need to forward merge

This change was added separately in each branch as that's easier to test.