### PR TITLE
docs: update intersphinx URLs to canonical.com

### DIFF
--- a/docs-rtd/conf.py
+++ b/docs-rtd/conf.py
@@ -305,12 +305,12 @@ extensions = [
 # Extension configs:
 # - sphinx.ext.intersphinx:
 intersphinx_mapping = {
-    'juju': ('https://documentation.ubuntu.com/juju/3.6', None),
+    'juju': ('https://canonical.com/juju/docs/juju-cli/latest', None),
     # 'tfjuju': ('https://documentation.ubuntu.com/terraform-provider-juju/latest/', None),
     'pyjuju': ('https://pythonlibjuju.readthedocs.io/en/latest/', None),
-    'jaas': ('https://documentation.ubuntu.com/jaas/latest/', None),
+    'jaas': ('https://canonical.com/juju/docs/jaas/v3', None),
     'charmcraft': ('https://documentation.ubuntu.com/charmcraft/stable/', None),
-    'ops': ('https://documentation.ubuntu.com/ops/latest/', None),
+    'ops': ('https://canonical.com/juju/docs/ops/latest', None),
 }
 # - sphinx_new_tab_link:
 new_tab_link_show_external_link_icon = True

--- a/docs-rtd/howto/manage-models.md
+++ b/docs-rtd/howto/manage-models.md
@@ -161,7 +161,7 @@ This means that, if you modify your plan in a way that causes recreation of the 
 
 Migrating models to a JAAS environment requires some updates to your Terraform plan when cross-model relations are involved, even if both models in the relation are migrated.
 
-When a model is migrated to JAAS, the model's name and offer URLs will change. The JAAS documentation on [model management](https://documentation.ubuntu.com/jaas/latest/howto/manage-models/) provides more detail.
+When a model is migrated to JAAS, the model's name and offer URLs will change. The JAAS documentation on [model management](https://canonical.com/juju/docs/jaas/v3/howto/manage-models/) provides more detail.
 
 Our recommended way of resolving your Terraform state for this scenario is described below.
 

--- a/docs-rtd/howto/manage-models.md
+++ b/docs-rtd/howto/manage-models.md
@@ -161,7 +161,7 @@ This means that, if you modify your plan in a way that causes recreation of the 
 
 Migrating models to a JAAS environment requires some updates to your Terraform plan when cross-model relations are involved, even if both models in the relation are migrated.
 
-When a model is migrated to JAAS, the model's name and offer URLs will change. The JAAS documentation on [model management](https://canonical.com/juju/docs/jaas/v3/howto/manage-models/) provides more detail.
+When a model is migrated to JAAS, the model's name and offer URLs will change. The JAAS documentation on {external+jaas:ref}`manage-models` provides more detail.
 
 Our recommended way of resolving your Terraform state for this scenario is described below.
 


### PR DESCRIPTION
Patch to update intersphinx links to the new domains.

## No need to forward merge

This patch was applied separately to each branch to fix the issue immediately.