### PR TITLE
ci: rerun failed integration tests once via gotestsum

### DIFF
--- a/.github/workflows/test_integration.yml
+++ b/.github/workflows/test_integration.yml
@@ -159,12 +159,32 @@ jobs:
           echo "TEST_PUBLIC_BR=10.170.80.0/24" >> $GITHUB_ENV
           echo "JUJU_SKIP_FAILED_DELETION=true" >> $GITHUB_ENV
       - run: go mod download
-      - env:
+      # gotestsum re-runs only the tests that failed (at most once, and only
+      # when 5 or fewer failed) as a backstop against one-off flakes failing
+      # the whole job. Tests that passed on the rerun are flagged in the
+      # summary and listed in the uploaded rerun report - a growing report is
+      # a flakiness signal to act on, not to ignore.
+      - name: Run integration tests
+        env:
           TF_ACC: "1"
           TEST_CLOUD: ${{ matrix.action-operator.cloud }}
           TEST_VAULT_ADDR: ${{ env.TEST_VAULT_ADDR }}
-        run: go test -parallel 4 -timeout 90m -v -cover ./internal/provider/
+        run: |
+          go run gotest.tools/gotestsum@v1.13.0 \
+            --format standard-verbose \
+            --rerun-fails=1 \
+            --rerun-fails-max-failures=5 \
+            --rerun-fails-report=rerun-report.txt \
+            --packages ./internal/provider/ \
+            -- -parallel 4 -timeout 90m -cover
         timeout-minutes: 90
+      - name: Upload flaky-test rerun report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: rerun-report-${{ matrix.action-operator.cloud }}-${{ strategy.job-index }}
+          path: rerun-report.txt
+          if-no-files-found: ignore
       - name: Dump Juju bootstrap logs on failure
         if: failure()
         run: |

--- a/.github/workflows/test_integration_jaas.yaml
+++ b/.github/workflows/test_integration_jaas.yaml
@@ -99,8 +99,28 @@ jobs:
           echo "JUJU_SKIP_FAILED_DELETION=true" >> $GITHUB_ENV
           echo "SKIP_JAAS_GROUP_TEST=true" >> "$GITHUB_ENV"
       - run: go mod download
-      - env:
+      # gotestsum re-runs only the tests that failed (at most once, and only
+      # when 5 or fewer failed) as a backstop against one-off flakes failing
+      # the whole job. Tests that passed on the rerun are flagged in the
+      # summary and listed in the uploaded rerun report - a growing report is
+      # a flakiness signal to act on, not to ignore.
+      - name: Run integration tests
+        env:
           TF_ACC: "1"
           TEST_CLOUD: "lxd"
-        run: go test -parallel 4 -timeout 90m -v -cover ./internal/provider/
+        run: |
+          go run gotest.tools/gotestsum@v1.13.0 \
+            --format standard-verbose \
+            --rerun-fails=1 \
+            --rerun-fails-max-failures=5 \
+            --rerun-fails-report=rerun-report.txt \
+            --packages ./internal/provider/ \
+            -- -parallel 4 -timeout 90m -cover
         timeout-minutes: 90
+      - name: Upload flaky-test rerun report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: rerun-report-jaas-${{ strategy.job-index }}
+          path: rerun-report.txt
+          if-no-files-found: ignore


### PR DESCRIPTION
## Description

Run the acceptance suites through gotestsum with --rerun-fails=1 as a backstop against one-off flakes (network blips, transient Juju errors) failing a 60-90 minute job. Only the failed tests are re-run, and only when 5 or fewer failed, so a genuinely broken build still fails fast. Tests that pass on the rerun are flagged in the summary and listed in an uploaded rerun-report artifact so flakiness stays visible instead of being silently masked.

Applied to the main integration matrix and the JAAS workflow, which run the full suite; the add-machine and cross-controller jobs run a handful of targeted tests and are left as-is.

## Type of change

- Change in tests (one or several tests have been changed)
