### PR TITLE
fix: retry transient CharmHub refresh failures

### DIFF
--- a/internal/charmhub/client.go
+++ b/internal/charmhub/client.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	stderrors "errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -17,7 +18,9 @@ import (
 	"github.com/juju/terraform-provider-juju/internal/charmhub/transport"
 
 	"github.com/juju/charm/v12"
+	"github.com/juju/clock"
 	"github.com/juju/errors"
+	"github.com/juju/retry"
 )
 
 const (
@@ -27,9 +30,19 @@ const (
 	refreshPath    = "/v2/charms/refresh"
 	defaultTimeout = 30 * time.Second
 	defaultArch    = "amd64"
+
+	// Requests that fail transiently (dropped connections, 429/5xx
+	// responses) are retried with doubling delays: 1s, 2s, 4s.
+	defaultRetryAttempts = 4
+	defaultRetryDelay    = time.Second
+	defaultRetryMaxDelay = 10 * time.Second
 )
 
 var refreshFields = []string{"bases", "metadata-yaml", "actions-yaml", "name", "resources", "revision"}
+
+// errTransient marks failures worth retrying: transport-level errors
+// (dropped connections, timeouts) and server-side 429/5xx responses.
+var errTransient = stderrors.New("transient charmhub error")
 
 // CharmRefreshInput contains the parameters for a charm refresh request.
 type CharmRefreshInput struct {
@@ -57,6 +70,11 @@ type CharmRefreshResult struct {
 type Client struct {
 	baseURL    string
 	httpClient *http.Client
+
+	retryAttempts int
+	retryDelay    time.Duration
+	retryMaxDelay time.Duration
+	clock         clock.Clock
 }
 
 // New returns a Client targeting baseURL. Pass a custom *http.Client as hc to
@@ -65,7 +83,14 @@ func New(baseURL string, hc *http.Client) *Client {
 	if hc == nil {
 		hc = &http.Client{Timeout: defaultTimeout}
 	}
-	return &Client{baseURL: baseURL, httpClient: hc}
+	return &Client{
+		baseURL:       baseURL,
+		httpClient:    hc,
+		retryAttempts: defaultRetryAttempts,
+		retryDelay:    defaultRetryDelay,
+		retryMaxDelay: defaultRetryMaxDelay,
+		clock:         clock.WallClock,
+	}
 }
 
 // HasAction returns true if the charm defines an action with the given name.
@@ -113,6 +138,34 @@ func (c *Client) Refresh(ctx context.Context, input CharmRefreshInput) (*CharmRe
 	if err != nil {
 		return nil, errors.Errorf("charmhub: %s", err)
 	}
+
+	var result *CharmRefreshResult
+	retryErr := retry.Call(retry.CallArgs{
+		Func: func() error {
+			var err error
+			result, err = c.refresh(ctx, body)
+			return err
+		},
+		IsFatalError: func(err error) bool {
+			return !stderrors.Is(err, errTransient)
+		},
+		Attempts:    c.retryAttempts,
+		Delay:       c.retryDelay,
+		MaxDelay:    c.retryMaxDelay,
+		BackoffFunc: retry.DoubleDelay,
+		Clock:       c.clock,
+		Stop:        ctx.Done(),
+	})
+	if retryErr != nil {
+		return nil, retry.LastError(retryErr)
+	}
+	return result, nil
+}
+
+// refresh performs a single refresh request and parses the response.
+// Failures likely to succeed on a subsequent attempt are wrapped with
+// errTransient so Refresh's retry loop picks them up.
+func (c *Client) refresh(ctx context.Context, body []byte) (*CharmRefreshResult, error) {
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+refreshPath, bytes.NewReader(body))
 	if err != nil {
 		return nil, errors.Errorf("charmhub: %s", err)
@@ -122,15 +175,21 @@ func (c *Client) Refresh(ctx context.Context, input CharmRefreshInput) (*CharmRe
 
 	httpResp, err := c.httpClient.Do(httpReq)
 	if err != nil {
-		return nil, errors.Errorf("charmhub: %s", err)
+		if ctx.Err() != nil {
+			return nil, errors.Errorf("charmhub: %s", err)
+		}
+		return nil, fmt.Errorf("%w: %v", errTransient, err)
 	}
 	defer httpResp.Body.Close()
 
 	data, err := io.ReadAll(httpResp.Body)
 	if err != nil {
-		return nil, errors.Errorf("charmhub: %s", err)
+		return nil, fmt.Errorf("%w: %v", errTransient, err)
 	}
 	if httpResp.StatusCode != http.StatusOK {
+		if httpResp.StatusCode == http.StatusTooManyRequests || httpResp.StatusCode >= http.StatusInternalServerError {
+			return nil, fmt.Errorf("%w: status %d: %s", errTransient, httpResp.StatusCode, string(data))
+		}
 		return nil, errors.Errorf("charmhub: status %d: %s", httpResp.StatusCode, string(data))
 	}
 

--- a/internal/charmhub/client_test.go
+++ b/internal/charmhub/client_test.go
@@ -1,0 +1,158 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the Apache License, Version 2.0, see LICENCE file for details.
+
+package charmhub
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+const refreshSuccessBody = `{
+  "results": [{
+    "charm": {
+      "revision": 42,
+      "bases": [{"name": "ubuntu", "channel": "22.04", "architecture": "amd64"}]
+    },
+    "effective-channel": "latest/stable",
+    "name": "testcharm",
+    "result": "install",
+    "instance-key": "key-0"
+  }]
+}`
+
+// newTestClient returns a client pointed at url with retry delays short
+// enough for tests.
+func newTestClient(url string) *Client {
+	c := New(url, nil)
+	c.retryDelay = time.Millisecond
+	c.retryMaxDelay = 2 * time.Millisecond
+	return c
+}
+
+func TestRefreshRetriesOnServerError(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if calls.Add(1) <= 2 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		_, _ = w.Write([]byte(refreshSuccessBody))
+	}))
+	defer srv.Close()
+
+	result, err := newTestClient(srv.URL).Refresh(context.Background(), CharmRefreshInput{
+		Name:    "testcharm",
+		Base:    "ubuntu@22.04",
+		Channel: "latest/stable",
+	})
+	require.NoError(t, err)
+	require.Equal(t, int32(3), calls.Load())
+	require.Equal(t, 42, result.Revision)
+	require.Equal(t, "latest/stable", result.Channel)
+	require.Equal(t, "ubuntu@22.04", result.Base)
+}
+
+func TestRefreshRetriesOnDroppedConnection(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if calls.Add(1) == 1 {
+			// Drop the connection without a response, so the
+			// client sees EOF, as observed with api.charmhub.io.
+			conn, _, err := w.(http.Hijacker).Hijack()
+			require.NoError(t, err)
+			conn.Close()
+			return
+		}
+		_, _ = w.Write([]byte(refreshSuccessBody))
+	}))
+	defer srv.Close()
+
+	result, err := newTestClient(srv.URL).Refresh(context.Background(), CharmRefreshInput{
+		Name:    "testcharm",
+		Base:    "ubuntu@22.04",
+		Channel: "latest/stable",
+	})
+	require.NoError(t, err)
+	require.Equal(t, int32(2), calls.Load())
+	require.Equal(t, 42, result.Revision)
+}
+
+func TestRefreshDoesNotRetryOnClientError(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	_, err := newTestClient(srv.URL).Refresh(context.Background(), CharmRefreshInput{
+		Name:    "testcharm",
+		Base:    "ubuntu@22.04",
+		Channel: "latest/stable",
+	})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "status 404")
+	require.Equal(t, int32(1), calls.Load())
+}
+
+func TestRefreshGivesUpAfterMaxAttempts(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	_, err := newTestClient(srv.URL).Refresh(context.Background(), CharmRefreshInput{
+		Name:    "testcharm",
+		Base:    "ubuntu@22.04",
+		Channel: "latest/stable",
+	})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "status 503")
+	require.Equal(t, int32(defaultRetryAttempts), calls.Load())
+}
+
+func TestRefreshStopsRetryingOnContextCancel(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, nil)
+	c.retryDelay = time.Hour // the cancelled context must interrupt the delay
+	c.retryMaxDelay = time.Hour
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, err := c.Refresh(ctx, CharmRefreshInput{
+			Name:    "testcharm",
+			Base:    "ubuntu@22.04",
+			Channel: "latest/stable",
+		})
+		done <- err
+	}()
+
+	// Wait for the first attempt to fail, then cancel while the client
+	// is waiting to retry.
+	require.Eventually(t, func() bool { return calls.Load() == 1 }, 5*time.Second, 10*time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		require.Error(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Refresh did not return after context cancellation")
+	}
+	require.Equal(t, int32(1), calls.Load())
+}


### PR DESCRIPTION
## Description

The provider calls the CharmHub refresh endpoint directly (action verification, charm data source). A single dropped connection or 5xx response — seen in CI as 'Post .../v2/charms/refresh: EOF' — failed the whole operation. 

Retry transient failures (transport errors, 429/5xx) up to 4 attempts with doubling backoff; client errors and CharmHub API errors still fail immediately.

## Type of change

- Logic changes in resources (the API interaction with Juju has been changed)
