### PR TITLE
test: pin charm revisions in acceptance tests

### DIFF
--- a/internal/provider/data_source_action_test.go
+++ b/internal/provider/data_source_action_test.go
@@ -74,6 +74,7 @@ resource "juju_application" "this" {
 
   charm {
     name = "{{.CharmName}}"
+    revision = 25
     {{ if .Base }}base = "{{.Base}}"{{ end }}
   }
   {{ if .Trust }}trust = true{{ end }}

--- a/internal/provider/data_source_application_test.go
+++ b/internal/provider/data_source_application_test.go
@@ -93,6 +93,7 @@ resource "juju_application" "this" {
 
   charm {
     name     = "ubuntu"
+    revision = 77
 	channel  = "latest/stable"
   }
 }

--- a/internal/provider/data_source_offer_test.go
+++ b/internal/provider/data_source_offer_test.go
@@ -42,6 +42,7 @@ resource "juju_application" "this" {
 
 	charm {
 		name = "juju-qa-dummy-source"
+		revision = 6
 		%s
 	}
 }

--- a/internal/provider/list_integration_test.go
+++ b/internal/provider/list_integration_test.go
@@ -115,6 +115,7 @@ resource "juju_application" "one" {
 	
 	charm {
 		name = "juju-qa-dummy-sink"
+		revision = 7
 		base = "ubuntu@22.04"
 	}
 }
@@ -125,6 +126,7 @@ resource "juju_application" "two" {
 
 	charm {
 		name = "juju-qa-dummy-source"
+		revision = 6
 		base = "ubuntu@22.04"
 	}
 }

--- a/internal/provider/list_offers_test.go
+++ b/internal/provider/list_offers_test.go
@@ -83,6 +83,7 @@ resource "juju_application" "this" {
 
 	charm {
 		name = "juju-qa-dummy-source"
+		revision = 6
 		base = "ubuntu@22.04"
 	}
 }

--- a/internal/provider/resource_access_jaas_offer_test.go
+++ b/internal/provider/resource_access_jaas_offer_test.go
@@ -129,6 +129,7 @@ resource "juju_application" "appone" {
 
 	charm {
 		name = "juju-qa-dummy-source"
+		revision = 6
 		base = "ubuntu@22.04"
 	}
 }

--- a/internal/provider/resource_access_offer_test.go
+++ b/internal/provider/resource_access_offer_test.go
@@ -257,6 +257,7 @@ resource "juju_application" "appone" {
 
   charm {
     name = "juju-qa-dummy-source"
+    revision = 6
     base = "ubuntu@22.04"
   }
 }
@@ -309,6 +310,7 @@ resource "juju_application" "appone" {
 
   charm {
     name = "juju-qa-dummy-source"
+    revision = 6
     base = "ubuntu@22.04"
   }
 }

--- a/internal/provider/resource_access_secret_test.go
+++ b/internal/provider/resource_access_secret_test.go
@@ -104,6 +104,7 @@ resource "juju_application" "jul" {
 
   charm {
 	name     = "ubuntu-lite"
+	revision = 4
 	channel  = "latest/stable"
   }
 
@@ -117,6 +118,7 @@ resource "juju_application" "jul2" {
 
   charm {
 	name     = "ubuntu-lite"
+	revision = 4
 	channel  = "latest/stable"
   }
 

--- a/internal/provider/resource_action_test.go
+++ b/internal/provider/resource_action_test.go
@@ -84,6 +84,7 @@ resource "juju_application" "this" {
 
   charm {
     name = "{{.CharmName}}"
+    revision = 6
   }
 }
 

--- a/internal/provider/resource_application_test.go
+++ b/internal/provider/resource_application_test.go
@@ -1333,10 +1333,13 @@ func testAccCheckApplicationResource(ctx context.Context, appResource string, ch
 func TestAcc_ResourceApplication_Minimal(t *testing.T) {
 	modelName := acctest.RandomWithPrefix("tf-test-application")
 	var charmName string
+	var charmRevision int
 	if testingCloud == LXDCloudTesting {
 		charmName = "juju-qa-test"
+		charmRevision = 25
 	} else {
 		charmName = "hello-juju"
+		charmRevision = 8
 	}
 	resourceName := "juju_application.testapp"
 	checkResourceAttr := []resource.TestCheckFunc{
@@ -1349,7 +1352,7 @@ func TestAcc_ResourceApplication_Minimal(t *testing.T) {
 		ProtoV6ProviderFactories: frameworkProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceApplicationBasic_Minimal(modelName, charmName),
+				Config: testAccResourceApplicationBasic_Minimal(modelName, charmName, charmRevision),
 				Check: resource.ComposeTestCheckFunc(
 					checkResourceAttr...),
 			},
@@ -1400,6 +1403,7 @@ func testAccResourceApplicationBasic_ntp_Subordinates(modelName string) string {
 			name = "ntp"
 			charm {
 				name = "ntp"
+				revision = 52
 				base = "ubuntu@22.04"
 			}
 		}
@@ -1534,6 +1538,7 @@ func testAccResourceApplicationBasic_MachinesWithSubordinates(modelName, charmNa
 
 		  charm {
 			name = %q
+			revision = 25
 			base = "ubuntu@22.04"
 		  }
 		}
@@ -1544,6 +1549,7 @@ func testAccResourceApplicationBasic_MachinesWithSubordinates(modelName, charmNa
 
 			charm {
 				name = "ntp"
+				revision = 52
 				base = "ubuntu@22.04"
 			}
 		}
@@ -1591,6 +1597,7 @@ func testAccResourceApplicationBasic_UnitsWithSubordinates(modelName, charmName,
 
 		  charm {
 			name = %q
+			revision = 25
 			base = "ubuntu@22.04"
 		  }
 		}
@@ -1601,6 +1608,7 @@ func testAccResourceApplicationBasic_UnitsWithSubordinates(modelName, charmName,
 
 			charm {
 				name = "ntp"
+				revision = 52
 				base = "ubuntu@22.04"
 			}
 		}
@@ -1689,6 +1697,7 @@ func testAccResourceApplicationBasic_Machines(modelName, charmName string, machi
 
 		  charm {
 			name = %q
+			revision = 25
 			base = "ubuntu@22.04"
 		  }
 		}
@@ -1973,6 +1982,7 @@ resource "juju_application" "{{.AppName}}" {
   name       = "{{.AppName}}"
   charm {
 	name = "juju-qa-dummy-source"
+	revision = 6
   }
   {{ if .IncludeConfig }}
   config = {
@@ -1988,19 +1998,20 @@ resource "juju_application" "{{.AppName}}" {
 	})
 }
 
-func testAccResourceApplicationBasic_Minimal(modelName, charmName string) string {
+func testAccResourceApplicationBasic_Minimal(modelName, charmName string, charmRevision int) string {
 	return fmt.Sprintf(`
 		resource "juju_model" "testmodel" {
 		  name = %q
 		}
-		
+
 		resource "juju_application" "testapp" {
 		  model_uuid = juju_model.testmodel.uuid
 		  charm {
 			name = %q
+			revision = %d
 		  }
 		}
-		`, modelName, charmName)
+		`, modelName, charmName, charmRevision)
 }
 
 func testAccResourceApplicationBasic(modelName, appName string) string {
@@ -2015,6 +2026,7 @@ func testAccResourceApplicationBasic(modelName, appName string) string {
 		  name = %q
 		  charm {
 			name = "ubuntu-lite"
+			revision = 4
 		  }
 		  trust = true
 		  expose{}
@@ -2032,6 +2044,7 @@ func testAccResourceApplicationBasic(modelName, appName string) string {
 		  name = %q
 		  charm {
 			name = "ubuntu-lite"
+			revision = 4
 		  }
 		  trust = true
 		  expose{}
@@ -2055,6 +2068,7 @@ func testAccResourceApplicationScaleUp(modelName, appName, numberOfUnits string)
 		  name = %q
 		  charm {
 			name = "ubuntu-lite"
+			revision = 4
 		  }
 		  trust = true
 		  expose{}
@@ -2073,6 +2087,7 @@ func testAccResourceApplicationScaleUp(modelName, appName, numberOfUnits string)
 		  name = %q
 		  charm {
 			name = "coredns"
+			revision = 204
 		  }
 		  trust = true
 		  units = %q
@@ -2780,6 +2795,7 @@ resource "juju_application" "{{.AppName1}}" {
   name = "{{.AppName1}}"
   charm {
     name = "{{.CharmName}}"
+    revision = 25
     channel = "{{.CharmChannel}}"
   }
   # No units needed: test only checks model_uuid attribute pair.
@@ -2791,6 +2807,7 @@ resource "juju_application" "{{.AppName2}}" {
   name = "{{.AppName2}}"
   charm {
     name = "{{.CharmName}}"
+    revision = 25
     channel = "{{.CharmChannel}}"
   }
   # No units needed: test only checks model_uuid attribute pair.
@@ -2944,6 +2961,7 @@ resource "juju_application" "this" {
   name = %q
   charm {
 	name = "conserver"
+	revision = 12
   }
   trust = %t
   config = {
@@ -2966,6 +2984,7 @@ resource "juju_application" "this" {
   name = %q
   charm {
 	name = "conserver"
+	revision = 12
   }
   trust = false
   # No units needed: test only checks config and trust attributes.
@@ -3001,6 +3020,7 @@ resource "juju_application" "this" {
   name = %q
   charm {
 	name = "ubuntu-lite"
+	revision = 4
   }
   # No units needed: test only checks that the apply succeeds.
   units = 0
@@ -3027,6 +3047,7 @@ resource "juju_application" "this" {
   name = "test-app"
   charm {
 	name = "ubuntu-lite"
+	revision = 4
   }
 }
 `, modelName),
@@ -3296,6 +3317,7 @@ func testAccResourceApplicationUnknownMachines(modelName string) string {
 		  machines   = toset(terraform_data.machine_ids.output)
 		  charm {
 			name = "juju-qa-test"
+			revision = 25
 			base = "ubuntu@22.04"
 		  }
 		}

--- a/internal/provider/resource_cross_controller_test.go
+++ b/internal/provider/resource_cross_controller_test.go
@@ -80,6 +80,7 @@ resource "juju_application" "consumer" {
 	
 	charm {
 		name = "juju-qa-dummy-sink"
+		revision = 7
 	}
 }
 

--- a/internal/provider/resource_integration_test.go
+++ b/internal/provider/resource_integration_test.go
@@ -210,6 +210,7 @@ resource "juju_application" "one" {
 	
 	charm {
 		name = "juju-qa-dummy-sink"
+		revision = 7
 		base = "ubuntu@22.04"
 	}
 }
@@ -220,6 +221,7 @@ resource "juju_application" "two" {
 
 	charm {
 		name = "juju-qa-dummy-source"
+		revision = 6
 		base = "ubuntu@22.04"
 	}
 }
@@ -252,6 +254,7 @@ resource "juju_application" "one" {
 	
 	charm {
 		name = "juju-qa-dummy-sink"
+		revision = 7
 		base = "ubuntu@22.04"
 	}
 }
@@ -262,6 +265,7 @@ resource "juju_application" "two" {
 
 	charm {
 		name = "juju-qa-dummy-source"
+		revision = 6
 		base = "ubuntu@22.04"
 	}
 }
@@ -310,6 +314,7 @@ resource "juju_application" "one" {
 	
 	charm {
 		name = "juju-qa-dummy-sink"
+		revision = 7
 		base = "ubuntu@22.04"
 	}
 }
@@ -320,6 +325,7 @@ resource "juju_application" "two" {
 
 	charm {
 		name = "juju-qa-dummy-source"
+		revision = 6
 		base = "ubuntu@22.04"
 	}
 }
@@ -330,6 +336,7 @@ resource "juju_application" "three" {
 
 	charm {
 		name = "juju-qa-dummy-source"
+		revision = 6
 		base = "ubuntu@22.04"
 	}
 }
@@ -365,6 +372,7 @@ resource "juju_application" "a" {
 	
 	charm {
 		name = "juju-qa-dummy-sink"
+		revision = 7
 		%s
 	}
 }
@@ -379,6 +387,7 @@ resource "juju_application" "b" {
 	
 	charm {
 		name = "juju-qa-dummy-source"
+		revision = 6
 		%s
 	}
 }
@@ -532,6 +541,7 @@ resource "juju_application" "a" {
 
         charm {
                 name    = "juju-qa-dummy-sink"
+                revision = 7
         }
 }
 
@@ -555,6 +565,7 @@ resource "juju_application" "b1" {
 
         charm {
                 name   = "juju-qa-dummy-source"
+                revision = 6
         }
 }
 
@@ -578,6 +589,7 @@ resource "juju_application" "b2" {
 
         charm {
                 name   = "juju-qa-dummy-source"
+                revision = 6
         }
 }
 
@@ -619,6 +631,7 @@ resource "juju_application" "appzero" {
 
   charm {
     name = "juju-qa-dummy-source"
+    revision = 6
   }
   config = {
   	token = "abc"
@@ -631,6 +644,7 @@ resource "juju_application" "appone" {
 
   charm {
     name = "juju-qa-dummy-source"
+    revision = 6
   }
   config = {
   	token = "abc"
@@ -667,6 +681,7 @@ resource "juju_application" "apptwo" {
 
   charm {
     name = "juju-qa-dummy-sink"
+    revision = 7
   }
   config = {
   	token = "abc"

--- a/internal/provider/resource_offer_test.go
+++ b/internal/provider/resource_offer_test.go
@@ -85,6 +85,7 @@ resource "juju_application" "appone" {
 
 	charm {
 		name = "juju-qa-dummy-source"
+		revision = 6
 		base = "ubuntu@22.04"
 	}
 }
@@ -105,6 +106,7 @@ resource "juju_application" "apptwo" {
 
 	charm {
 		name = "juju-qa-dummy-sink"
+		revision = 7
 		base = "ubuntu@22.04"
 	}
 }
@@ -171,6 +173,7 @@ resource "juju_application" "this" {
 
 	charm {
 		name = "juju-qa-dummy-source"
+		revision = 6
 		base = "ubuntu@22.04"
 	}
 }
@@ -335,6 +338,7 @@ resource "juju_application" "haproxy" {
 
 	charm {
 		name = "juju-qa-dummy-source"
+		revision = 6
 		base = "ubuntu@22.04"
 	}
 }
@@ -345,6 +349,7 @@ resource "juju_application" "haproxy_two" {
 
 	charm {
 		name = "juju-qa-dummy-source"
+		revision = 6
 		base = "ubuntu@22.04"
 	}
 }
@@ -370,6 +375,7 @@ resource "juju_application" "haproxy" {
 
 	charm {
 		name = "juju-qa-dummy-source"
+		revision = 6
 		base = "ubuntu@22.04"
 	}
 }
@@ -380,6 +386,7 @@ resource "juju_application" "haproxy_two" {
 
 	charm {
 		name = "juju-qa-dummy-source"
+		revision = 6
 		base = "ubuntu@22.04"
 	}
 }
@@ -435,6 +442,7 @@ resource "juju_application" "haproxy" {
 
 	charm {
 		name = "juju-qa-dummy-source"
+		revision = 6
 		base = "ubuntu@22.04"
 	}
 }
@@ -551,6 +559,7 @@ resource "juju_application" "src" {
   name       = "src"
   charm {
     name = "juju-qa-dummy-source"
+    revision = 6
     base = "ubuntu@22.04"
   }
   config = {


### PR DESCRIPTION
## Description

Acceptance tests deployed most charms without a revision, so a charm publish on Charmhub mid-test or a published charm that changes behavior could change behaviour between test steps and produce non-empty refresh plans (seen in CI as coredns resource revision drift). Pin every scaffolding charm to the revision currently resolved for amd64/ubuntu@22.04 in its channel.

Deliberately left floating: configs exercising charm updates via channel switches (testAccApplicationUpdatesCharm,
testAccResourceApplicationWithCustomResources and friends) and the skipped TestAcc_CharmUpdateBase, where a floating revision is the point of the test.

## Type of change

- Other: tests 
