### PR TITLE
fix: cli output parsing

### DIFF
--- a/internal/juju/utils.go
+++ b/internal/juju/utils.go
@@ -17,6 +17,8 @@ import (
 	"github.com/juju/names/v5"
 )
 
+var getLocalControllerConfigOnce = sync.OnceValues(loadLocalControllerConfig)
+
 // controllerConfig is a representation of the output
 // returned when running the CLI command
 // `juju show-controller --show-password`
@@ -45,68 +47,68 @@ type controllerConfig struct {
 	} `json:"account"`
 }
 
-// localProviderConfig is populated once and queried later
-// to avoid multiple juju CLI executions
-var localProviderConfig map[string]string
-
-// singleQuery will be used to limit the number of CLI queries to ONE
-var singleQuery sync.Once
-
 // GetLocalControllerConfig runs the locally installed juju command,
 // if available, to get the current controller configuration.
 func GetLocalControllerConfig() (map[string]string, bool) {
-	// populate the controller controllerConfig information only once
-	singleQuery.Do(populateControllerConfig)
-
-	return localProviderConfig, localProviderConfig == nil
+	return getLocalControllerConfigOnce()
 }
 
-// populateControllerConfig executes the local juju CLI command
-// to obtain the current controller configuration
-func populateControllerConfig() {
+// loadLocalControllerConfig executes the local juju CLI command
+// to obtain the current controller configuration.
+func loadLocalControllerConfig() (map[string]string, bool) {
 	// get the value from the juju provider
 	cmd := exec.Command("juju", "show-controller", "--show-password", "--format=json")
 
 	cmdData, err := cmd.Output()
 	if err != nil {
-		tflog.Error(context.TODO(), "error invoking juju CLI", map[string]interface{}{"error": err})
-		return
+		tflog.Error(context.TODO(), "error invoking juju CLI", map[string]any{"error": err})
+		return nil, true
 	}
 
+	ctrlConfig, err := parseLocalControllerConfig(cmdData)
+	if err != nil {
+		tflog.Error(context.TODO(), "error parsing Juju CLI output", map[string]any{"error": err})
+		return nil, true
+	}
+
+	// Avoid logging the password below, but return it in the map for use by the provider.
+	tflog.Debug(context.TODO(), "local provider controllerConfig was set", map[string]any{
+		"JUJU_AGENT_VERSION":        ctrlConfig.ProviderDetails.AgentVersion,
+		"JUJU_CONTROLLER_ADDRESSES": strings.Join(ctrlConfig.ProviderDetails.ApiEndpoints, ","),
+		"JUJU_USERNAME":             ctrlConfig.Account.User,
+		"JUJU_CA_CERT":              ctrlConfig.ProviderDetails.CACert,
+	})
+
+	return map[string]string{
+		"JUJU_AGENT_VERSION":        ctrlConfig.ProviderDetails.AgentVersion,
+		"JUJU_CONTROLLER_ADDRESSES": strings.Join(ctrlConfig.ProviderDetails.ApiEndpoints, ","),
+		"JUJU_USERNAME":             ctrlConfig.Account.User,
+		"JUJU_PASSWORD":             ctrlConfig.Account.Password,
+		"JUJU_CA_CERT":              ctrlConfig.ProviderDetails.CACert,
+	}, false
+}
+
+func parseLocalControllerConfig(cmdData []byte) (controllerConfig, error) {
 	// given that the CLI output is a map containing arbitrary keys
 	// (controllers) and fixed json structures, we have to do some
 	// workaround to populate the struct
-	var cliOutput interface{}
-	err = json.Unmarshal(cmdData, &cliOutput)
+	var cliOutput map[string]json.RawMessage
+	err := json.Unmarshal(cmdData, &cliOutput)
 	if err != nil {
-		tflog.Error(context.TODO(), "error unmarshalling Juju CLI output", map[string]interface{}{"error": err})
-		return
+		return controllerConfig{}, err
 	}
 
 	// convert to the map and extract the only entry
-	controllerConfig := controllerConfig{}
-	for _, v := range cliOutput.(map[string]interface{}) {
-		// now v is a map[string]interface{} type
-		marshalled, err := json.Marshal(v)
+	config := controllerConfig{}
+	for _, raw := range cliOutput {
+		err = json.Unmarshal(raw, &config)
 		if err != nil {
-			tflog.Error(context.TODO(), "error marshalling provider controllerConfig", map[string]interface{}{"error": err})
-			return
+			return controllerConfig{}, err
 		}
-		// now we have a controllerConfig type
-		err = json.Unmarshal(marshalled, &controllerConfig)
-		if err != nil {
-			tflog.Error(context.TODO(), "error unmarshalling provider configuration from Juju CLI", map[string]interface{}{"error": err})
-			return
-		}
-		break
+		return config, nil
 	}
 
-	tflog.Debug(context.TODO(), "local provider controllerConfig was set", map[string]interface{}{
-		"JUJU_AGENT_VERSION":        controllerConfig.ProviderDetails.AgentVersion,
-		"JUJU_CONTROLLER_ADDRESSES": strings.Join(controllerConfig.ProviderDetails.ApiEndpoints, ","),
-		"JUJU_USERNAME":             controllerConfig.Account.User,
-		"JUJU_CA_CERT":              controllerConfig.ProviderDetails.CACert,
-	})
+	return controllerConfig{}, errors.New("juju CLI returned no controllers")
 }
 
 // WaitForAppsAvailable blocks the execution flow and waits until all the

--- a/internal/juju/utils_test.go
+++ b/internal/juju/utils_test.go
@@ -1,0 +1,34 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the Apache License, Version 2.0, see LICENCE file for details.
+
+package juju
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseLocalControllerConfig(t *testing.T) {
+	config, err := parseLocalControllerConfig([]byte(`{
+		"test-controller": {
+			"details": {
+				"api-endpoints": ["10.0.0.1:17070", "10.0.0.2:17070"],
+				"agent-version": "3.6.0",
+				"ca-cert": "test-ca-cert"
+			},
+			"account": {
+				"user": "admin",
+				"password": "super-secret"
+			}
+		}
+	}`))
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"10.0.0.1:17070", "10.0.0.2:17070"}, config.ProviderDetails.ApiEndpoints)
+	assert.Equal(t, "3.6.0", config.ProviderDetails.AgentVersion)
+	assert.Equal(t, "test-ca-cert", config.ProviderDetails.CACert)
+	assert.Equal(t, "admin", config.Account.User)
+	assert.Equal(t, "super-secret", config.Account.Password)
+}


### PR DESCRIPTION
## Description

A previous change https://github.com/juju/terraform-provider-juju/pull/1254, broke the ability for the provider to use the Juju CLI to fetch controller details. The change avoided logging the password but stopped setting the values on the global `localProviderConfig` that was used elsewhere. In this change we avoid the use of a global map and a sync.Once var and use the newer sync.OnceValues which computes a function once and stores the value.

It also refactors the `populateControllerConfig` into 2 separate functions, one `loadLocalControllerConfig` and another `parseLocalControllerConfig` so that we can introduce some testing.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## QA steps

Manual QA steps should be done to test this PR.

Verify v1.5.5 is broken with a simple plan like below which should fail with `Error: Username and password or client id and client secret must be set`.
```tf
terraform {
  required_version = ">= 1.6.6"
  required_providers {
    juju = {
      source  = "juju/juju"
      version = "=1.5.5"
    }
  }
}

provider "juju" {}

resource "juju_model" "model" {
  name = "test-model"
}
```
Then test the latest changes by running the provider in debug mode or with `make install` and re-running the plan above which should now work. 