### PR TITLE
fix: persist resource id after creation

### DIFF
--- a/internal/provider/resource_application.go
+++ b/internal/provider/resource_application.go
@@ -689,6 +689,17 @@ func (r *applicationResource) Create(ctx context.Context, req resource.CreateReq
 		return
 	}
 
+	// The application now exists in Juju. Persist the ID and identity to state
+	// before waiting or reading, so any later failure taints the resource
+	// instead of leaking it.
+	plan.ID = types.StringValue(newAppID(modelUUID, createResp.AppName))
+	plan.ApplicationName = types.StringValue(createResp.AppName)
+	resp.Diagnostics.Append(resp.Identity.Set(ctx, applicationResourceIdentityModel{ID: plan.ID})...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	r.trace(fmt.Sprintf("create application resource %q", createResp.AppName))
 	readResp, err := wait.WaitFor(
 		wait.WaitForCfg[*juju.ReadApplicationInput, *juju.ReadApplicationResponse]{
@@ -708,7 +719,11 @@ func (r *applicationResource) Create(ctx context.Context, req resource.CreateReq
 		},
 	)
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read application, got error: %s", err))
+		// The application was created in Juju but failed to become ready. The
+		// ID is already saved to state above, so returning an error here marks
+		// the resource as tainted: the next apply will destroy and recreate it,
+		// or the user can fix the underlying issue and untaint it.
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Application created but failed while waiting for it to be ready, got error: %s", err))
 		return
 	}
 	r.trace(fmt.Sprintf("read application resource %q", createResp.AppName))
@@ -772,11 +787,8 @@ func (r *applicationResource) Create(ctx context.Context, req resource.CreateReq
 		plan.Storage = types.SetNull(storageType)
 	}
 
-	plan.ID = types.StringValue(newAppID(plan.ModelUUID.ValueString(), createResp.AppName))
-	identity := applicationResourceIdentityModel{
-		ID: plan.ID,
-	}
-	resp.Diagnostics.Append(resp.Identity.Set(ctx, identity)...)
+	// ID and identity were already persisted right after creation; here we
+	// overwrite state with the fully-enriched plan now that the read succeeded.
 	r.trace("Created", applicationResourceModelForLogging(ctx, &plan))
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)

--- a/internal/provider/resource_integration.go
+++ b/internal/provider/resource_integration.go
@@ -286,6 +286,17 @@ func (r *integrationResource) Create(ctx context.Context, req resource.CreateReq
 	}
 	r.trace(fmt.Sprintf("integration created on Juju between %q at %q on model %q", appNames, endpoints, modelUUID))
 
+	// The integration now exists in Juju. Persist the ID and identity to state
+	// before enriching the plan, so any later failure taints the resource
+	// instead of leaking the integration.
+	id := newIDForIntegrationResource(modelUUID, response.Applications)
+	plan.ID = types.StringValue(id)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+	resp.Diagnostics.Append(resp.Identity.Set(ctx, integrationResourceIdentityModel{ID: plan.ID})...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	parsedApplications, err := parseApplications(r.client, response.Applications)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to parse applications, got error: %s", err))
@@ -300,17 +311,9 @@ func (r *integrationResource) Create(ctx context.Context, req resource.CreateReq
 	}
 	plan.Application = parsedApps
 
-	id := newIDForIntegrationResource(modelUUID, response.Applications)
-	plan.ID = types.StringValue(id)
-
 	r.trace(fmt.Sprintf("integration resource created: %q", id))
-	// Write the state plan into the Response.State
+	// Overwrite state with the fully-enriched plan now that parsing succeeded.
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
-
-	identity := integrationResourceIdentityModel{
-		ID: plan.ID,
-	}
-	resp.Diagnostics.Append(resp.Identity.Set(ctx, identity)...)
 }
 
 func (r *integrationResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {

--- a/internal/provider/resource_space.go
+++ b/internal/provider/resource_space.go
@@ -187,6 +187,15 @@ func (r *spaceResource) Create(ctx context.Context, req resource.CreateRequest, 
 		return
 	}
 
+	// The space now exists in Juju. Persist the ID and identity to state before
+	// waiting, so a wait failure taints the resource instead of leaking it.
+	plan.ID = types.StringValue(newSpaceResourceID(plan.ModelUUID.ValueString(), plan.Name.ValueString()))
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+	resp.Diagnostics.Append(resp.Identity.Set(ctx, spaceResourceIdentityModel{ID: plan.ID})...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	if _, err := wait.WaitFor(wait.WaitForCfg[juju.ReadSpaceInput, *juju.ReadSpaceOutput]{
 		Context: ctx,
 		GetData: func(ctx context.Context, input juju.ReadSpaceInput) (*juju.ReadSpaceOutput, error) {
@@ -210,12 +219,6 @@ func (r *spaceResource) Create(ctx context.Context, req resource.CreateRequest, 
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to wait for space, got error: %s", err))
 		return
 	}
-
-	plan.ID = types.StringValue(newSpaceResourceID(plan.ModelUUID.ValueString(), plan.Name.ValueString()))
-	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
-
-	identity := spaceResourceIdentityModel{ID: plan.ID}
-	resp.Diagnostics.Append(resp.Identity.Set(ctx, identity)...)
 }
 
 // Read implements [resource.Resource].

--- a/internal/provider/resource_storage_pool.go
+++ b/internal/provider/resource_storage_pool.go
@@ -224,6 +224,15 @@ func (r *storagePoolResource) Create(ctx context.Context, req resource.CreateReq
 		return
 	}
 
+	// The pool now exists in Juju. Persist the ID and identity to state before
+	// waiting, so a wait failure taints the resource instead of leaking it.
+	plan.ID = generateResourceID(plan)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+	resp.Diagnostics.Append(resp.Identity.Set(ctx, storagePoolResourceIdentityModel{ID: plan.ID})...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	// Wait for the pool to be created.
 	if _, err := wait.WaitFor(
 		wait.WaitForCfg[juju.GetStoragePoolInput, juju.GetStoragePoolResponse]{
@@ -253,13 +262,6 @@ func (r *storagePoolResource) Create(ctx context.Context, req resource.CreateReq
 		"model":            plan.ModelUUID.ValueString(),
 		"storage_provider": plan.StorageProvider.ValueString(),
 	})
-
-	plan.ID = generateResourceID(plan)
-
-	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
-
-	identity := storagePoolResourceIdentityModel{ID: plan.ID}
-	resp.Diagnostics.Append(resp.Identity.Set(ctx, identity)...)
 }
 
 // Read implements resource.Resource.

--- a/internal/provider/resource_subnet.go
+++ b/internal/provider/resource_subnet.go
@@ -174,6 +174,16 @@ func (r *subnetResource) Create(ctx context.Context, req resource.CreateRequest,
 		return
 	}
 
+	// The subnet has been moved to its target space in Juju. Persist the ID and
+	// identity to state before waiting, so a wait failure taints the resource
+	// instead of leaving the move untracked.
+	plan.ID = types.StringValue(newSubnetResourceID(plan.ModelUUID.ValueString(), plan.CIDR.ValueString()))
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+	resp.Diagnostics.Append(resp.Identity.Set(ctx, subnetResourceIdentityModel{ID: plan.ID})...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	if _, err := wait.WaitFor(wait.WaitForCfg[juju.ReadSubnetInput, *juju.SubnetInfo]{
 		Context: ctx,
 		GetData: func(ctx context.Context, input juju.ReadSubnetInput) (*juju.SubnetInfo, error) {
@@ -197,12 +207,6 @@ func (r *subnetResource) Create(ctx context.Context, req resource.CreateRequest,
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("waiting for subnet to move to space %s failed, got error: %s", plan.SpaceName.ValueString(), err))
 		return
 	}
-
-	plan.ID = types.StringValue(newSubnetResourceID(plan.ModelUUID.ValueString(), plan.CIDR.ValueString()))
-	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
-
-	identity := subnetResourceIdentityModel{ID: plan.ID}
-	resp.Diagnostics.Append(resp.Identity.Set(ctx, identity)...)
 }
 
 // Read implements [resource.Resource].


### PR DESCRIPTION
## Description

Address #1333

This pr makes sure we persist the ID after resource's creation, to make sure that if we fail during the wait-for or any other subsequent operations the resource is tainted, so it's recreated on the following `terraform apply`

I thought about creating an helper, but it was less readable than what i have here.

# QA

```
terraform {
  required_providers {
    juju = { source = "juju/juju" }
  }
}

provider "juju" {}

resource "juju_model" "this" {
  name = "taint-repro"
}

resource "juju_application" "this" {
  model_uuid = juju_model.this.uuid
  name       = "ubuntu"
  charm {
    name = "ubuntu"
  }
  units = 1
}
```

change the code
```
assertEqualsUnitCount(unitCount),
-> 
assertEqualsUnitCount(unitCount +999),
```
plus lower the max duration to 1 second in the create wait-for for the application to make sure the resource is marked as tainted.

Then `terraform apply` once:
```
╷
│ Error: Client Error
│ 
│   with juju_application.this,
│   on example.tf line 13, in resource "juju_application" "this":
│   13: resource "juju_application" "this" {
│ 
│ Application created but failed while waiting for it to be ready, got error: max
│ duration exceeded: retrying: plan units differ from application units: expected 1000,
│ got 1
╵
```

on the following `terraform apply` you should see:

```
  # juju_application.this is tainted, so must be replaced
-/+ resource "juju_application" "this" {
      ~ constraints  = "arch=amd64" -> (known after apply)
      ~ id           = "a33ef73c-a8ff-45d3-82d2-b2112e66ea4d:ubuntu" -> (known after apply)
      ~ machines     = [
          - "0",
        ] -> (known after apply)
      ~ model_type   = "iaas" -> (known after apply)
        name         = "ubuntu"
      + storage      = (known after apply)
      ~ unit_numbers = [
          - "0",
        ] -> (known after apply)
        # (3 unchanged attributes hidden)

      ~ charm {
          ~ base     = "ubuntu@24.04" -> (known after apply)
          ~ channel  = "latest/stable" -> (known after apply)
            name     = "ubuntu"
          ~ revision = 79 -> (known after apply)
        }
    }
```
