### PR TITLE
perf: charmhub caching proxy for integrationt tests

### DIFF
--- a/.github/workflows/test_integration.yml
+++ b/.github/workflows/test_integration.yml
@@ -72,29 +72,22 @@ jobs:
         with:
           path: charmhub-cache-store
           key: charmhub-cache-${{ matrix.action-operator.cloud }}-${{ matrix.action-operator.juju }}
-      # Start the charmhub cache proxy before bootstrap so it serves every charm
-      # fetch, including the k8s bootstrap's juju-controller charm. Advertise the
-      # host's primary IP (reachable from LXD/microk8s, known before LXD exists)
-      # and pass it to bootstrap via bootstrap-options.
+      # Start the charmhub cache proxy before bootstrap so it's ready when
+      # needed. The proxy derives its externally reachable base URL from each
+      # request's Host header, so it never needs restarting once the
+      # controller-reachable address is known (see the "Configure charmhub
+      # cache proxy URL" step below).
       - name: Start charmhub cache proxy
         # language=bash
         run: |
-          PROXY_HOST=$(hostname -I | awk '{print $1}')
-          PROXY_URL="http://${PROXY_HOST}:8080"
-
           go build -o /tmp/charmhub-cache ./tools/charmhub-cache/
           /tmp/charmhub-cache \
             --addr "0.0.0.0:8080" \
-            --base-url "$PROXY_URL" \
             --store "charmhub-cache-store" &
 
-          # Wait for the proxy's readiness endpoint.
-          curl --retry 30 --retry-delay 1 --retry-connrefused -fsS "$PROXY_URL/healthz"
-          echo "charmhub-cache proxy is ready at $PROXY_URL"
-
-          # Expose the URL for bootstrap-options and for the provider's
-          # direct charmhub client.
-          echo "CHARMHUB_URL=$PROXY_URL" >> $GITHUB_ENV
+          # Wait for the proxy's readiness endpoint (on localhost).
+          curl --retry 30 --retry-delay 1 --retry-connrefused -fsS "http://127.0.0.1:8080/healthz"
+          echo "charmhub-cache proxy is ready"
       # This step fails intermittently on Juju 2.9 (mongodb fails to start up).
       # In that case, it'll retry a little in order to improve CI UX.
       - name: Setup operator environment
@@ -106,7 +99,6 @@ jobs:
           channel: ${{ matrix.action-operator.cloud-channel }}
           juju-channel: ${{ matrix.action-operator.juju }}
           lxd-channel: ${{ matrix.action-operator.lxd-channel }}
-          bootstrap-options: "--config charmhub-url=${{ env.CHARMHUB_URL }}"
       - name: Setup operator environment (retry 1)
         id: setup-op-1
         continue-on-error: true
@@ -117,7 +109,6 @@ jobs:
           channel: ${{ matrix.action-operator.cloud-channel }}
           juju-channel: ${{ matrix.action-operator.juju }}
           lxd-channel: ${{ matrix.action-operator.lxd-channel }}
-          bootstrap-options: "--config charmhub-url=${{ env.CHARMHUB_URL }}"
       - name: Setup operator environment (retry 2)
         id: setup-op-2
         continue-on-error: true
@@ -128,7 +119,6 @@ jobs:
           channel: ${{ matrix.action-operator.cloud-channel }}
           juju-channel: ${{ matrix.action-operator.juju }}
           lxd-channel: ${{ matrix.action-operator.lxd-channel }}
-          bootstrap-options: "--config charmhub-url=${{ env.CHARMHUB_URL }}"
       - name: Setup operator environment (set status)
         if: always()
         run: |
@@ -192,6 +182,22 @@ jobs:
           echo "TEST_MANAGEMENT_BR=10.150.40.0/24" >> $GITHUB_ENV
           echo "TEST_PUBLIC_BR=10.170.80.0/24" >> $GITHUB_ENV
           echo "JUJU_SKIP_FAILED_DELETION=true" >> $GITHUB_ENV
+      - name: Configure charmhub cache proxy URL
+        # language=bash
+        # Now that LXD/microk8s is up, compute the controller-reachable address
+        # and point the controller and provider at the proxy. The proxy itself
+        # doesn't need restarting: it derives its base URL from each request's
+        # Host header.
+        run: |
+          if [ "${{ matrix.action-operator.cloud }}" = "lxd" ]; then
+            PROXY_HOST=$(ip -4 addr show lxdbr0 | grep -oP '(?<=inet\s)\d+(\.\d+){3}')
+          else
+            PROXY_HOST=$(hostname -I | awk '{print $1}')
+          fi
+          PROXY_URL="http://${PROXY_HOST}:8080"
+
+          juju model-config charmhub-url="$PROXY_URL"
+          echo "CHARMHUB_URL=$PROXY_URL" >> $GITHUB_ENV
       - run: go mod download
       # gotestsum re-runs only the tests that failed (at most once, and only
       # when 5 or fewer failed) as a backstop against one-off flakes failing

--- a/.github/workflows/test_integration.yml
+++ b/.github/workflows/test_integration.yml
@@ -64,6 +64,37 @@ jobs:
         with:
           terraform_version: ${{ matrix.terraform }}
           terraform_wrapper: false
+      # Cache charmhub refresh responses and charm blobs across runs.
+      # Pinned revisions are immutable, so the cache key is stable.
+      - name: Restore charmhub cache
+        id: charmhub-cache
+        uses: actions/cache@v4
+        with:
+          path: charmhub-cache-store
+          key: charmhub-cache-${{ matrix.action-operator.cloud }}-${{ matrix.action-operator.juju }}
+      # Start the charmhub cache proxy before bootstrap so it serves every charm
+      # fetch, including the k8s bootstrap's juju-controller charm. Advertise the
+      # host's primary IP (reachable from LXD/microk8s, known before LXD exists)
+      # and pass it to bootstrap via bootstrap-options.
+      - name: Start charmhub cache proxy
+        # language=bash
+        run: |
+          PROXY_HOST=$(hostname -I | awk '{print $1}')
+          PROXY_URL="http://${PROXY_HOST}:8080"
+
+          go build -o /tmp/charmhub-cache ./tools/charmhub-cache/
+          /tmp/charmhub-cache \
+            --addr "0.0.0.0:8080" \
+            --base-url "$PROXY_URL" \
+            --store "charmhub-cache-store" &
+
+          # Wait for the proxy's readiness endpoint.
+          curl --retry 30 --retry-delay 1 --retry-connrefused -fsS "$PROXY_URL/healthz"
+          echo "charmhub-cache proxy is ready at $PROXY_URL"
+
+          # Expose the URL for bootstrap-options and for the provider's
+          # direct charmhub client.
+          echo "CHARMHUB_URL=$PROXY_URL" >> $GITHUB_ENV
       # This step fails intermittently on Juju 2.9 (mongodb fails to start up).
       # In that case, it'll retry a little in order to improve CI UX.
       - name: Setup operator environment
@@ -75,6 +106,7 @@ jobs:
           channel: ${{ matrix.action-operator.cloud-channel }}
           juju-channel: ${{ matrix.action-operator.juju }}
           lxd-channel: ${{ matrix.action-operator.lxd-channel }}
+          bootstrap-options: "--config charmhub-url=${{ env.CHARMHUB_URL }}"
       - name: Setup operator environment (retry 1)
         id: setup-op-1
         continue-on-error: true
@@ -85,6 +117,7 @@ jobs:
           channel: ${{ matrix.action-operator.cloud-channel }}
           juju-channel: ${{ matrix.action-operator.juju }}
           lxd-channel: ${{ matrix.action-operator.lxd-channel }}
+          bootstrap-options: "--config charmhub-url=${{ env.CHARMHUB_URL }}"
       - name: Setup operator environment (retry 2)
         id: setup-op-2
         continue-on-error: true
@@ -95,6 +128,7 @@ jobs:
           channel: ${{ matrix.action-operator.cloud-channel }}
           juju-channel: ${{ matrix.action-operator.juju }}
           lxd-channel: ${{ matrix.action-operator.lxd-channel }}
+          bootstrap-options: "--config charmhub-url=${{ env.CHARMHUB_URL }}"
       - name: Setup operator environment (set status)
         if: always()
         run: |
@@ -169,6 +203,7 @@ jobs:
           TF_ACC: "1"
           TEST_CLOUD: ${{ matrix.action-operator.cloud }}
           TEST_VAULT_ADDR: ${{ env.TEST_VAULT_ADDR }}
+          CHARMHUB_URL: ${{ env.CHARMHUB_URL }}
         run: |
           go run gotest.tools/gotestsum@v1.13.0 \
             --format standard-verbose \

--- a/.github/workflows/test_integration.yml
+++ b/.github/workflows/test_integration.yml
@@ -196,7 +196,11 @@ jobs:
           fi
           PROXY_URL="http://${PROXY_HOST}:8080"
 
-          juju model-config charmhub-url="$PROXY_URL"
+          # model-defaults (not model-config) because no model is selected yet
+          # at this point — bootstrap only creates the controller model. This
+          # sets charmhub-url as an inherited default for every model the
+          # tests create afterwards.
+          juju model-defaults charmhub-url="$PROXY_URL"
           echo "CHARMHUB_URL=$PROXY_URL" >> $GITHUB_ENV
       - run: go mod download
       # gotestsum re-runs only the tests that failed (at most once, and only

--- a/internal/charmhub/client.go
+++ b/internal/charmhub/client.go
@@ -12,15 +12,15 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"strings"
 	"time"
-
-	"github.com/juju/terraform-provider-juju/internal/charmhub/transport"
 
 	"github.com/juju/charm/v12"
 	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/retry"
+	"github.com/juju/terraform-provider-juju/internal/charmhub/transport"
 )
 
 const (
@@ -39,6 +39,16 @@ const (
 )
 
 var refreshFields = []string{"bases", "metadata-yaml", "actions-yaml", "name", "resources", "revision"}
+
+// DefaultURL returns the base URL clients should use when no explicit URL is
+// provided. It honors the CHARMHUB_URL environment variable (used in CI to
+// route refresh calls through a caching proxy), falling back to ProductionURL.
+func DefaultURL() string {
+	if u := strings.TrimSpace(os.Getenv("CHARMHUB_URL")); u != "" {
+		return u
+	}
+	return ProductionURL
+}
 
 // errTransient marks failures worth retrying: transport-level errors
 // (dropped connections, timeouts) and server-side 429/5xx responses.

--- a/internal/juju/applications.go
+++ b/internal/juju/applications.go
@@ -22,6 +22,10 @@ import (
 
 	"github.com/juju/collections/set"
 	jujuerrors "github.com/juju/errors"
+	"github.com/juju/names/v6"
+	"github.com/juju/terraform-provider-juju/internal/charmhub"
+	goyaml "gopkg.in/yaml.v2"
+
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"
 	apiapplication "github.com/juju/juju/api/client/application"
@@ -42,10 +46,6 @@ import (
 	charmresources "github.com/juju/juju/domain/deployment/charm/resource"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/rpc/params"
-	"github.com/juju/names/v6"
-	goyaml "gopkg.in/yaml.v2"
-
-	"github.com/juju/terraform-provider-juju/internal/charmhub"
 )
 
 // NewApplicationNotFoundError returns a new error indicating that the
@@ -911,7 +911,8 @@ func (c applicationsClient) ActionExists(ctx context.Context, modelUUID, appName
 	}
 	charmhubURL, _ := modelConfig.CharmHubURL()
 	if charmhubURL == "" {
-		charmhubURL = charmhub.ProductionURL
+		// Fall back to CHARMHUB_URL (CI cache proxy) then production.
+		charmhubURL = charmhub.DefaultURL()
 	}
 
 	// Parse the charm URL to extract the charm name (without revision).

--- a/internal/provider/data_source_charm.go
+++ b/internal/provider/data_source_charm.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-
 	"github.com/juju/terraform-provider-juju/internal/charmhub"
 )
 
@@ -121,7 +120,7 @@ func (d *charmDataSource) Read(ctx context.Context, req datasource.ReadRequest, 
 		return
 	}
 
-	storeURL := charmhub.ProductionURL
+	storeURL := charmhub.DefaultURL()
 	if !data.StoreURL.IsNull() && data.StoreURL.ValueString() != "" {
 		storeURL = data.StoreURL.ValueString()
 	}

--- a/tools/charmhub-cache/main.go
+++ b/tools/charmhub-cache/main.go
@@ -469,7 +469,9 @@ func isHex(s string) bool {
 		return false
 	}
 	for _, r := range s {
-		if !((r >= '0' && r <= '9') || (r >= 'a' && r <= 'f')) {
+		isDigit := r >= '0' && r <= '9'
+		isLowerHex := r >= 'a' && r <= 'f'
+		if !isDigit && !isLowerHex {
 			return false
 		}
 	}

--- a/tools/charmhub-cache/main.go
+++ b/tools/charmhub-cache/main.go
@@ -2,35 +2,21 @@
 // Licensed under the Apache License, Version 2.0, see LICENCE file for details.
 
 // Command charmhub-cache is a caching reverse proxy for the CharmHub refresh
-// API and charm blob downloads. It is designed for CI: it makes charm metadata
-// and blob fetches deterministic and resilient to CharmHub outages, and its
-// on-disk store is trivially cacheable via actions/cache.
+// API and charm blob downloads, designed for CI. Responses are cached by the
+// resolved charm identity (name + revision) so a charm deployed by pinned
+// revision (the provider) and the same charm resolved by channel (the Juju
+// controller) share one cache entry. Once warm, the proxy serves entirely
+// offline. The on-disk store is trivially cacheable via actions/cache.
 //
-// Two endpoints are served:
+// Store layout:
 //
-//   - POST /v2/charms/refresh: responses are cached by the *resolved* charm
-//     identity (name + revision) read back from the response, not by the
-//     request. This lets a charm the provider deploys by pinned revision and
-//     the same charm the controller resolves by channel converge on one cache
-//     entry. A channel->revision index lets channel-only requests resolve
-//     offline, and an id->name index lets refresh-by-id requests (e.g. the
-//     charmrevisioner worker) resolve offline. On a hit the stored JSON is
-//     replayed verbatim; on a miss the request is forwarded upstream, embedded
-//     download URLs are rewritten to route through this proxy, and the
-//     response is stored. Once warm, the proxy serves entirely offline.
-//   - GET /blob/<hash>: serves a cached charm blob from disk. On a miss the
-//     blob is fetched from the real upstream CDN URL (following redirects),
-//     streamed to disk, and served.
+//	<store>/refresh/<key>.json   # response keyed by resolved name@revision
+//	<store>/channels/<key>.rev   # channel+base -> resolved revision index
+//	<store>/ids/<key>.name       # charmhub id+revision -> name index
+//	<store>/blobs/<hash>         # charm blob bytes
+//	<store>/blobs/<hash>.url     # real upstream URL for cold backfill
 //
-// The store layout is:
-//
-//	<store>/refresh/<key>.json          # response keyed by resolved name@revision
-//	<store>/channels/<key>.rev          # channel+base -> resolved revision index
-//	<store>/ids/<key>.name              # charmhub id+revision -> name index
-//	<store>/blobs/<hash>                # charm blob bytes
-//	<store>/blobs/<hash>.url            # the real upstream URL for cold backfill
-//
-// Because charm revisions are immutable, cache entries never expire.
+// Charm revisions are immutable, so entries never expire.
 package main
 
 import (
@@ -53,18 +39,11 @@ import (
 )
 
 const (
-	// refreshPath is the CharmHub refresh endpoint. Both the provider's
-	// direct client and the Juju controller post here.
 	refreshPath = "/v2/charms/refresh"
 
-	// blobPathPrefix is the path prefix under which rewritten download URLs
-	// are served. The segment after the prefix is the blob's sha256, which
-	// doubles as the on-disk filename.
+	// blobPathPrefix is where rewritten download URLs are served; the
+	// segment after it is the blob's sha256, doubling as the on-disk name.
 	blobPathPrefix = "/blob/"
-
-	// downloadURLField is the JSON path (within each refresh result) that
-	// carries the upstream CDN URL for the charm blob.
-	downloadURLField = "url"
 )
 
 func main() {
@@ -90,8 +69,6 @@ func main() {
 	mux := http.NewServeMux()
 	mux.Handle(refreshPath, http.HandlerFunc(proxy.handleRefresh))
 	mux.Handle(blobPathPrefix, http.HandlerFunc(proxy.handleBlob))
-	// Readiness endpoint: CI polls this (e.g. curl --retry) before pointing
-	// the controller and provider at the proxy.
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
@@ -112,23 +89,11 @@ func main() {
 type server struct {
 	store    *store
 	upstream string
-	baseURL  string // externally reachable URL of this proxy, for rewriting download URLs
+	baseURL  string // externally reachable URL, for rewriting download URLs
 }
 
-// handleRefresh serves POST /v2/charms/refresh.
-//
-// The cache is keyed by the *resolved* charm identity (name + revision), not
-// the request. This is what makes the proxy serve offline across clients:
-// the provider requests a charm by pinned revision (revision=77), while the
-// Juju controller resolves the same charm by channel (latest/stable). Both
-// converge on the same (name, revision) once Charmhub answers, so we store
-// the response under that canonical key and maintain a channel->revision
-// index so channel-only requests can be answered offline too.
-//
-// On a hit the stored response is replayed verbatim. On a miss the request is
-// forwarded to upstream; the response is parsed to learn the resolved
-// (name, revision), its download URLs are rewritten to route through this
-// proxy, and it is stored under both the canonical key and the channel index.
+// handleRefresh serves POST /v2/charms/refresh. See the package comment for
+// the caching strategy.
 func (s *server) handleRefresh(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
@@ -148,16 +113,13 @@ func (s *server) handleRefresh(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Try to answer from cache. A request is answerable offline only if every
-	// action resolves to a cached entry (directly by revision, or via the
-	// channel index). We only support single-action requests for offline
-	// replay; multi-action requests fall through to upstream.
+	// Only single-action requests are replayed from cache; multi-action
+	// requests fall through to upstream.
 	if len(actions) == 1 {
 		if cached, ok := s.store.LookupRefresh(actions[0]); ok {
-			// Rewrite the instance-key in the cached response to match the
-			// current request. The instance-key is a per-request UUID; the
-			// cached response carries the original request's key, which won't
-			// match and causes the client's Ensure() to reject it.
+			// The instance-key is a per-request UUID; the cached response
+			// carries the original request's key, which the client's
+			// Ensure() would reject. Rewrite it to match.
 			replayed := rewriteInstanceKey(cached, actions[0].InstanceKey)
 			w.Header().Set("Content-Type", "application/json")
 			w.Header().Set("X-Charmhub-Cache", "HIT")
@@ -197,13 +159,11 @@ func (s *server) handleRefresh(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Rewrite download URLs so blob fetches route back through this proxy,
-	// then store under the resolved identity and return the rewritten bytes.
+	// Rewrite download URLs so blob fetches route back through this proxy.
 	rewritten, err := rewriteDownloadURLs(respBody, s.store, s.baseURL)
 	if err != nil {
-		// Rewriting failed: fall back to returning the original so we never
-		// break a deploy because of a schema surprise. The blob path will
-		// then hit the live CDN directly.
+		// Never break a deploy over a schema surprise; the blob path will
+		// hit the live CDN directly.
 		log.Printf("charmhub-cache: rewrite failed (%v); returning raw response", err)
 		w.Header().Set("Content-Type", "application/json")
 		w.Header().Set("X-Charmhub-Cache", "MISS")
@@ -211,9 +171,7 @@ func (s *server) handleRefresh(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Store under the resolved (name, revision) and record the channel index
-	// so future channel-only requests resolve offline. Best-effort: a store
-	// failure must not fail the deploy.
+	// Best-effort: a store failure must not fail the deploy.
 	if err := s.store.PutRefresh(actions, rewritten); err != nil {
 		log.Printf("charmhub-cache: store refresh failed: %v", err)
 	}
@@ -223,11 +181,8 @@ func (s *server) handleRefresh(w http.ResponseWriter, r *http.Request) {
 	_, _ = w.Write(rewritten)
 }
 
-// handleBlob serves GET /blob/<hash>.
-//
-// The <hash> is the charm blob's sha256 (as reported by the refresh
-// response's download.hash-sha-256). On a miss the blob is fetched from the
-// real upstream URL recorded when the refresh response was rewritten.
+// handleBlob serves GET /blob/<hash>, where <hash> is the blob's sha256 as
+// reported by the refresh response's download.hash-sha-256.
 func (s *server) handleBlob(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet && r.Method != http.MethodHead {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
@@ -255,10 +210,8 @@ func (s *server) handleBlob(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Fetch from the upstream CDN, following redirects, streaming to disk
-	// and to the client simultaneously. fetchAndStoreBlob reports whether it
-	// began writing the body; if it failed before writing anything we can
-	// still send an error status, otherwise the response is already committed.
+	// fetchAndStoreBlob reports whether it began writing the body; if it
+	// failed before writing anything we can still send an error status.
 	wrote, err := s.fetchAndStoreBlob(r.Context(), hash, realURL, w)
 	if err != nil {
 		log.Printf("charmhub-cache: blob fetch %s failed: %v", hash, err)
@@ -268,10 +221,8 @@ func (s *server) handleBlob(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// fetchAndStoreBlob downloads the blob from the upstream CDN URL, teeing the
-// bytes to both the on-disk store and the HTTP response. It returns whether
-// any response bytes were written, so the caller can decide if an error
-// status can still be sent.
+// fetchAndStoreBlob downloads the blob, teeing bytes to the store and the
+// client. It returns whether any response bytes were written.
 func (s *server) fetchAndStoreBlob(ctx context.Context, hash, realURL string, w http.ResponseWriter) (bool, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, realURL, nil)
 	if err != nil {
@@ -286,8 +237,7 @@ func (s *server) fetchAndStoreBlob(ctx context.Context, hash, realURL string, w 
 		return false, fmt.Errorf("upstream status %d", resp.StatusCode)
 	}
 
-	// Tee into the store while streaming to the client. The store writer is
-	// buffered to a temp file and renamed on close, so a partial download
+	// Buffered to a temp file and renamed on commit, so a partial download
 	// never leaves a corrupt entry.
 	sink, commit, err := s.store.BeginBlob(hash)
 	if err != nil {
@@ -318,18 +268,16 @@ func contentLength(resp *http.Response) (int64, bool) {
 	return 0, false
 }
 
-// action is a single parsed refresh request action. Only the fields needed
-// for cache keying are captured.
+// action is a single parsed refresh request action.
 //
 // Two wire shapes exist:
-//   - install/download-by-name (provider, controller fresh deploy): the action
-//     carries Name and optional Revision/Channel/Base.
-//   - refresh-by-id (controller re-resolve, charmrevisioner): the action
-//     carries only ID; Revision/Channel/Base live in the matching context
-//     entry (keyed by instance-key).
+//   - by-name (provider, controller fresh deploy): Name plus optional
+//     Revision/Channel/Base in the action.
+//   - by-id (controller re-resolve, charmrevisioner): only ID in the action;
+//     Revision/Channel/Base live in the matching context entry.
 type action struct {
-	ID          string // charmhub charm ID (refresh-by-id); empty for by-name
-	Name        string // charm name (by-name); empty for by-id
+	ID          string
+	Name        string
 	Channel     string
 	Revision    *int
 	Base        string // "arch/os/channel", empty if absent
@@ -337,9 +285,8 @@ type action struct {
 }
 
 // parseRefreshActions extracts the actions from a refresh request body,
-// merging in revision/channel/base from the context array for refresh-by-id
-// requests (matched by instance-key). It returns an error only if the body is
-// not valid JSON; a request with no actions yields an empty slice.
+// merging revision/channel/base from the context array (matched by
+// instance-key) for by-id requests.
 func parseRefreshActions(body []byte) ([]action, error) {
 	var req struct {
 		Context []struct {
@@ -369,8 +316,8 @@ func parseRefreshActions(body []byte) ([]action, error) {
 		return nil, err
 	}
 
-	// Index context entries by instance-key so refresh-by-id actions can pick
-	// up their revision/channel/base.
+	// Index context entries by instance-key so by-id actions can pick up
+	// their revision/channel/base.
 	type ctxInfo struct {
 		revision *int
 		channel  string
@@ -391,7 +338,7 @@ func parseRefreshActions(body []byte) ([]action, error) {
 		if a.Base != nil {
 			act.Base = fmt.Sprintf("%s/%s/%s", a.Base.Architecture, a.Base.Name, a.Base.Channel)
 		}
-		// For refresh-by-id, revision/channel/base come from the context.
+		// For by-id requests, revision/channel/base come from the context.
 		if ci, ok := ctxByKey[a.InstanceKey]; ok {
 			if act.Revision == nil {
 				act.Revision = ci.revision
@@ -408,14 +355,10 @@ func parseRefreshActions(body []byte) ([]action, error) {
 	return actions, nil
 }
 
-// rewriteDownloadURLs rewrites the download.url field in each refresh result
-// to point at this proxy's /blob/<hash> endpoint, recording the real upstream
-// rewriteInstanceKey replaces the instance-key in each refresh result with the
-// given key. The instance-key is a per-request UUID; a cached response carries
-// the original request's key, which won't match the current request and causes
-// the client's Ensure() to reject it ("install action key not valid"). Uses
-// map[string]any to preserve all other fields verbatim. If parsing fails the
-// original body is returned unchanged (best-effort).
+// rewriteInstanceKey replaces the instance-key in each result with the given
+// key, so a replayed response passes the client's Ensure() check. Uses
+// map[string]any to preserve all other fields verbatim; on any parse failure
+// the original body is returned unchanged.
 func rewriteInstanceKey(body []byte, instanceKey string) []byte {
 	if instanceKey == "" {
 		return body
@@ -442,12 +385,10 @@ func rewriteInstanceKey(body []byte, instanceKey string) []byte {
 	return rewritten
 }
 
-// rewriteDownloadURLs rewrites the download.url field in each refresh result
-// to point at this proxy's /blob/<hash> endpoint, recording the real upstream
-// URL for later backfill. It operates on generic JSON (map[string]any) so
-// that fields not modelled by the transport package are preserved verbatim.
-// proxyBase is the externally reachable URL of this proxy (e.g.
-// http://127.0.0.1:8080); Juju's charm downloader requires absolute URLs.
+// rewriteDownloadURLs rewrites each result's download.url to point at this
+// proxy's /blob/<hash> endpoint, recording the real upstream URL for later
+// backfill. Uses map[string]any so unmodelled fields are preserved verbatim.
+// Juju's charm downloader requires absolute URLs, hence proxyBase.
 func rewriteDownloadURLs(body []byte, st *store, proxyBase string) ([]byte, error) {
 	var doc map[string]any
 	if err := json.Unmarshal(body, &doc); err != nil {
@@ -473,37 +414,31 @@ func rewriteDownloadURLs(body []byte, st *store, proxyBase string) ([]byte, erro
 		if !ok {
 			continue
 		}
-		realURL, _ := download[downloadURLField].(string)
+		realURL, _ := download["url"].(string)
 		if realURL == "" {
 			continue
 		}
 		hash, _ := download["hash-sha-256"].(string)
 		if hash == "" {
-			// Fall back to a hash of the URL so we still have a stable key.
 			sum := sha256.Sum256([]byte(realURL))
 			hash = hex.EncodeToString(sum[:])
 		}
-		// Record the real URL so a blob miss can backfill from upstream.
 		if err := st.PutBlobURL(hash, realURL); err != nil {
 			return nil, fmt.Errorf("record blob url: %w", err)
 		}
-		// Rewrite the URL to an absolute URL routing through this proxy.
-		// Juju's charm downloader requires an absolute URL.
-		download[downloadURLField] = proxyBase + blobPathPrefix + hash
+		download["url"] = proxyBase + blobPathPrefix + hash
 	}
 
 	return json.Marshal(doc)
 }
 
-// httpClient is used for all upstream fetches. It follows redirects (the
-// CharmHub blob CDN issues 302s) and uses a generous timeout suitable for
-// large charm blobs.
+// httpClient follows redirects (the CharmHub blob CDN issues 302s) and uses
+// a generous timeout suitable for large charm blobs.
 var httpClient = &http.Client{
 	Timeout:       5 * time.Minute,
 	CheckRedirect: func(*http.Request, []*http.Request) error { return nil },
 }
 
-// isHex reports whether s is a non-empty lowercase hex string.
 func isHex(s string) bool {
 	if s == "" {
 		return false
@@ -535,38 +470,33 @@ func newStore(dir string) (*store, error) {
 	return &store{dir: dir}, nil
 }
 
-// canonicalKey returns the on-disk key for a resolved charm identity. The
-// response is stored under this key so that any request resolving to the same
-// (name, revision) — whether by pinned revision or by channel — hits it.
+// canonicalKey returns the on-disk key for a resolved charm identity.
 func canonicalKey(name string, revision int) string {
-	sum := sha256.Sum256([]byte(fmt.Sprintf("%s@%d", name, revision)))
+	sum := sha256.Sum256(fmt.Appendf(nil, "%s@%d", name, revision))
 	return hex.EncodeToString(sum[:])
 }
 
-// channelKey returns the on-disk key for the channel->revision index entry.
 func channelKey(name, channel, base string) string {
-	sum := sha256.Sum256([]byte(fmt.Sprintf("%s|%s|%s", name, channel, base)))
+	sum := sha256.Sum256(fmt.Appendf(nil, "%s|%s|%s", name, channel, base))
 	return hex.EncodeToString(sum[:])
 }
 
-// LookupRefresh returns the cached response for a single action. It resolves
-//   - pinned-revision requests directly via the canonical (name, revision) key,
-//   - channel-only requests via the channel->revision index, then canonical,
-//   - refresh-by-id requests (charmrevisioner / re-resolve) via the id index,
-//     then the revision-keyed canonical entry for the SAME id+revision.
-//
-// It returns false if the action cannot be answered from cache.
+func idKey(id string, revision int) string {
+	sum := sha256.Sum256(fmt.Appendf(nil, "%s@%d", id, revision))
+	return hex.EncodeToString(sum[:])
+}
+
+// LookupRefresh returns the cached response for a single action, resolving:
+//   - pinned-revision requests via the canonical (name, revision) key,
+//   - channel-only requests via the channel->revision index,
+//   - by-id requests via the id->name index (requires a revision).
 func (s *store) LookupRefresh(a action) ([]byte, bool) {
 	s.refreshMu.Lock()
 	defer s.refreshMu.Unlock()
 
-	// refresh-by-id: the action carries the charmhub ID, not the name. Resolve
-	// the id to its canonical (name, revision) via the ids index. The id index
-	// stores "name@revision" keyed by id+revision so the same id at a new
-	// revision is a distinct entry.
 	if a.Name == "" && a.ID != "" {
 		if a.Revision == nil {
-			return nil, false // can't key an id lookup without a revision
+			return nil, false
 		}
 		nameBytes, err := os.ReadFile(filepath.Join(s.dir, "ids", idKey(a.ID, *a.Revision)+".name"))
 		if err != nil {
@@ -585,11 +515,8 @@ func (s *store) LookupRefresh(a action) ([]byte, bool) {
 
 	var key string
 	if a.Revision != nil {
-		// Pinned revision: direct canonical lookup.
 		key = canonicalKey(a.Name, *a.Revision)
 	} else if a.Channel != "" {
-		// Channel-only: resolve via the channel index to a revision, then
-		// look up the canonical entry.
 		revBytes, err := os.ReadFile(filepath.Join(s.dir, "channels", channelKey(a.Name, a.Channel, a.Base)+".rev"))
 		if err != nil {
 			return nil, false
@@ -610,18 +537,9 @@ func (s *store) LookupRefresh(a action) ([]byte, bool) {
 	return b, true
 }
 
-// idKey returns the on-disk key for the id->name index, scoped by revision so
-// the same charm id at different revisions maps to distinct canonical entries.
-func idKey(id string, revision int) string {
-	sum := sha256.Sum256([]byte(fmt.Sprintf("%s@%d", id, revision)))
-	return hex.EncodeToString(sum[:])
-}
-
-// PutRefresh stores a refresh response under the resolved (name, revision)
-// identity and records the channel->revision index for each action that
-// specified a channel. The resolved identity is read back from the response
-// body (each result's charm.name and charm.revision), so the store reflects
-// what Charmhub actually resolved to.
+// PutRefresh stores a response under the resolved (name, revision) identity
+// read back from the response body, and records the channel and id indexes
+// so future channel-only and by-id requests resolve offline.
 func (s *store) PutRefresh(actions []action, body []byte) error {
 	s.refreshMu.Lock()
 	defer s.refreshMu.Unlock()
@@ -634,8 +552,7 @@ func (s *store) PutRefresh(actions []action, body []byte) error {
 		return errors.New("no resolved results in response")
 	}
 
-	// Store the response under the canonical key of the first result. The
-	// proxy only caches single-action requests, so there is exactly one.
+	// Only single-action requests are cached, so there is exactly one result.
 	name, rev := resolved[0].name, resolved[0].revision
 	path := filepath.Join(s.dir, "refresh", canonicalKey(name, rev)+".json")
 	tmp := path + ".tmp"
@@ -646,8 +563,6 @@ func (s *store) PutRefresh(actions []action, body []byte) error {
 		return err
 	}
 
-	// Record the id->name index so refresh-by-id requests (charmrevisioner,
-	// re-resolve) resolve offline. The id comes from the response entity.
 	if id := resolved[0].id; id != "" {
 		idPath := filepath.Join(s.dir, "ids", idKey(id, rev)+".name")
 		if err := os.WriteFile(idPath, []byte(name), 0o644); err != nil {
@@ -655,31 +570,21 @@ func (s *store) PutRefresh(actions []action, body []byte) error {
 		}
 	}
 
-	// Record the channel index for any action that named a channel, so
-	// future channel-only requests for the same channel/base resolve offline.
 	for _, a := range actions {
 		if a.Channel == "" {
 			continue
 		}
-		// For by-name actions use the action's name; for by-id actions use the
-		// resolved name (the action has no name).
+		// By-id actions have no name; use the resolved name.
 		chName := a.Name
 		if chName == "" {
 			chName = name
 		}
 		revPath := filepath.Join(s.dir, "channels", channelKey(chName, a.Channel, a.Base)+".rev")
-		if err := os.WriteFile(revPath, []byte(fmt.Sprintf("%d", rev)), 0o644); err != nil {
+		if err := os.WriteFile(revPath, fmt.Appendf(nil, "%d", rev), 0o644); err != nil {
 			return err
 		}
 	}
 	return nil
-}
-
-// resolvedIdentity is the (id, name, revision) a refresh result resolved to.
-type resolvedIdentity struct {
-	id       string
-	name     string
-	revision int
 }
 
 // resolvedIdentities parses a refresh response and returns the resolved
@@ -707,7 +612,12 @@ func resolvedIdentities(body []byte) ([]resolvedIdentity, error) {
 	return out, nil
 }
 
-// OpenBlob opens a cached blob for reading. The caller must close the file.
+type resolvedIdentity struct {
+	id       string
+	name     string
+	revision int
+}
+
 func (s *store) OpenBlob(hash string) (*os.File, bool) {
 	path := filepath.Join(s.dir, "blobs", hash)
 	f, err := os.Open(path)
@@ -717,7 +627,6 @@ func (s *store) OpenBlob(hash string) (*os.File, bool) {
 	return f, true
 }
 
-// BlobURL returns the recorded upstream URL for a blob hash.
 func (s *store) BlobURL(hash string) (string, bool) {
 	b, err := os.ReadFile(filepath.Join(s.dir, "blobs", hash+".url"))
 	if err != nil {
@@ -726,16 +635,14 @@ func (s *store) BlobURL(hash string) (string, bool) {
 	return strings.TrimSpace(string(b)), true
 }
 
-// PutBlobURL records the upstream URL for a blob hash.
 func (s *store) PutBlobURL(hash, url string) error {
 	path := filepath.Join(s.dir, "blobs", hash+".url")
 	return os.WriteFile(path, []byte(url), 0o644)
 }
 
-// BeginBlob returns a writer that buffers the blob to a unique temp file.
-// Call commit to atomically promote it to its final name. A unique temp name
-// (via os.CreateTemp) prevents two concurrent fetches of the same blob from
-// truncating each other's writes.
+// BeginBlob returns a writer that buffers the blob to a unique temp file;
+// call commit to atomically promote it to its final name. A unique temp name
+// prevents concurrent fetches of the same blob from truncating each other.
 func (s *store) BeginBlob(hash string) (sink io.WriteCloser, commit func() error, err error) {
 	s.blobMu.Lock()
 	defer s.blobMu.Unlock()

--- a/tools/charmhub-cache/main.go
+++ b/tools/charmhub-cache/main.go
@@ -218,9 +218,15 @@ func (s *server) handleRefresh(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Best-effort: a store failure must not fail the deploy.
-	if err := s.store.PutRefresh(rewritten); err != nil {
-		log.Printf("charmhub-cache: store refresh failed: %v", err)
+	// Only cache single-action responses. A batched (multi-action) response
+	// contains multiple results; storing it under one canonical key would
+	// later be replayed to an unrelated single-action request expecting
+	// exactly one result, which the client rejects ("more than 1 result
+	// found"). Best-effort: a store failure must not fail the deploy.
+	if len(actions) == 1 {
+		if err := s.store.PutRefresh(rewritten); err != nil {
+			log.Printf("charmhub-cache: store refresh failed: %v", err)
+		}
 	}
 
 	w.Header().Set("Content-Type", "application/json")
@@ -569,6 +575,11 @@ func (s *store) LookupRefresh(a action) ([]byte, bool) {
 // PutRefresh stores a response under the resolved (name, revision) identity
 // read back from the response body, and records the id index so future by-id
 // requests for the same immutable id+revision resolve offline.
+//
+// body must contain exactly one result. A multi-result (batched) response
+// must never be cached here: it would later be replayed verbatim to an
+// unrelated single-action request, which the Juju client rejects with
+// "more than 1 result found" (it requires exactly one result per action).
 func (s *store) PutRefresh(body []byte) error {
 	s.refreshMu.Lock()
 	defer s.refreshMu.Unlock()
@@ -579,6 +590,9 @@ func (s *store) PutRefresh(body []byte) error {
 	}
 	if len(resolved) == 0 {
 		return errors.New("no resolved results in response")
+	}
+	if len(resolved) > 1 {
+		return fmt.Errorf("refusing to cache a multi-result response (%d results)", len(resolved))
 	}
 
 	// Only single-action requests are cached, so there is exactly one result.

--- a/tools/charmhub-cache/main.go
+++ b/tools/charmhub-cache/main.go
@@ -1,0 +1,713 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the Apache License, Version 2.0, see LICENCE file for details.
+
+// Command charmhub-cache is a caching reverse proxy for the CharmHub refresh
+// API and charm blob downloads. It is designed for CI: it makes charm metadata
+// and blob fetches deterministic and resilient to CharmHub outages, and its
+// on-disk store is trivially cacheable via actions/cache.
+//
+// Two endpoints are served:
+//
+//   - POST /v2/charms/refresh: responses are cached by the *resolved* charm
+//     identity (name + revision) read back from the response, not by the
+//     request. This lets a charm the provider deploys by pinned revision and
+//     the same charm the controller resolves by channel converge on one cache
+//     entry. A channel->revision index lets channel-only requests resolve
+//     offline, and an id->name index lets refresh-by-id requests (e.g. the
+//     charmrevisioner worker) resolve offline. On a hit the stored JSON is
+//     replayed verbatim; on a miss the request is forwarded upstream, embedded
+//     download URLs are rewritten to route through this proxy, and the
+//     response is stored. Once warm, the proxy serves entirely offline.
+//   - GET /blob/<hash>: serves a cached charm blob from disk. On a miss the
+//     blob is fetched from the real upstream CDN URL (following redirects),
+//     streamed to disk, and served.
+//
+// The store layout is:
+//
+//	<store>/refresh/<key>.json          # response keyed by resolved name@revision
+//	<store>/channels/<key>.rev          # channel+base -> resolved revision index
+//	<store>/ids/<key>.name              # charmhub id+revision -> name index
+//	<store>/blobs/<hash>                # charm blob bytes
+//	<store>/blobs/<hash>.url            # the real upstream URL for cold backfill
+//
+// Because charm revisions are immutable, cache entries never expire.
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	// refreshPath is the CharmHub refresh endpoint. Both the provider's
+	// direct client and the Juju controller post here.
+	refreshPath = "/v2/charms/refresh"
+
+	// blobPathPrefix is the path prefix under which rewritten download URLs
+	// are served. The segment after the prefix is the blob's sha256, which
+	// doubles as the on-disk filename.
+	blobPathPrefix = "/blob/"
+
+	// downloadURLField is the JSON path (within each refresh result) that
+	// carries the upstream CDN URL for the charm blob.
+	downloadURLField = "url"
+)
+
+func main() {
+	var (
+		addr     = flag.String("addr", "127.0.0.1:8080", "address to listen on")
+		storeDir = flag.String("store", "charmhub-cache-store", "directory for the on-disk cache")
+		upstream = flag.String("upstream", "https://api.charmhub.io", "upstream CharmHub API base URL")
+		baseURL  = flag.String("base-url", "http://127.0.0.1:8080", "externally reachable base URL of this proxy, used to rewrite charm download URLs")
+	)
+	flag.Parse()
+
+	store, err := newStore(*storeDir)
+	if err != nil {
+		log.Fatalf("charmhub-cache: open store: %v", err)
+	}
+
+	proxy := &server{
+		store:    store,
+		upstream: strings.TrimRight(*upstream, "/"),
+		baseURL:  strings.TrimRight(*baseURL, "/"),
+	}
+
+	mux := http.NewServeMux()
+	mux.Handle(refreshPath, http.HandlerFunc(proxy.handleRefresh))
+	mux.Handle(blobPathPrefix, http.HandlerFunc(proxy.handleBlob))
+	// Readiness endpoint: CI polls this (e.g. curl --retry) before pointing
+	// the controller and provider at the proxy.
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	srv := &http.Server{
+		Addr:              *addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+
+	log.Printf("charmhub-cache: listening on %s (upstream=%s store=%s)", *addr, *upstream, *storeDir)
+	if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		log.Fatalf("charmhub-cache: %v", err)
+	}
+}
+
+// server implements the caching proxy.
+type server struct {
+	store    *store
+	upstream string
+	baseURL  string // externally reachable URL of this proxy, for rewriting download URLs
+}
+
+// handleRefresh serves POST /v2/charms/refresh.
+//
+// The cache is keyed by the *resolved* charm identity (name + revision), not
+// the request. This is what makes the proxy serve offline across clients:
+// the provider requests a charm by pinned revision (revision=77), while the
+// Juju controller resolves the same charm by channel (latest/stable). Both
+// converge on the same (name, revision) once Charmhub answers, so we store
+// the response under that canonical key and maintain a channel->revision
+// index so channel-only requests can be answered offline too.
+//
+// On a hit the stored response is replayed verbatim. On a miss the request is
+// forwarded to upstream; the response is parsed to learn the resolved
+// (name, revision), its download URLs are rewritten to route through this
+// proxy, and it is stored under both the canonical key and the channel index.
+func (s *server) handleRefresh(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("read body: %v", err), http.StatusBadRequest)
+		return
+	}
+	_ = r.Body.Close()
+
+	actions, err := parseRefreshActions(body)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("parse refresh request: %v", err), http.StatusBadRequest)
+		return
+	}
+
+	// Try to answer from cache. A request is answerable offline only if every
+	// action resolves to a cached entry (directly by revision, or via the
+	// channel index). We only support single-action requests for offline
+	// replay; multi-action requests fall through to upstream.
+	if len(actions) == 1 {
+		if cached, ok := s.store.LookupRefresh(actions[0]); ok {
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("X-Charmhub-Cache", "HIT")
+			_, _ = w.Write(cached)
+			return
+		}
+	}
+
+	// Cache miss: forward to upstream and capture the response.
+	upstreamURL := s.upstream + refreshPath
+	req, err := http.NewRequestWithContext(r.Context(), http.MethodPost, upstreamURL, bytes.NewReader(body))
+	if err != nil {
+		http.Error(w, fmt.Sprintf("build upstream request: %v", err), http.StatusBadGateway)
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("upstream unreachable and no cache entry: %v", err), http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("read upstream: %v", err), http.StatusBadGateway)
+		return
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		// Pass non-200 responses through unmodified; they are not cached.
+		w.Header().Set("Content-Type", resp.Header.Get("Content-Type"))
+		w.WriteHeader(resp.StatusCode)
+		_, _ = w.Write(respBody)
+		return
+	}
+
+	// Rewrite download URLs so blob fetches route back through this proxy,
+	// then store under the resolved identity and return the rewritten bytes.
+	rewritten, err := rewriteDownloadURLs(respBody, s.store, s.baseURL)
+	if err != nil {
+		// Rewriting failed: fall back to returning the original so we never
+		// break a deploy because of a schema surprise. The blob path will
+		// then hit the live CDN directly.
+		log.Printf("charmhub-cache: rewrite failed (%v); returning raw response", err)
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Charmhub-Cache", "MISS")
+		_, _ = w.Write(respBody)
+		return
+	}
+
+	// Store under the resolved (name, revision) and record the channel index
+	// so future channel-only requests resolve offline. Best-effort: a store
+	// failure must not fail the deploy.
+	if err := s.store.PutRefresh(actions, rewritten); err != nil {
+		log.Printf("charmhub-cache: store refresh failed: %v", err)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("X-Charmhub-Cache", "MISS")
+	_, _ = w.Write(rewritten)
+}
+
+// handleBlob serves GET /blob/<hash>.
+//
+// The <hash> is the charm blob's sha256 (as reported by the refresh
+// response's download.hash-sha-256). On a miss the blob is fetched from the
+// real upstream URL recorded when the refresh response was rewritten.
+func (s *server) handleBlob(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	hash := strings.TrimPrefix(r.URL.Path, blobPathPrefix)
+	if hash == "" || !isHex(hash) {
+		http.Error(w, "bad blob id", http.StatusBadRequest)
+		return
+	}
+
+	// Fast path: serve from disk.
+	if f, ok := s.store.OpenBlob(hash); ok {
+		defer f.Close()
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.Header().Set("X-Charmhub-Cache", "HIT")
+		_, _ = io.Copy(w, f)
+		return
+	}
+
+	// Miss: look up the real upstream URL we recorded for this hash.
+	realURL, ok := s.store.BlobURL(hash)
+	if !ok {
+		http.Error(w, "blob not found and no upstream URL recorded", http.StatusNotFound)
+		return
+	}
+
+	// Fetch from the upstream CDN, following redirects, streaming to disk
+	// and to the client simultaneously. fetchAndStoreBlob reports whether it
+	// began writing the body; if it failed before writing anything we can
+	// still send an error status, otherwise the response is already committed.
+	wrote, err := s.fetchAndStoreBlob(r.Context(), hash, realURL, w)
+	if err != nil {
+		log.Printf("charmhub-cache: blob fetch %s failed: %v", hash, err)
+		if !wrote {
+			http.Error(w, fmt.Sprintf("blob fetch failed: %v", err), http.StatusBadGateway)
+		}
+	}
+}
+
+// fetchAndStoreBlob downloads the blob from the upstream CDN URL, teeing the
+// bytes to both the on-disk store and the HTTP response. It returns whether
+// any response bytes were written, so the caller can decide if an error
+// status can still be sent.
+func (s *server) fetchAndStoreBlob(ctx context.Context, hash, realURL string, w http.ResponseWriter) (bool, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, realURL, nil)
+	if err != nil {
+		return false, fmt.Errorf("build request: %w", err)
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return false, fmt.Errorf("fetch: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return false, fmt.Errorf("upstream status %d", resp.StatusCode)
+	}
+
+	// Tee into the store while streaming to the client. The store writer is
+	// buffered to a temp file and renamed on close, so a partial download
+	// never leaves a corrupt entry.
+	sink, commit, err := s.store.BeginBlob(hash)
+	if err != nil {
+		return false, fmt.Errorf("begin store: %w", err)
+	}
+	defer sink.Close()
+
+	w.Header().Set("Content-Type", "application/octet-stream")
+	w.Header().Set("X-Charmhub-Cache", "MISS")
+	if n, ok := contentLength(resp); ok {
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", n))
+	}
+
+	mw := io.MultiWriter(w, sink)
+	if _, err := io.Copy(mw, resp.Body); err != nil {
+		return true, fmt.Errorf("copy: %w", err)
+	}
+	if err := commit(); err != nil {
+		return true, fmt.Errorf("commit: %w", err)
+	}
+	return true, nil
+}
+
+func contentLength(resp *http.Response) (int64, bool) {
+	if resp.ContentLength > 0 {
+		return resp.ContentLength, true
+	}
+	return 0, false
+}
+
+// action is a single parsed refresh request action. Only the fields needed
+// for cache keying are captured.
+//
+// Two wire shapes exist:
+//   - install/download-by-name (provider, controller fresh deploy): the action
+//     carries Name and optional Revision/Channel/Base.
+//   - refresh-by-id (controller re-resolve, charmrevisioner): the action
+//     carries only ID; Revision/Channel/Base live in the matching context
+//     entry (keyed by instance-key).
+type action struct {
+	ID       string // charmhub charm ID (refresh-by-id); empty for by-name
+	Name     string // charm name (by-name); empty for by-id
+	Channel  string
+	Revision *int
+	Base     string // "arch/os/channel", empty if absent
+}
+
+// parseRefreshActions extracts the actions from a refresh request body,
+// merging in revision/channel/base from the context array for refresh-by-id
+// requests (matched by instance-key). It returns an error only if the body is
+// not valid JSON; a request with no actions yields an empty slice.
+func parseRefreshActions(body []byte) ([]action, error) {
+	var req struct {
+		Context []struct {
+			InstanceKey     string `json:"instance-key"`
+			Revision        *int   `json:"revision"`
+			TrackingChannel string `json:"tracking-channel"`
+			Base            *struct {
+				Architecture string `json:"architecture"`
+				Name         string `json:"name"`
+				Channel      string `json:"channel"`
+			} `json:"base"`
+		} `json:"context"`
+		Actions []struct {
+			InstanceKey string `json:"instance-key"`
+			ID          string `json:"id"`
+			Name        string `json:"name"`
+			Channel     string `json:"channel"`
+			Revision    *int   `json:"revision"`
+			Base        *struct {
+				Architecture string `json:"architecture"`
+				Name         string `json:"name"`
+				Channel      string `json:"channel"`
+			} `json:"base"`
+		} `json:"actions"`
+	}
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, err
+	}
+
+	// Index context entries by instance-key so refresh-by-id actions can pick
+	// up their revision/channel/base.
+	type ctxInfo struct {
+		revision *int
+		channel  string
+		base     string
+	}
+	ctxByKey := make(map[string]ctxInfo, len(req.Context))
+	for _, c := range req.Context {
+		base := ""
+		if c.Base != nil {
+			base = fmt.Sprintf("%s/%s/%s", c.Base.Architecture, c.Base.Name, c.Base.Channel)
+		}
+		ctxByKey[c.InstanceKey] = ctxInfo{revision: c.Revision, channel: c.TrackingChannel, base: base}
+	}
+
+	actions := make([]action, 0, len(req.Actions))
+	for _, a := range req.Actions {
+		act := action{ID: a.ID, Name: a.Name, Channel: a.Channel, Revision: a.Revision}
+		if a.Base != nil {
+			act.Base = fmt.Sprintf("%s/%s/%s", a.Base.Architecture, a.Base.Name, a.Base.Channel)
+		}
+		// For refresh-by-id, revision/channel/base come from the context.
+		if ci, ok := ctxByKey[a.InstanceKey]; ok {
+			if act.Revision == nil {
+				act.Revision = ci.revision
+			}
+			if act.Channel == "" {
+				act.Channel = ci.channel
+			}
+			if act.Base == "" {
+				act.Base = ci.base
+			}
+		}
+		actions = append(actions, act)
+	}
+	return actions, nil
+}
+
+// rewriteDownloadURLs rewrites the download.url field in each refresh result
+// to point at this proxy's /blob/<hash> endpoint, recording the real upstream
+// URL for later backfill. It operates on generic JSON (map[string]any) so
+// that fields not modelled by the transport package are preserved verbatim.
+// proxyBase is the externally reachable URL of this proxy (e.g.
+// http://127.0.0.1:8080); Juju's charm downloader requires absolute URLs.
+func rewriteDownloadURLs(body []byte, st *store, proxyBase string) ([]byte, error) {
+	var doc map[string]any
+	if err := json.Unmarshal(body, &doc); err != nil {
+		return nil, fmt.Errorf("unmarshal refresh response: %w", err)
+	}
+
+	results, ok := doc["results"].([]any)
+	if !ok {
+		// No results array (e.g. an error-list response): nothing to rewrite.
+		return body, nil
+	}
+
+	for _, res := range results {
+		result, ok := res.(map[string]any)
+		if !ok {
+			continue
+		}
+		entity, ok := result["charm"].(map[string]any)
+		if !ok {
+			continue
+		}
+		download, ok := entity["download"].(map[string]any)
+		if !ok {
+			continue
+		}
+		realURL, _ := download[downloadURLField].(string)
+		if realURL == "" {
+			continue
+		}
+		hash, _ := download["hash-sha-256"].(string)
+		if hash == "" {
+			// Fall back to a hash of the URL so we still have a stable key.
+			sum := sha256.Sum256([]byte(realURL))
+			hash = hex.EncodeToString(sum[:])
+		}
+		// Record the real URL so a blob miss can backfill from upstream.
+		if err := st.PutBlobURL(hash, realURL); err != nil {
+			return nil, fmt.Errorf("record blob url: %w", err)
+		}
+		// Rewrite the URL to an absolute URL routing through this proxy.
+		// Juju's charm downloader requires an absolute URL.
+		download[downloadURLField] = proxyBase + blobPathPrefix + hash
+	}
+
+	return json.Marshal(doc)
+}
+
+// httpClient is used for all upstream fetches. It follows redirects (the
+// CharmHub blob CDN issues 302s) and uses a generous timeout suitable for
+// large charm blobs.
+var httpClient = &http.Client{
+	Timeout:       5 * time.Minute,
+	CheckRedirect: func(*http.Request, []*http.Request) error { return nil },
+}
+
+// isHex reports whether s is a non-empty lowercase hex string.
+func isHex(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if !((r >= '0' && r <= '9') || (r >= 'a' && r <= 'f')) {
+			return false
+		}
+	}
+	return true
+}
+
+// --- store -----------------------------------------------------------------
+
+type store struct {
+	dir       string
+	refreshMu sync.Mutex
+	blobMu    sync.Mutex
+}
+
+func newStore(dir string) (*store, error) {
+	for _, sub := range []string{"refresh", "blobs", "channels", "ids"} {
+		if err := os.MkdirAll(filepath.Join(dir, sub), 0o755); err != nil {
+			return nil, err
+		}
+	}
+	return &store{dir: dir}, nil
+}
+
+// canonicalKey returns the on-disk key for a resolved charm identity. The
+// response is stored under this key so that any request resolving to the same
+// (name, revision) — whether by pinned revision or by channel — hits it.
+func canonicalKey(name string, revision int) string {
+	sum := sha256.Sum256([]byte(fmt.Sprintf("%s@%d", name, revision)))
+	return hex.EncodeToString(sum[:])
+}
+
+// channelKey returns the on-disk key for the channel->revision index entry.
+func channelKey(name, channel, base string) string {
+	sum := sha256.Sum256([]byte(fmt.Sprintf("%s|%s|%s", name, channel, base)))
+	return hex.EncodeToString(sum[:])
+}
+
+// LookupRefresh returns the cached response for a single action. It resolves
+//   - pinned-revision requests directly via the canonical (name, revision) key,
+//   - channel-only requests via the channel->revision index, then canonical,
+//   - refresh-by-id requests (charmrevisioner / re-resolve) via the id index,
+//     then the revision-keyed canonical entry for the SAME id+revision.
+//
+// It returns false if the action cannot be answered from cache.
+func (s *store) LookupRefresh(a action) ([]byte, bool) {
+	s.refreshMu.Lock()
+	defer s.refreshMu.Unlock()
+
+	// refresh-by-id: the action carries the charmhub ID, not the name. Resolve
+	// the id to its canonical (name, revision) via the ids index. The id index
+	// stores "name@revision" keyed by id+revision so the same id at a new
+	// revision is a distinct entry.
+	if a.Name == "" && a.ID != "" {
+		if a.Revision == nil {
+			return nil, false // can't key an id lookup without a revision
+		}
+		nameBytes, err := os.ReadFile(filepath.Join(s.dir, "ids", idKey(a.ID, *a.Revision)+".name"))
+		if err != nil {
+			return nil, false
+		}
+		name := strings.TrimSpace(string(nameBytes))
+		if name == "" {
+			return nil, false
+		}
+		b, err := os.ReadFile(filepath.Join(s.dir, "refresh", canonicalKey(name, *a.Revision)+".json"))
+		if err != nil {
+			return nil, false
+		}
+		return b, true
+	}
+
+	var key string
+	if a.Revision != nil {
+		// Pinned revision: direct canonical lookup.
+		key = canonicalKey(a.Name, *a.Revision)
+	} else if a.Channel != "" {
+		// Channel-only: resolve via the channel index to a revision, then
+		// look up the canonical entry.
+		revBytes, err := os.ReadFile(filepath.Join(s.dir, "channels", channelKey(a.Name, a.Channel, a.Base)+".rev"))
+		if err != nil {
+			return nil, false
+		}
+		var rev int
+		if _, err := fmt.Sscanf(strings.TrimSpace(string(revBytes)), "%d", &rev); err != nil {
+			return nil, false
+		}
+		key = canonicalKey(a.Name, rev)
+	} else {
+		return nil, false
+	}
+
+	b, err := os.ReadFile(filepath.Join(s.dir, "refresh", key+".json"))
+	if err != nil {
+		return nil, false
+	}
+	return b, true
+}
+
+// idKey returns the on-disk key for the id->name index, scoped by revision so
+// the same charm id at different revisions maps to distinct canonical entries.
+func idKey(id string, revision int) string {
+	sum := sha256.Sum256([]byte(fmt.Sprintf("%s@%d", id, revision)))
+	return hex.EncodeToString(sum[:])
+}
+
+// PutRefresh stores a refresh response under the resolved (name, revision)
+// identity and records the channel->revision index for each action that
+// specified a channel. The resolved identity is read back from the response
+// body (each result's charm.name and charm.revision), so the store reflects
+// what Charmhub actually resolved to.
+func (s *store) PutRefresh(actions []action, body []byte) error {
+	s.refreshMu.Lock()
+	defer s.refreshMu.Unlock()
+
+	resolved, err := resolvedIdentities(body)
+	if err != nil {
+		return fmt.Errorf("parse resolved identities: %w", err)
+	}
+	if len(resolved) == 0 {
+		return errors.New("no resolved results in response")
+	}
+
+	// Store the response under the canonical key of the first result. The
+	// proxy only caches single-action requests, so there is exactly one.
+	name, rev := resolved[0].name, resolved[0].revision
+	path := filepath.Join(s.dir, "refresh", canonicalKey(name, rev)+".json")
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, body, 0o644); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		return err
+	}
+
+	// Record the id->name index so refresh-by-id requests (charmrevisioner,
+	// re-resolve) resolve offline. The id comes from the response entity.
+	if id := resolved[0].id; id != "" {
+		idPath := filepath.Join(s.dir, "ids", idKey(id, rev)+".name")
+		if err := os.WriteFile(idPath, []byte(name), 0o644); err != nil {
+			return err
+		}
+	}
+
+	// Record the channel index for any action that named a channel, so
+	// future channel-only requests for the same channel/base resolve offline.
+	for _, a := range actions {
+		if a.Channel == "" {
+			continue
+		}
+		// For by-name actions use the action's name; for by-id actions use the
+		// resolved name (the action has no name).
+		chName := a.Name
+		if chName == "" {
+			chName = name
+		}
+		revPath := filepath.Join(s.dir, "channels", channelKey(chName, a.Channel, a.Base)+".rev")
+		if err := os.WriteFile(revPath, []byte(fmt.Sprintf("%d", rev)), 0o644); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// resolvedIdentity is the (id, name, revision) a refresh result resolved to.
+type resolvedIdentity struct {
+	id       string
+	name     string
+	revision int
+}
+
+// resolvedIdentities parses a refresh response and returns the resolved
+// (id, name, revision) for each result.
+func resolvedIdentities(body []byte) ([]resolvedIdentity, error) {
+	var doc struct {
+		Results []struct {
+			Entity struct {
+				ID       string `json:"id"`
+				Name     string `json:"name"`
+				Revision int    `json:"revision"`
+			} `json:"charm"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal(body, &doc); err != nil {
+		return nil, err
+	}
+	out := make([]resolvedIdentity, 0, len(doc.Results))
+	for _, r := range doc.Results {
+		if r.Entity.Name == "" {
+			continue
+		}
+		out = append(out, resolvedIdentity{id: r.Entity.ID, name: r.Entity.Name, revision: r.Entity.Revision})
+	}
+	return out, nil
+}
+
+// OpenBlob opens a cached blob for reading. The caller must close the file.
+func (s *store) OpenBlob(hash string) (*os.File, bool) {
+	path := filepath.Join(s.dir, "blobs", hash)
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, false
+	}
+	return f, true
+}
+
+// BlobURL returns the recorded upstream URL for a blob hash.
+func (s *store) BlobURL(hash string) (string, bool) {
+	b, err := os.ReadFile(filepath.Join(s.dir, "blobs", hash+".url"))
+	if err != nil {
+		return "", false
+	}
+	return strings.TrimSpace(string(b)), true
+}
+
+// PutBlobURL records the upstream URL for a blob hash.
+func (s *store) PutBlobURL(hash, url string) error {
+	path := filepath.Join(s.dir, "blobs", hash+".url")
+	return os.WriteFile(path, []byte(url), 0o644)
+}
+
+// BeginBlob returns a writer that buffers the blob to a unique temp file.
+// Call commit to atomically promote it to its final name. A unique temp name
+// (via os.CreateTemp) prevents two concurrent fetches of the same blob from
+// truncating each other's writes.
+func (s *store) BeginBlob(hash string) (sink io.WriteCloser, commit func() error, err error) {
+	s.blobMu.Lock()
+	defer s.blobMu.Unlock()
+	final := filepath.Join(s.dir, "blobs", hash)
+	f, err := os.CreateTemp(filepath.Join(s.dir, "blobs"), hash+".tmp.*")
+	if err != nil {
+		return nil, nil, err
+	}
+	tmp := f.Name()
+	commit = func() error {
+		if err := f.Sync(); err != nil {
+			return err
+		}
+		return os.Rename(tmp, final)
+	}
+	return f, commit, nil
+}

--- a/tools/charmhub-cache/main.go
+++ b/tools/charmhub-cache/main.go
@@ -3,20 +3,21 @@
 
 // Command charmhub-cache is a caching reverse proxy for the CharmHub refresh
 // API and charm blob downloads, designed for CI. Responses are cached by the
-// resolved charm identity (name + revision) plus the requested fields, since
-// different callers (e.g. the provider's ActionExists vs. the controller's
-// deploy resolve) request different field sets for the same charm+revision;
-// the identity portion is immutable, so entries never expire. Requests
-// pinned to a revision (or an id+revision) and carrying no channel are
-// served from cache; requests with no revision, or with a revision AND a
-// channel (an "is there an update?" check), always go upstream, since their
-// purpose is to learn the CURRENT revision for a channel, which can change
-// at any time — caching that would serve stale revisions.
+// resolved charm identity (name + revision) plus a variant key covering the
+// requested fields AND resource revisions, since different callers (e.g. the
+// provider's ActionExists vs. the controller's deploy resolve) request
+// different field/resource sets for the same charm+revision; the identity
+// portion is immutable, so entries never expire. Requests pinned to a
+// revision (or an id+revision) and carrying no channel are served from
+// cache; requests with no revision, or with a revision AND a channel (an
+// "is there an update?" check), always go upstream, since their purpose is
+// to learn the CURRENT revision for a channel, which can change at any time
+// — caching that would serve stale revisions.
 //
 // Store layout:
 //
-//	<store>/refresh/<key>.json   # response keyed by name@revision#fields
-//	<store>/ids/<key>.name       # charmhub id+revision+fields -> name index
+//	<store>/refresh/<key>.json   # response keyed by name@revision#variant
+//	<store>/ids/<key>.name       # charmhub id+revision+variant -> name index
 //	<store>/blobs/<hash>         # charm blob bytes
 //	<store>/blobs/<hash>.url     # real upstream URL for cold backfill
 package main
@@ -230,7 +231,7 @@ func (s *server) handleRefresh(w http.ResponseWriter, r *http.Request) {
 	// action responses are excluded here and rejected again in PutRefresh.
 	// Best-effort: a store failure must not fail the deploy.
 	if len(actions) == 1 && isCacheable(actions[0]) {
-		if err := s.store.PutRefresh(rewritten, actions[0].FieldsKey); err != nil {
+		if err := s.store.PutRefresh(rewritten, variantKey(actions[0])); err != nil {
 			log.Printf("charmhub-cache: store refresh failed: %v", err)
 		}
 	}
@@ -245,12 +246,25 @@ func (s *server) handleRefresh(w http.ResponseWriter, r *http.Request) {
 // cached:
 //   - no revision (channel-only resolve; the revision can change);
 //   - revision AND channel (an "is there an update?" check whose response
-//     reflects the current channel head);
-//   - a resource-revisions discriminator, since the cache key ignores it and
-//     would conflate different requested resource revisions of the same
-//     charm+revision (see action.HasResourceRevisions).
+//     reflects the current channel head).
+//
+// A resource-revisions discriminator does NOT make a request uncacheable:
+// it is folded into the cache key via variantKey, so requests for different
+// resource revisions of the same charm+revision get distinct entries.
 func isCacheable(a action) bool {
-	return a.Revision != nil && a.Channel == "" && !a.HasResourceRevisions
+	return a.Revision != nil && a.Channel == ""
+}
+
+// variantKey combines every request-side discriminator the cache key must
+// vary on beyond (name/id, revision): the requested fields and the requested
+// resource revisions. Two requests that agree on identity but differ in
+// either must not share a cache entry (their responses differ). Returns ""
+// when neither is present, so the common no-variant case keys cleanly.
+func variantKey(a action) string {
+	if a.FieldsKey == "" && a.ResourcesKey == "" {
+		return ""
+	}
+	return a.FieldsKey + "|" + a.ResourcesKey
 }
 
 // handleBlob serves GET /blob/<hash>, where <hash> is the blob's sha256 as
@@ -360,16 +374,15 @@ type action struct {
 	// doesn't), so this must be part of the cache key or a response cached
 	// for one field set gets replayed to a caller needing another.
 	FieldsKey string
-	// HasResourceRevisions is set when the action carries a
-	// "resource-revisions" discriminator (charmhub.AddResource). The
-	// controller uses this to resolve a SPECIFIC resource revision for the
-	// same charm+revision (e.g. coredns@191 with coredns-image rev 59 vs
-	// 70); the response's embedded resources reflect that requested
-	// resource revision. Our cache key does NOT include it, so such a
-	// request must never be cached — otherwise coredns@191+res59 and
-	// coredns@191+res70 collide on one entry and the first to populate it
-	// wins, serving the wrong resource revision.
-	HasResourceRevisions bool
+	// ResourcesKey is a signature of the action's "resource-revisions"
+	// discriminator (charmhub.AddResource), used to resolve a SPECIFIC
+	// resource revision for the same charm+revision (e.g. coredns@191 with
+	// coredns-image rev 59 vs 70). The response's embedded resources reflect
+	// that requested resource revision, so it must be part of the cache key
+	// or coredns@191+res59 and coredns@191+res70 would collide on one entry
+	// and the first to populate it would win, serving the wrong revision.
+	// Empty when the action carries no resource-revisions.
+	ResourcesKey string
 }
 
 // parseRefreshActions extracts the actions from a refresh request body,
@@ -400,7 +413,10 @@ func parseRefreshActions(body []byte) ([]action, error) {
 				Name         string `json:"name"`
 				Channel      string `json:"channel"`
 			} `json:"base"`
-			ResourceRevisions []json.RawMessage `json:"resource-revisions"`
+			ResourceRevisions []struct {
+				Name     string `json:"name"`
+				Revision int    `json:"revision"`
+			} `json:"resource-revisions"`
 		} `json:"actions"`
 	}
 	if err := json.Unmarshal(body, &req); err != nil {
@@ -427,7 +443,16 @@ func parseRefreshActions(body []byte) ([]action, error) {
 
 	actions := make([]action, 0, len(req.Actions))
 	for _, a := range req.Actions {
-		act := action{ID: a.ID, Name: a.Name, Channel: a.Channel, Revision: a.Revision, InstanceKey: a.InstanceKey, FieldsKey: fieldsKey, HasResourceRevisions: len(a.ResourceRevisions) > 0}
+		resourcesKey := ""
+		if len(a.ResourceRevisions) > 0 {
+			pairs := make([]string, 0, len(a.ResourceRevisions))
+			for _, rr := range a.ResourceRevisions {
+				pairs = append(pairs, fmt.Sprintf("%s@%d", rr.Name, rr.Revision))
+			}
+			sort.Strings(pairs)
+			resourcesKey = strings.Join(pairs, ",")
+		}
+		act := action{ID: a.ID, Name: a.Name, Channel: a.Channel, Revision: a.Revision, InstanceKey: a.InstanceKey, FieldsKey: fieldsKey, ResourcesKey: resourcesKey}
 		if a.Base != nil {
 			act.Base = fmt.Sprintf("%s/%s/%s", a.Base.Architecture, a.Base.Name, a.Base.Channel)
 		}
@@ -576,15 +601,16 @@ func newStore(dir string) (*store, error) {
 }
 
 // canonicalKey returns the on-disk key for a resolved charm identity,
-// scoped by fieldsKey so responses fetched with different requested fields
-// are never conflated (see action.FieldsKey).
-func canonicalKey(name string, revision int, fieldsKey string) string {
-	sum := sha256.Sum256(fmt.Appendf(nil, "%s@%d#%s", name, revision, fieldsKey))
+// scoped by variant (requested fields + resource revisions) so responses
+// fetched with different request-side discriminators are never conflated
+// (see variantKey).
+func canonicalKey(name string, revision int, variant string) string {
+	sum := sha256.Sum256(fmt.Appendf(nil, "%s@%d#%s", name, revision, variant))
 	return hex.EncodeToString(sum[:])
 }
 
-func idKey(id string, revision int, fieldsKey string) string {
-	sum := sha256.Sum256(fmt.Appendf(nil, "%s@%d#%s", id, revision, fieldsKey))
+func idKey(id string, revision int, variant string) string {
+	sum := sha256.Sum256(fmt.Appendf(nil, "%s@%d#%s", id, revision, variant))
 	return hex.EncodeToString(sum[:])
 }
 
@@ -597,17 +623,20 @@ func idKey(id string, revision int, fieldsKey string) string {
 // (juju3/charmhub/refresh.go) sends BOTH the installed revision AND the
 // tracking channel to ask "has this channel advanced?" — that answer
 // changes as the channel advances, so it must never be served from a cache
-// keyed on the (stale) installed revision.
+// keyed on the (stale) installed revision. Cacheable requests are scoped by
+// variantKey so different fields/resource-revisions get distinct entries.
 func (s *store) LookupRefresh(a action) ([]byte, bool) {
 	if !isCacheable(a) {
 		return nil, false
 	}
 
+	variant := variantKey(a)
+
 	s.refreshMu.Lock()
 	defer s.refreshMu.Unlock()
 
 	if a.Name == "" && a.ID != "" {
-		nameBytes, err := os.ReadFile(filepath.Join(s.dir, "ids", idKey(a.ID, *a.Revision, a.FieldsKey)+".name"))
+		nameBytes, err := os.ReadFile(filepath.Join(s.dir, "ids", idKey(a.ID, *a.Revision, variant)+".name"))
 		if err != nil {
 			return nil, false
 		}
@@ -615,30 +644,31 @@ func (s *store) LookupRefresh(a action) ([]byte, bool) {
 		if name == "" {
 			return nil, false
 		}
-		b, err := os.ReadFile(filepath.Join(s.dir, "refresh", canonicalKey(name, *a.Revision, a.FieldsKey)+".json"))
+		b, err := os.ReadFile(filepath.Join(s.dir, "refresh", canonicalKey(name, *a.Revision, variant)+".json"))
 		if err != nil {
 			return nil, false
 		}
 		return b, true
 	}
 
-	b, err := os.ReadFile(filepath.Join(s.dir, "refresh", canonicalKey(a.Name, *a.Revision, a.FieldsKey)+".json"))
+	b, err := os.ReadFile(filepath.Join(s.dir, "refresh", canonicalKey(a.Name, *a.Revision, variant)+".json"))
 	if err != nil {
 		return nil, false
 	}
 	return b, true
 }
 
-// PutRefresh stores a response under the resolved (name, revision, fields)
+// PutRefresh stores a response under the resolved (name, revision, variant)
 // identity read back from the response body and the requesting action's
-// FieldsKey, and records the id index so future by-id requests for the same
-// immutable id+revision+fields resolve offline.
+// variant key (fields + resource revisions), and records the id index so
+// future by-id requests for the same immutable id+revision+variant resolve
+// offline.
 //
 // body must contain exactly one result. A multi-result (batched) response
 // must never be cached here: it would later be replayed verbatim to an
 // unrelated single-action request, which the Juju client rejects with
 // "more than 1 result found" (it requires exactly one result per action).
-func (s *store) PutRefresh(body []byte, fieldsKey string) error {
+func (s *store) PutRefresh(body []byte, variant string) error {
 	s.refreshMu.Lock()
 	defer s.refreshMu.Unlock()
 
@@ -655,7 +685,7 @@ func (s *store) PutRefresh(body []byte, fieldsKey string) error {
 
 	// Only single-action requests are cached, so there is exactly one result.
 	name, rev := resolved[0].name, resolved[0].revision
-	path := filepath.Join(s.dir, "refresh", canonicalKey(name, rev, fieldsKey)+".json")
+	path := filepath.Join(s.dir, "refresh", canonicalKey(name, rev, variant)+".json")
 	tmp := path + ".tmp"
 	if err := os.WriteFile(tmp, body, 0o644); err != nil {
 		return err
@@ -665,7 +695,7 @@ func (s *store) PutRefresh(body []byte, fieldsKey string) error {
 	}
 
 	if id := resolved[0].id; id != "" {
-		idPath := filepath.Join(s.dir, "ids", idKey(id, rev, fieldsKey)+".name")
+		idPath := filepath.Join(s.dir, "ids", idKey(id, rev, variant)+".name")
 		if err := os.WriteFile(idPath, []byte(name), 0o644); err != nil {
 			return err
 		}

--- a/tools/charmhub-cache/main.go
+++ b/tools/charmhub-cache/main.go
@@ -241,12 +241,16 @@ func (s *server) handleRefresh(w http.ResponseWriter, r *http.Request) {
 }
 
 // isCacheable reports whether an action's response may be safely stored and
-// later replayed. It must mirror the read-side check in LookupRefresh: a
-// request with no revision, or with a revision AND a channel (an
-// "is there an update?" check whose response reflects the current channel
-// head), must never be cached.
+// later replayed. It must mirror the read-side check in LookupRefresh. Never
+// cached:
+//   - no revision (channel-only resolve; the revision can change);
+//   - revision AND channel (an "is there an update?" check whose response
+//     reflects the current channel head);
+//   - a resource-revisions discriminator, since the cache key ignores it and
+//     would conflate different requested resource revisions of the same
+//     charm+revision (see action.HasResourceRevisions).
 func isCacheable(a action) bool {
-	return a.Revision != nil && a.Channel == ""
+	return a.Revision != nil && a.Channel == "" && !a.HasResourceRevisions
 }
 
 // handleBlob serves GET /blob/<hash>, where <hash> is the blob's sha256 as
@@ -356,6 +360,16 @@ type action struct {
 	// doesn't), so this must be part of the cache key or a response cached
 	// for one field set gets replayed to a caller needing another.
 	FieldsKey string
+	// HasResourceRevisions is set when the action carries a
+	// "resource-revisions" discriminator (charmhub.AddResource). The
+	// controller uses this to resolve a SPECIFIC resource revision for the
+	// same charm+revision (e.g. coredns@191 with coredns-image rev 59 vs
+	// 70); the response's embedded resources reflect that requested
+	// resource revision. Our cache key does NOT include it, so such a
+	// request must never be cached — otherwise coredns@191+res59 and
+	// coredns@191+res70 collide on one entry and the first to populate it
+	// wins, serving the wrong resource revision.
+	HasResourceRevisions bool
 }
 
 // parseRefreshActions extracts the actions from a refresh request body,
@@ -386,6 +400,7 @@ func parseRefreshActions(body []byte) ([]action, error) {
 				Name         string `json:"name"`
 				Channel      string `json:"channel"`
 			} `json:"base"`
+			ResourceRevisions []json.RawMessage `json:"resource-revisions"`
 		} `json:"actions"`
 	}
 	if err := json.Unmarshal(body, &req); err != nil {
@@ -412,7 +427,7 @@ func parseRefreshActions(body []byte) ([]action, error) {
 
 	actions := make([]action, 0, len(req.Actions))
 	for _, a := range req.Actions {
-		act := action{ID: a.ID, Name: a.Name, Channel: a.Channel, Revision: a.Revision, InstanceKey: a.InstanceKey, FieldsKey: fieldsKey}
+		act := action{ID: a.ID, Name: a.Name, Channel: a.Channel, Revision: a.Revision, InstanceKey: a.InstanceKey, FieldsKey: fieldsKey, HasResourceRevisions: len(a.ResourceRevisions) > 0}
 		if a.Base != nil {
 			act.Base = fmt.Sprintf("%s/%s/%s", a.Base.Architecture, a.Base.Name, a.Base.Channel)
 		}

--- a/tools/charmhub-cache/main.go
+++ b/tools/charmhub-cache/main.go
@@ -7,10 +7,11 @@
 // different callers (e.g. the provider's ActionExists vs. the controller's
 // deploy resolve) request different field sets for the same charm+revision;
 // the identity portion is immutable, so entries never expire. Requests
-// pinned to a revision (or an id+revision) are served from cache;
-// channel-only requests always go upstream, since their entire purpose is to
-// learn the CURRENT revision for a channel, which can change at any time —
-// caching that would serve stale revisions.
+// pinned to a revision (or an id+revision) and carrying no channel are
+// served from cache; requests with no revision, or with a revision AND a
+// channel (an "is there an update?" check), always go upstream, since their
+// purpose is to learn the CURRENT revision for a channel, which can change
+// at any time — caching that would serve stale revisions.
 //
 // Store layout:
 //
@@ -566,11 +567,13 @@ func idKey(id string, revision int, fieldsKey string) string {
 //   - pinned-revision requests via the canonical (name, revision) key,
 //   - by-id requests via the id->name index (requires a revision).
 //
-// Channel-only requests (no revision) are never served from cache: a
-// channel's resolved revision can change at any time, so caching it would
-// serve stale revisions once the channel advances upstream.
+// Requests with no revision, OR with a revision but also a channel, are
+// never served from cache. RefreshOne (juju3/charmhub/refresh.go) sends
+// BOTH the installed revision AND the tracking channel to ask "has this
+// channel advanced?" — that answer changes as the channel advances, so it
+// must never be served from a cache keyed on the (stale) installed revision.
 func (s *store) LookupRefresh(a action) ([]byte, bool) {
-	if a.Revision == nil {
+	if a.Revision == nil || a.Channel != "" {
 		return nil, false
 	}
 

--- a/tools/charmhub-cache/main.go
+++ b/tools/charmhub-cache/main.go
@@ -3,20 +3,18 @@
 
 // Command charmhub-cache is a caching reverse proxy for the CharmHub refresh
 // API and charm blob downloads, designed for CI. Responses are cached by the
-// resolved charm identity (name + revision) so a charm deployed by pinned
-// revision (the provider) and the same charm resolved by channel (the Juju
-// controller) share one cache entry. Once warm, the proxy serves entirely
-// offline. The on-disk store is trivially cacheable via actions/cache.
+// resolved charm identity (name + revision), which is immutable, so entries
+// never expire. Requests pinned to a revision (or an id+revision) are served
+// from cache; channel-only requests always go upstream, since their entire
+// purpose is to learn the CURRENT revision for a channel, which can change at
+// any time — caching that would serve stale revisions.
 //
 // Store layout:
 //
 //	<store>/refresh/<key>.json   # response keyed by resolved name@revision
-//	<store>/channels/<key>.rev   # channel+base -> resolved revision index
 //	<store>/ids/<key>.name       # charmhub id+revision -> name index
 //	<store>/blobs/<hash>         # charm blob bytes
 //	<store>/blobs/<hash>.url     # real upstream URL for cold backfill
-//
-// Charm revisions are immutable, so entries never expire.
 package main
 
 import (
@@ -70,6 +68,10 @@ func main() {
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
+	// Anything else under the Charmhub API (e.g. resource revision lookups)
+	// isn't cached; pass it straight through to upstream so the client sees a
+	// real Charmhub response instead of this proxy's 404.
+	mux.Handle("/", http.HandlerFunc(proxy.handlePassthrough))
 
 	srv := &http.Server{
 		Addr:              *addr,
@@ -100,6 +102,41 @@ func proxyBaseURL(r *http.Request) string {
 		scheme = "https"
 	}
 	return scheme + "://" + r.Host
+}
+
+// handlePassthrough forwards any request not otherwise cached (e.g.
+// /v2/charms/resources/<charm>/<resource>/revisions) straight to upstream,
+// preserving method, headers, and body. Not cached: these are outside the
+// refresh/blob paths this proxy understands.
+func (s *server) handlePassthrough(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("read body: %v", err), http.StatusBadRequest)
+		return
+	}
+	_ = r.Body.Close()
+
+	req, err := http.NewRequestWithContext(r.Context(), r.Method, s.upstream+r.URL.RequestURI(), bytes.NewReader(body))
+	if err != nil {
+		http.Error(w, fmt.Sprintf("build upstream request: %v", err), http.StatusBadGateway)
+		return
+	}
+	for k, v := range r.Header {
+		req.Header[k] = v
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("upstream unreachable: %v", err), http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close()
+
+	for k, v := range resp.Header {
+		w.Header()[k] = v
+	}
+	w.WriteHeader(resp.StatusCode)
+	_, _ = io.Copy(w, resp.Body)
 }
 
 // handleRefresh serves POST /v2/charms/refresh. See the package comment for
@@ -182,7 +219,7 @@ func (s *server) handleRefresh(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Best-effort: a store failure must not fail the deploy.
-	if err := s.store.PutRefresh(actions, rewritten); err != nil {
+	if err := s.store.PutRefresh(rewritten); err != nil {
 		log.Printf("charmhub-cache: store refresh failed: %v", err)
 	}
 
@@ -472,7 +509,7 @@ type store struct {
 }
 
 func newStore(dir string) (*store, error) {
-	for _, sub := range []string{"refresh", "blobs", "channels", "ids"} {
+	for _, sub := range []string{"refresh", "blobs", "ids"} {
 		if err := os.MkdirAll(filepath.Join(dir, sub), 0o755); err != nil {
 			return nil, err
 		}
@@ -486,11 +523,6 @@ func canonicalKey(name string, revision int) string {
 	return hex.EncodeToString(sum[:])
 }
 
-func channelKey(name, channel, base string) string {
-	sum := sha256.Sum256(fmt.Appendf(nil, "%s|%s|%s", name, channel, base))
-	return hex.EncodeToString(sum[:])
-}
-
 func idKey(id string, revision int) string {
 	sum := sha256.Sum256(fmt.Appendf(nil, "%s@%d", id, revision))
 	return hex.EncodeToString(sum[:])
@@ -498,16 +530,20 @@ func idKey(id string, revision int) string {
 
 // LookupRefresh returns the cached response for a single action, resolving:
 //   - pinned-revision requests via the canonical (name, revision) key,
-//   - channel-only requests via the channel->revision index,
 //   - by-id requests via the id->name index (requires a revision).
+//
+// Channel-only requests (no revision) are never served from cache: a
+// channel's resolved revision can change at any time, so caching it would
+// serve stale revisions once the channel advances upstream.
 func (s *store) LookupRefresh(a action) ([]byte, bool) {
+	if a.Revision == nil {
+		return nil, false
+	}
+
 	s.refreshMu.Lock()
 	defer s.refreshMu.Unlock()
 
 	if a.Name == "" && a.ID != "" {
-		if a.Revision == nil {
-			return nil, false
-		}
 		nameBytes, err := os.ReadFile(filepath.Join(s.dir, "ids", idKey(a.ID, *a.Revision)+".name"))
 		if err != nil {
 			return nil, false
@@ -523,24 +559,7 @@ func (s *store) LookupRefresh(a action) ([]byte, bool) {
 		return b, true
 	}
 
-	var key string
-	if a.Revision != nil {
-		key = canonicalKey(a.Name, *a.Revision)
-	} else if a.Channel != "" {
-		revBytes, err := os.ReadFile(filepath.Join(s.dir, "channels", channelKey(a.Name, a.Channel, a.Base)+".rev"))
-		if err != nil {
-			return nil, false
-		}
-		var rev int
-		if _, err := fmt.Sscanf(strings.TrimSpace(string(revBytes)), "%d", &rev); err != nil {
-			return nil, false
-		}
-		key = canonicalKey(a.Name, rev)
-	} else {
-		return nil, false
-	}
-
-	b, err := os.ReadFile(filepath.Join(s.dir, "refresh", key+".json"))
+	b, err := os.ReadFile(filepath.Join(s.dir, "refresh", canonicalKey(a.Name, *a.Revision)+".json"))
 	if err != nil {
 		return nil, false
 	}
@@ -548,9 +567,9 @@ func (s *store) LookupRefresh(a action) ([]byte, bool) {
 }
 
 // PutRefresh stores a response under the resolved (name, revision) identity
-// read back from the response body, and records the channel and id indexes
-// so future channel-only and by-id requests resolve offline.
-func (s *store) PutRefresh(actions []action, body []byte) error {
+// read back from the response body, and records the id index so future by-id
+// requests for the same immutable id+revision resolve offline.
+func (s *store) PutRefresh(body []byte) error {
 	s.refreshMu.Lock()
 	defer s.refreshMu.Unlock()
 
@@ -576,21 +595,6 @@ func (s *store) PutRefresh(actions []action, body []byte) error {
 	if id := resolved[0].id; id != "" {
 		idPath := filepath.Join(s.dir, "ids", idKey(id, rev)+".name")
 		if err := os.WriteFile(idPath, []byte(name), 0o644); err != nil {
-			return err
-		}
-	}
-
-	for _, a := range actions {
-		if a.Channel == "" {
-			continue
-		}
-		// By-id actions have no name; use the resolved name.
-		chName := a.Name
-		if chName == "" {
-			chName = name
-		}
-		revPath := filepath.Join(s.dir, "channels", channelKey(chName, a.Channel, a.Base)+".rev")
-		if err := os.WriteFile(revPath, fmt.Appendf(nil, "%d", rev), 0o644); err != nil {
 			return err
 		}
 	}

--- a/tools/charmhub-cache/main.go
+++ b/tools/charmhub-cache/main.go
@@ -154,9 +154,14 @@ func (s *server) handleRefresh(w http.ResponseWriter, r *http.Request) {
 	// replay; multi-action requests fall through to upstream.
 	if len(actions) == 1 {
 		if cached, ok := s.store.LookupRefresh(actions[0]); ok {
+			// Rewrite the instance-key in the cached response to match the
+			// current request. The instance-key is a per-request UUID; the
+			// cached response carries the original request's key, which won't
+			// match and causes the client's Ensure() to reject it.
+			replayed := rewriteInstanceKey(cached, actions[0].InstanceKey)
 			w.Header().Set("Content-Type", "application/json")
 			w.Header().Set("X-Charmhub-Cache", "HIT")
-			_, _ = w.Write(cached)
+			_, _ = w.Write(replayed)
 			return
 		}
 	}
@@ -323,11 +328,12 @@ func contentLength(resp *http.Response) (int64, bool) {
 //     carries only ID; Revision/Channel/Base live in the matching context
 //     entry (keyed by instance-key).
 type action struct {
-	ID       string // charmhub charm ID (refresh-by-id); empty for by-name
-	Name     string // charm name (by-name); empty for by-id
-	Channel  string
-	Revision *int
-	Base     string // "arch/os/channel", empty if absent
+	ID          string // charmhub charm ID (refresh-by-id); empty for by-name
+	Name        string // charm name (by-name); empty for by-id
+	Channel     string
+	Revision    *int
+	Base        string // "arch/os/channel", empty if absent
+	InstanceKey string // per-request unique key; must match in the response
 }
 
 // parseRefreshActions extracts the actions from a refresh request body,
@@ -381,7 +387,7 @@ func parseRefreshActions(body []byte) ([]action, error) {
 
 	actions := make([]action, 0, len(req.Actions))
 	for _, a := range req.Actions {
-		act := action{ID: a.ID, Name: a.Name, Channel: a.Channel, Revision: a.Revision}
+		act := action{ID: a.ID, Name: a.Name, Channel: a.Channel, Revision: a.Revision, InstanceKey: a.InstanceKey}
 		if a.Base != nil {
 			act.Base = fmt.Sprintf("%s/%s/%s", a.Base.Architecture, a.Base.Name, a.Base.Channel)
 		}
@@ -400,6 +406,40 @@ func parseRefreshActions(body []byte) ([]action, error) {
 		actions = append(actions, act)
 	}
 	return actions, nil
+}
+
+// rewriteDownloadURLs rewrites the download.url field in each refresh result
+// to point at this proxy's /blob/<hash> endpoint, recording the real upstream
+// rewriteInstanceKey replaces the instance-key in each refresh result with the
+// given key. The instance-key is a per-request UUID; a cached response carries
+// the original request's key, which won't match the current request and causes
+// the client's Ensure() to reject it ("install action key not valid"). Uses
+// map[string]any to preserve all other fields verbatim. If parsing fails the
+// original body is returned unchanged (best-effort).
+func rewriteInstanceKey(body []byte, instanceKey string) []byte {
+	if instanceKey == "" {
+		return body
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(body, &doc); err != nil {
+		return body
+	}
+	results, ok := doc["results"].([]any)
+	if !ok {
+		return body
+	}
+	for _, res := range results {
+		result, ok := res.(map[string]any)
+		if !ok {
+			continue
+		}
+		result["instance-key"] = instanceKey
+	}
+	rewritten, err := json.Marshal(doc)
+	if err != nil {
+		return body
+	}
+	return rewritten
 }
 
 // rewriteDownloadURLs rewrites the download.url field in each refresh result

--- a/tools/charmhub-cache/main.go
+++ b/tools/charmhub-cache/main.go
@@ -51,7 +51,6 @@ func main() {
 		addr     = flag.String("addr", "127.0.0.1:8080", "address to listen on")
 		storeDir = flag.String("store", "charmhub-cache-store", "directory for the on-disk cache")
 		upstream = flag.String("upstream", "https://api.charmhub.io", "upstream CharmHub API base URL")
-		baseURL  = flag.String("base-url", "http://127.0.0.1:8080", "externally reachable base URL of this proxy, used to rewrite charm download URLs")
 	)
 	flag.Parse()
 
@@ -63,7 +62,6 @@ func main() {
 	proxy := &server{
 		store:    store,
 		upstream: strings.TrimRight(*upstream, "/"),
-		baseURL:  strings.TrimRight(*baseURL, "/"),
 	}
 
 	mux := http.NewServeMux()
@@ -89,7 +87,19 @@ func main() {
 type server struct {
 	store    *store
 	upstream string
-	baseURL  string // externally reachable URL, for rewriting download URLs
+}
+
+// proxyBaseURL derives this proxy's externally reachable base URL from the
+// incoming request, so no --base-url flag or restart is needed when the
+// controller-reachable address only becomes known later (e.g. once the LXD
+// bridge exists). Whatever host:port the client used to reach us (via
+// charmhub-url/CHARMHUB_URL) is what must be embedded in rewritten URLs.
+func proxyBaseURL(r *http.Request) string {
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+	return scheme + "://" + r.Host
 }
 
 // handleRefresh serves POST /v2/charms/refresh. See the package comment for
@@ -160,7 +170,7 @@ func (s *server) handleRefresh(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Rewrite download URLs so blob fetches route back through this proxy.
-	rewritten, err := rewriteDownloadURLs(respBody, s.store, s.baseURL)
+	rewritten, err := rewriteDownloadURLs(respBody, s.store, proxyBaseURL(r))
 	if err != nil {
 		// Never break a deploy over a schema surprise; the blob path will
 		// hit the live CDN directly.

--- a/tools/charmhub-cache/main.go
+++ b/tools/charmhub-cache/main.go
@@ -223,12 +223,13 @@ func (s *server) handleRefresh(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Only cache single-action responses. A batched (multi-action) response
-	// contains multiple results; storing it under one canonical key would
-	// later be replayed to an unrelated single-action request expecting
-	// exactly one result, which the client rejects ("more than 1 result
-	// found"). Best-effort: a store failure must not fail the deploy.
-	if len(actions) == 1 {
+	// Only store responses that are safe to replay: single-action, and
+	// cacheable per isCacheable (which must mirror the LookupRefresh gate,
+	// else a revision+channel "update check" response — reflecting the
+	// current channel head — poisons the pinned-revision entry). Multi-
+	// action responses are excluded here and rejected again in PutRefresh.
+	// Best-effort: a store failure must not fail the deploy.
+	if len(actions) == 1 && isCacheable(actions[0]) {
 		if err := s.store.PutRefresh(rewritten, actions[0].FieldsKey); err != nil {
 			log.Printf("charmhub-cache: store refresh failed: %v", err)
 		}
@@ -237,6 +238,15 @@ func (s *server) handleRefresh(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("X-Charmhub-Cache", "MISS")
 	_, _ = w.Write(rewritten)
+}
+
+// isCacheable reports whether an action's response may be safely stored and
+// later replayed. It must mirror the read-side check in LookupRefresh: a
+// request with no revision, or with a revision AND a channel (an
+// "is there an update?" check whose response reflects the current channel
+// head), must never be cached.
+func isCacheable(a action) bool {
+	return a.Revision != nil && a.Channel == ""
 }
 
 // handleBlob serves GET /blob/<hash>, where <hash> is the blob's sha256 as
@@ -568,12 +578,13 @@ func idKey(id string, revision int, fieldsKey string) string {
 //   - by-id requests via the id->name index (requires a revision).
 //
 // Requests with no revision, OR with a revision but also a channel, are
-// never served from cache. RefreshOne (juju3/charmhub/refresh.go) sends
-// BOTH the installed revision AND the tracking channel to ask "has this
-// channel advanced?" — that answer changes as the channel advances, so it
-// must never be served from a cache keyed on the (stale) installed revision.
+// never served from cache (see isCacheable). RefreshOne
+// (juju3/charmhub/refresh.go) sends BOTH the installed revision AND the
+// tracking channel to ask "has this channel advanced?" — that answer
+// changes as the channel advances, so it must never be served from a cache
+// keyed on the (stale) installed revision.
 func (s *store) LookupRefresh(a action) ([]byte, bool) {
-	if a.Revision == nil || a.Channel != "" {
+	if !isCacheable(a) {
 		return nil, false
 	}
 

--- a/tools/charmhub-cache/main.go
+++ b/tools/charmhub-cache/main.go
@@ -7,17 +7,19 @@
 // requested fields AND resource revisions, since different callers (e.g. the
 // provider's ActionExists vs. the controller's deploy resolve) request
 // different field/resource sets for the same charm+revision; the identity
-// portion is immutable, so entries never expire. Requests pinned to a
-// revision (or an id+revision) and carrying no channel are served from
-// cache; requests with no revision, or with a revision AND a channel (an
-// "is there an update?" check), always go upstream, since their purpose is
-// to learn the CURRENT revision for a channel, which can change at any time
-// — caching that would serve stale revisions.
+// portion is immutable, so entries never expire. Only by-name requests
+// pinned to a revision and carrying no channel are served from cache;
+// requests with no revision, or with a revision AND a channel (an "is there
+// an update?" check), always go upstream, since their purpose is to learn
+// the CURRENT revision for a channel, which can change at any time — caching
+// that would serve stale revisions. By-id refreshes (the controller's
+// charmrevisioner worker, which first fires ~24h after model creation) are
+// deliberately not cached and always pass through; they never occur within
+// a CI job's lifetime.
 //
 // Store layout:
 //
 //	<store>/refresh/<key>.json   # response keyed by name@revision#variant
-//	<store>/ids/<key>.name       # charmhub id+revision+variant -> name index
 //	<store>/blobs/<hash>         # charm blob bytes
 //	<store>/blobs/<hash>.url     # real upstream URL for cold backfill
 package main
@@ -212,8 +214,9 @@ func (s *server) handleRefresh(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Rewrite download URLs so blob fetches route back through this proxy.
-	rewritten, err := rewriteDownloadURLs(respBody, s.store, proxyBaseURL(r))
+	// Rewrite download URLs so blob fetches route back through this proxy,
+	// and extract the resolved identity from the same single parse.
+	rewritten, identities, err := rewriteDownloadURLs(respBody, s.store, proxyBaseURL(r))
 	if err != nil {
 		// Never break a deploy over a schema surprise; the blob path will
 		// hit the live CDN directly.
@@ -224,14 +227,16 @@ func (s *server) handleRefresh(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Only store responses that are safe to replay: single-action, and
-	// cacheable per isCacheable (which must mirror the LookupRefresh gate,
-	// else a revision+channel "update check" response — reflecting the
-	// current channel head — poisons the pinned-revision entry). Multi-
-	// action responses are excluded here and rejected again in PutRefresh.
-	// Best-effort: a store failure must not fail the deploy.
-	if len(actions) == 1 && isCacheable(actions[0]) {
-		if err := s.store.PutRefresh(rewritten, variantKey(actions[0])); err != nil {
+	// Only store responses that are safe to replay: single-action, cacheable
+	// per isCacheable (which must mirror the LookupRefresh gate, else a
+	// revision+channel "update check" response — reflecting the current
+	// channel head — poisons the pinned-revision entry), and carrying
+	// exactly one resolved identity. A batched (multi-result) response must
+	// never be cached: it would later be replayed verbatim to an unrelated
+	// single-action request, which the Juju client rejects ("more than 1
+	// result found"). Best-effort: a store failure must not fail the deploy.
+	if len(actions) == 1 && isCacheable(actions[0]) && len(identities) == 1 {
+		if err := s.store.PutRefresh(rewritten, identities[0], variantKey(actions[0])); err != nil {
 			log.Printf("charmhub-cache: store refresh failed: %v", err)
 		}
 	}
@@ -244,6 +249,8 @@ func (s *server) handleRefresh(w http.ResponseWriter, r *http.Request) {
 // isCacheable reports whether an action's response may be safely stored and
 // later replayed. It must mirror the read-side check in LookupRefresh. Never
 // cached:
+//   - no name (by-id refreshes: the charmrevisioner worker, which never
+//     fires within a CI job's lifetime — always pass through);
 //   - no revision (channel-only resolve; the revision can change);
 //   - revision AND channel (an "is there an update?" check whose response
 //     reflects the current channel head).
@@ -252,11 +259,11 @@ func (s *server) handleRefresh(w http.ResponseWriter, r *http.Request) {
 // it is folded into the cache key via variantKey, so requests for different
 // resource revisions of the same charm+revision get distinct entries.
 func isCacheable(a action) bool {
-	return a.Revision != nil && a.Channel == ""
+	return a.Name != "" && a.Revision != nil && a.Channel == ""
 }
 
 // variantKey combines every request-side discriminator the cache key must
-// vary on beyond (name/id, revision): the requested fields and the requested
+// vary on beyond (name, revision): the requested fields and the requested
 // resource revisions. Two requests that agree on identity but differ in
 // either must not share a cache entry (their responses differ). Returns ""
 // when neither is present, so the common no-variant case keys cleanly.
@@ -354,19 +361,13 @@ func contentLength(resp *http.Response) (int64, bool) {
 	return 0, false
 }
 
-// action is a single parsed refresh request action.
-//
-// Two wire shapes exist:
-//   - by-name (provider, controller fresh deploy): Name plus optional
-//     Revision/Channel/Base in the action.
-//   - by-id (controller re-resolve, charmrevisioner): only ID in the action;
-//     Revision/Channel/Base live in the matching context entry.
+// action is a single parsed refresh request action. Only the fields that
+// feed the cacheability check and the cache key are captured; everything
+// else in the request body is irrelevant to caching and ignored.
 type action struct {
-	ID          string
 	Name        string
 	Channel     string
 	Revision    *int
-	Base        string // "arch/os/channel", empty if absent
 	InstanceKey string // per-request unique key; must match in the response
 	// FieldsKey is a signature of the requested "fields" array. Different
 	// callers request different fields for the same charm+revision (e.g.
@@ -385,34 +386,18 @@ type action struct {
 	ResourcesKey string
 }
 
-// parseRefreshActions extracts the actions from a refresh request body,
-// merging revision/channel/base from the context array (matched by
-// instance-key) for by-id requests. The top-level "fields" array is folded
-// into each action's FieldsKey (see action.FieldsKey for why this matters).
+// parseRefreshActions extracts the actions from a refresh request body.
+// The top-level "fields" array is folded into each action's FieldsKey (see
+// action.FieldsKey for why this matters). By-id actions carry no name, so
+// they fail the isCacheable check and pass through to upstream.
 func parseRefreshActions(body []byte) ([]action, error) {
 	var req struct {
 		Fields  []string `json:"fields"`
-		Context []struct {
-			InstanceKey     string `json:"instance-key"`
-			Revision        *int   `json:"revision"`
-			TrackingChannel string `json:"tracking-channel"`
-			Base            *struct {
-				Architecture string `json:"architecture"`
-				Name         string `json:"name"`
-				Channel      string `json:"channel"`
-			} `json:"base"`
-		} `json:"context"`
 		Actions []struct {
-			InstanceKey string `json:"instance-key"`
-			ID          string `json:"id"`
-			Name        string `json:"name"`
-			Channel     string `json:"channel"`
-			Revision    *int   `json:"revision"`
-			Base        *struct {
-				Architecture string `json:"architecture"`
-				Name         string `json:"name"`
-				Channel      string `json:"channel"`
-			} `json:"base"`
+			InstanceKey       string `json:"instance-key"`
+			Name              string `json:"name"`
+			Channel           string `json:"channel"`
+			Revision          *int   `json:"revision"`
 			ResourceRevisions []struct {
 				Name     string `json:"name"`
 				Revision int    `json:"revision"`
@@ -425,22 +410,6 @@ func parseRefreshActions(body []byte) ([]action, error) {
 
 	fieldsKey := normalizeFields(req.Fields)
 
-	// Index context entries by instance-key so by-id actions can pick up
-	// their revision/channel/base.
-	type ctxInfo struct {
-		revision *int
-		channel  string
-		base     string
-	}
-	ctxByKey := make(map[string]ctxInfo, len(req.Context))
-	for _, c := range req.Context {
-		base := ""
-		if c.Base != nil {
-			base = fmt.Sprintf("%s/%s/%s", c.Base.Architecture, c.Base.Name, c.Base.Channel)
-		}
-		ctxByKey[c.InstanceKey] = ctxInfo{revision: c.Revision, channel: c.TrackingChannel, base: base}
-	}
-
 	actions := make([]action, 0, len(req.Actions))
 	for _, a := range req.Actions {
 		resourcesKey := ""
@@ -452,23 +421,14 @@ func parseRefreshActions(body []byte) ([]action, error) {
 			sort.Strings(pairs)
 			resourcesKey = strings.Join(pairs, ",")
 		}
-		act := action{ID: a.ID, Name: a.Name, Channel: a.Channel, Revision: a.Revision, InstanceKey: a.InstanceKey, FieldsKey: fieldsKey, ResourcesKey: resourcesKey}
-		if a.Base != nil {
-			act.Base = fmt.Sprintf("%s/%s/%s", a.Base.Architecture, a.Base.Name, a.Base.Channel)
-		}
-		// For by-id requests, revision/channel/base come from the context.
-		if ci, ok := ctxByKey[a.InstanceKey]; ok {
-			if act.Revision == nil {
-				act.Revision = ci.revision
-			}
-			if act.Channel == "" {
-				act.Channel = ci.channel
-			}
-			if act.Base == "" {
-				act.Base = ci.base
-			}
-		}
-		actions = append(actions, act)
+		actions = append(actions, action{
+			Name:         a.Name,
+			Channel:      a.Channel,
+			Revision:     a.Revision,
+			InstanceKey:  a.InstanceKey,
+			FieldsKey:    fieldsKey,
+			ResourcesKey: resourcesKey,
+		})
 	}
 	return actions, nil
 }
@@ -517,20 +477,26 @@ func rewriteInstanceKey(body []byte, instanceKey string) []byte {
 
 // rewriteDownloadURLs rewrites each result's download.url to point at this
 // proxy's /blob/<hash> endpoint, recording the real upstream URL for later
-// backfill. Uses map[string]any so unmodelled fields are preserved verbatim.
-// Juju's charm downloader requires absolute URLs, hence proxyBase.
-func rewriteDownloadURLs(body []byte, st *store, proxyBase string) ([]byte, error) {
+// backfill, and returns the rewritten body together with the resolved
+// (name, revision) identity of each result — extracted from the same single
+// parse, so callers don't need to unmarshal the body again. Uses
+// map[string]any so unmodelled fields are preserved verbatim. Juju's charm
+// downloader requires absolute URLs, hence proxyBase. Responses without a
+// results array (e.g. error-list responses) are returned unchanged with a
+// nil identity.
+func rewriteDownloadURLs(body []byte, st *store, proxyBase string) ([]byte, []resolvedIdentity, error) {
 	var doc map[string]any
 	if err := json.Unmarshal(body, &doc); err != nil {
-		return nil, fmt.Errorf("unmarshal refresh response: %w", err)
+		return nil, nil, fmt.Errorf("unmarshal refresh response: %w", err)
 	}
 
 	results, ok := doc["results"].([]any)
 	if !ok {
 		// No results array (e.g. an error-list response): nothing to rewrite.
-		return body, nil
+		return body, nil, nil
 	}
 
+	identities := make([]resolvedIdentity, 0, len(results))
 	for _, res := range results {
 		result, ok := res.(map[string]any)
 		if !ok {
@@ -539,6 +505,10 @@ func rewriteDownloadURLs(body []byte, st *store, proxyBase string) ([]byte, erro
 		entity, ok := result["charm"].(map[string]any)
 		if !ok {
 			continue
+		}
+		if name, _ := entity["name"].(string); name != "" {
+			rev, _ := entity["revision"].(float64)
+			identities = append(identities, resolvedIdentity{name: name, revision: int(rev)})
 		}
 		download, ok := entity["download"].(map[string]any)
 		if !ok {
@@ -554,12 +524,16 @@ func rewriteDownloadURLs(body []byte, st *store, proxyBase string) ([]byte, erro
 			hash = hex.EncodeToString(sum[:])
 		}
 		if err := st.PutBlobURL(hash, realURL); err != nil {
-			return nil, fmt.Errorf("record blob url: %w", err)
+			return nil, nil, fmt.Errorf("record blob url: %w", err)
 		}
 		download["url"] = proxyBase + blobPathPrefix + hash
 	}
 
-	return json.Marshal(doc)
+	rewritten, err := json.Marshal(doc)
+	if err != nil {
+		return nil, nil, err
+	}
+	return rewritten, identities, nil
 }
 
 // httpClient follows redirects (the CharmHub blob CDN issues 302s) and uses
@@ -592,7 +566,7 @@ type store struct {
 }
 
 func newStore(dir string) (*store, error) {
-	for _, sub := range []string{"refresh", "blobs", "ids"} {
+	for _, sub := range []string{"refresh", "blobs"} {
 		if err := os.MkdirAll(filepath.Join(dir, sub), 0o755); err != nil {
 			return nil, err
 		}
@@ -609,127 +583,52 @@ func canonicalKey(name string, revision int, variant string) string {
 	return hex.EncodeToString(sum[:])
 }
 
-func idKey(id string, revision int, variant string) string {
-	sum := sha256.Sum256(fmt.Appendf(nil, "%s@%d#%s", id, revision, variant))
-	return hex.EncodeToString(sum[:])
-}
-
-// LookupRefresh returns the cached response for a single action, resolving:
-//   - pinned-revision requests via the canonical (name, revision) key,
-//   - by-id requests via the id->name index (requires a revision).
-//
-// Requests with no revision, OR with a revision but also a channel, are
-// never served from cache (see isCacheable). RefreshOne
-// (juju3/charmhub/refresh.go) sends BOTH the installed revision AND the
-// tracking channel to ask "has this channel advanced?" — that answer
-// changes as the channel advances, so it must never be served from a cache
-// keyed on the (stale) installed revision. Cacheable requests are scoped by
-// variantKey so different fields/resource-revisions get distinct entries.
+// LookupRefresh returns the cached response for a single action, keyed by
+// (name, revision, variant). Requests failing isCacheable are never served
+// from cache. RefreshOne (juju3/charmhub/refresh.go) sends BOTH the installed
+// revision AND the tracking channel to ask "has this channel advanced?" —
+// that answer changes as the channel advances, so it must never be served
+// from a cache keyed on the (stale) installed revision.
 func (s *store) LookupRefresh(a action) ([]byte, bool) {
 	if !isCacheable(a) {
 		return nil, false
 	}
 
-	variant := variantKey(a)
-
 	s.refreshMu.Lock()
 	defer s.refreshMu.Unlock()
 
-	if a.Name == "" && a.ID != "" {
-		nameBytes, err := os.ReadFile(filepath.Join(s.dir, "ids", idKey(a.ID, *a.Revision, variant)+".name"))
-		if err != nil {
-			return nil, false
-		}
-		name := strings.TrimSpace(string(nameBytes))
-		if name == "" {
-			return nil, false
-		}
-		b, err := os.ReadFile(filepath.Join(s.dir, "refresh", canonicalKey(name, *a.Revision, variant)+".json"))
-		if err != nil {
-			return nil, false
-		}
-		return b, true
-	}
-
-	b, err := os.ReadFile(filepath.Join(s.dir, "refresh", canonicalKey(a.Name, *a.Revision, variant)+".json"))
+	b, err := os.ReadFile(filepath.Join(s.dir, "refresh", canonicalKey(a.Name, *a.Revision, variantKey(a))+".json"))
 	if err != nil {
 		return nil, false
 	}
 	return b, true
 }
 
-// PutRefresh stores a response under the resolved (name, revision, variant)
-// identity read back from the response body and the requesting action's
-// variant key (fields + resource revisions), and records the id index so
-// future by-id requests for the same immutable id+revision+variant resolve
-// offline.
+// PutRefresh stores a response under the given resolved (name, revision)
+// identity — extracted by rewriteDownloadURLs from the same single parse —
+// and the requesting action's variant key (fields + resource revisions).
 //
 // body must contain exactly one result. A multi-result (batched) response
 // must never be cached here: it would later be replayed verbatim to an
 // unrelated single-action request, which the Juju client rejects with
 // "more than 1 result found" (it requires exactly one result per action).
-func (s *store) PutRefresh(body []byte, variant string) error {
+func (s *store) PutRefresh(body []byte, identity resolvedIdentity, variant string) error {
 	s.refreshMu.Lock()
 	defer s.refreshMu.Unlock()
 
-	resolved, err := resolvedIdentities(body)
-	if err != nil {
-		return fmt.Errorf("parse resolved identities: %w", err)
-	}
-	if len(resolved) == 0 {
-		return errors.New("no resolved results in response")
-	}
-	if len(resolved) > 1 {
-		return fmt.Errorf("refusing to cache a multi-result response (%d results)", len(resolved))
+	if identity.name == "" {
+		return errors.New("no resolved result in response")
 	}
 
-	// Only single-action requests are cached, so there is exactly one result.
-	name, rev := resolved[0].name, resolved[0].revision
-	path := filepath.Join(s.dir, "refresh", canonicalKey(name, rev, variant)+".json")
+	path := filepath.Join(s.dir, "refresh", canonicalKey(identity.name, identity.revision, variant)+".json")
 	tmp := path + ".tmp"
 	if err := os.WriteFile(tmp, body, 0o644); err != nil {
 		return err
 	}
-	if err := os.Rename(tmp, path); err != nil {
-		return err
-	}
-
-	if id := resolved[0].id; id != "" {
-		idPath := filepath.Join(s.dir, "ids", idKey(id, rev, variant)+".name")
-		if err := os.WriteFile(idPath, []byte(name), 0o644); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// resolvedIdentities parses a refresh response and returns the resolved
-// (id, name, revision) for each result.
-func resolvedIdentities(body []byte) ([]resolvedIdentity, error) {
-	var doc struct {
-		Results []struct {
-			Entity struct {
-				ID       string `json:"id"`
-				Name     string `json:"name"`
-				Revision int    `json:"revision"`
-			} `json:"charm"`
-		} `json:"results"`
-	}
-	if err := json.Unmarshal(body, &doc); err != nil {
-		return nil, err
-	}
-	out := make([]resolvedIdentity, 0, len(doc.Results))
-	for _, r := range doc.Results {
-		if r.Entity.Name == "" {
-			continue
-		}
-		out = append(out, resolvedIdentity{id: r.Entity.ID, name: r.Entity.Name, revision: r.Entity.Revision})
-	}
-	return out, nil
+	return os.Rename(tmp, path)
 }
 
 type resolvedIdentity struct {
-	id       string
 	name     string
 	revision int
 }

--- a/tools/charmhub-cache/main.go
+++ b/tools/charmhub-cache/main.go
@@ -3,16 +3,19 @@
 
 // Command charmhub-cache is a caching reverse proxy for the CharmHub refresh
 // API and charm blob downloads, designed for CI. Responses are cached by the
-// resolved charm identity (name + revision), which is immutable, so entries
-// never expire. Requests pinned to a revision (or an id+revision) are served
-// from cache; channel-only requests always go upstream, since their entire
-// purpose is to learn the CURRENT revision for a channel, which can change at
-// any time — caching that would serve stale revisions.
+// resolved charm identity (name + revision) plus the requested fields, since
+// different callers (e.g. the provider's ActionExists vs. the controller's
+// deploy resolve) request different field sets for the same charm+revision;
+// the identity portion is immutable, so entries never expire. Requests
+// pinned to a revision (or an id+revision) are served from cache;
+// channel-only requests always go upstream, since their entire purpose is to
+// learn the CURRENT revision for a channel, which can change at any time —
+// caching that would serve stale revisions.
 //
 // Store layout:
 //
-//	<store>/refresh/<key>.json   # response keyed by resolved name@revision
-//	<store>/ids/<key>.name       # charmhub id+revision -> name index
+//	<store>/refresh/<key>.json   # response keyed by name@revision#fields
+//	<store>/ids/<key>.name       # charmhub id+revision+fields -> name index
 //	<store>/blobs/<hash>         # charm blob bytes
 //	<store>/blobs/<hash>.url     # real upstream URL for cold backfill
 package main
@@ -31,6 +34,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -224,7 +228,7 @@ func (s *server) handleRefresh(w http.ResponseWriter, r *http.Request) {
 	// exactly one result, which the client rejects ("more than 1 result
 	// found"). Best-effort: a store failure must not fail the deploy.
 	if len(actions) == 1 {
-		if err := s.store.PutRefresh(rewritten); err != nil {
+		if err := s.store.PutRefresh(rewritten, actions[0].FieldsKey); err != nil {
 			log.Printf("charmhub-cache: store refresh failed: %v", err)
 		}
 	}
@@ -335,13 +339,21 @@ type action struct {
 	Revision    *int
 	Base        string // "arch/os/channel", empty if absent
 	InstanceKey string // per-request unique key; must match in the response
+	// FieldsKey is a signature of the requested "fields" array. Different
+	// callers request different fields for the same charm+revision (e.g.
+	// ActionExists needs "actions-yaml", the controller's deploy resolve
+	// doesn't), so this must be part of the cache key or a response cached
+	// for one field set gets replayed to a caller needing another.
+	FieldsKey string
 }
 
 // parseRefreshActions extracts the actions from a refresh request body,
 // merging revision/channel/base from the context array (matched by
-// instance-key) for by-id requests.
+// instance-key) for by-id requests. The top-level "fields" array is folded
+// into each action's FieldsKey (see action.FieldsKey for why this matters).
 func parseRefreshActions(body []byte) ([]action, error) {
 	var req struct {
+		Fields  []string `json:"fields"`
 		Context []struct {
 			InstanceKey     string `json:"instance-key"`
 			Revision        *int   `json:"revision"`
@@ -369,6 +381,8 @@ func parseRefreshActions(body []byte) ([]action, error) {
 		return nil, err
 	}
 
+	fieldsKey := normalizeFields(req.Fields)
+
 	// Index context entries by instance-key so by-id actions can pick up
 	// their revision/channel/base.
 	type ctxInfo struct {
@@ -387,7 +401,7 @@ func parseRefreshActions(body []byte) ([]action, error) {
 
 	actions := make([]action, 0, len(req.Actions))
 	for _, a := range req.Actions {
-		act := action{ID: a.ID, Name: a.Name, Channel: a.Channel, Revision: a.Revision, InstanceKey: a.InstanceKey}
+		act := action{ID: a.ID, Name: a.Name, Channel: a.Channel, Revision: a.Revision, InstanceKey: a.InstanceKey, FieldsKey: fieldsKey}
 		if a.Base != nil {
 			act.Base = fmt.Sprintf("%s/%s/%s", a.Base.Architecture, a.Base.Name, a.Base.Channel)
 		}
@@ -406,6 +420,18 @@ func parseRefreshActions(body []byte) ([]action, error) {
 		actions = append(actions, act)
 	}
 	return actions, nil
+}
+
+// normalizeFields returns a stable, order-independent signature for a
+// refresh request's "fields" array, used to key the cache so responses
+// fetched with different field sets are never conflated.
+func normalizeFields(fields []string) string {
+	if len(fields) == 0 {
+		return ""
+	}
+	sorted := append([]string(nil), fields...)
+	sort.Strings(sorted)
+	return strings.Join(sorted, ",")
 }
 
 // rewriteInstanceKey replaces the instance-key in each result with the given
@@ -523,14 +549,16 @@ func newStore(dir string) (*store, error) {
 	return &store{dir: dir}, nil
 }
 
-// canonicalKey returns the on-disk key for a resolved charm identity.
-func canonicalKey(name string, revision int) string {
-	sum := sha256.Sum256(fmt.Appendf(nil, "%s@%d", name, revision))
+// canonicalKey returns the on-disk key for a resolved charm identity,
+// scoped by fieldsKey so responses fetched with different requested fields
+// are never conflated (see action.FieldsKey).
+func canonicalKey(name string, revision int, fieldsKey string) string {
+	sum := sha256.Sum256(fmt.Appendf(nil, "%s@%d#%s", name, revision, fieldsKey))
 	return hex.EncodeToString(sum[:])
 }
 
-func idKey(id string, revision int) string {
-	sum := sha256.Sum256(fmt.Appendf(nil, "%s@%d", id, revision))
+func idKey(id string, revision int, fieldsKey string) string {
+	sum := sha256.Sum256(fmt.Appendf(nil, "%s@%d#%s", id, revision, fieldsKey))
 	return hex.EncodeToString(sum[:])
 }
 
@@ -550,7 +578,7 @@ func (s *store) LookupRefresh(a action) ([]byte, bool) {
 	defer s.refreshMu.Unlock()
 
 	if a.Name == "" && a.ID != "" {
-		nameBytes, err := os.ReadFile(filepath.Join(s.dir, "ids", idKey(a.ID, *a.Revision)+".name"))
+		nameBytes, err := os.ReadFile(filepath.Join(s.dir, "ids", idKey(a.ID, *a.Revision, a.FieldsKey)+".name"))
 		if err != nil {
 			return nil, false
 		}
@@ -558,29 +586,30 @@ func (s *store) LookupRefresh(a action) ([]byte, bool) {
 		if name == "" {
 			return nil, false
 		}
-		b, err := os.ReadFile(filepath.Join(s.dir, "refresh", canonicalKey(name, *a.Revision)+".json"))
+		b, err := os.ReadFile(filepath.Join(s.dir, "refresh", canonicalKey(name, *a.Revision, a.FieldsKey)+".json"))
 		if err != nil {
 			return nil, false
 		}
 		return b, true
 	}
 
-	b, err := os.ReadFile(filepath.Join(s.dir, "refresh", canonicalKey(a.Name, *a.Revision)+".json"))
+	b, err := os.ReadFile(filepath.Join(s.dir, "refresh", canonicalKey(a.Name, *a.Revision, a.FieldsKey)+".json"))
 	if err != nil {
 		return nil, false
 	}
 	return b, true
 }
 
-// PutRefresh stores a response under the resolved (name, revision) identity
-// read back from the response body, and records the id index so future by-id
-// requests for the same immutable id+revision resolve offline.
+// PutRefresh stores a response under the resolved (name, revision, fields)
+// identity read back from the response body and the requesting action's
+// FieldsKey, and records the id index so future by-id requests for the same
+// immutable id+revision+fields resolve offline.
 //
 // body must contain exactly one result. A multi-result (batched) response
 // must never be cached here: it would later be replayed verbatim to an
 // unrelated single-action request, which the Juju client rejects with
 // "more than 1 result found" (it requires exactly one result per action).
-func (s *store) PutRefresh(body []byte) error {
+func (s *store) PutRefresh(body []byte, fieldsKey string) error {
 	s.refreshMu.Lock()
 	defer s.refreshMu.Unlock()
 
@@ -597,7 +626,7 @@ func (s *store) PutRefresh(body []byte) error {
 
 	// Only single-action requests are cached, so there is exactly one result.
 	name, rev := resolved[0].name, resolved[0].revision
-	path := filepath.Join(s.dir, "refresh", canonicalKey(name, rev)+".json")
+	path := filepath.Join(s.dir, "refresh", canonicalKey(name, rev, fieldsKey)+".json")
 	tmp := path + ".tmp"
 	if err := os.WriteFile(tmp, body, 0o644); err != nil {
 		return err
@@ -607,7 +636,7 @@ func (s *store) PutRefresh(body []byte) error {
 	}
 
 	if id := resolved[0].id; id != "" {
-		idPath := filepath.Join(s.dir, "ids", idKey(id, rev)+".name")
+		idPath := filepath.Join(s.dir, "ids", idKey(id, rev, fieldsKey)+".name")
 		if err := os.WriteFile(idPath, []byte(name), 0o644); err != nil {
 			return err
 		}

--- a/tools/charmhub-cache/main_test.go
+++ b/tools/charmhub-cache/main_test.go
@@ -426,6 +426,33 @@ func TestFieldsMismatchNotServedFromCache(t *testing.T) {
 	}
 }
 
+// TestRevisionWithChannelNeverCached is a regression test for a real CI
+// failure: RefreshOne (juju3/charmhub/refresh.go) sends BOTH the currently
+// installed revision AND the tracking channel, to ask "has this channel
+// advanced past what I have installed?". That answer changes as the channel
+// advances, exactly like a channel-only resolve. The proxy previously only
+// treated a nil Revision as "never cache", so this shape (revision set,
+// channel also set) was wrongly served from cache: after switching to a new
+// channel at the same starting revision, the update check kept replaying
+// the stale "no update available" response recorded under the old channel.
+func TestRevisionWithChannelNeverCached(t *testing.T) {
+	st, err := newStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("newStore: %v", err)
+	}
+
+	resp := refreshResponse("ubuntu", 25, "abc123", "https://cdn.example/ubuntu_25.charm")
+	if err := st.PutRefresh(resp, ""); err != nil {
+		t.Fatalf("PutRefresh: %v", err)
+	}
+
+	rev := 25
+	updateCheck := action{Name: "ubuntu", Revision: &rev, Channel: "2.0/stable"}
+	if _, ok := st.LookupRefresh(updateCheck); ok {
+		t.Fatalf("revision+channel request unexpectedly resolved from cache; must always miss to upstream")
+	}
+}
+
 // TestStoreBlobURLRoundTrip verifies the blob URL index persists.
 func TestStoreBlobURLRoundTrip(t *testing.T) {
 	st, err := newStore(t.TempDir())

--- a/tools/charmhub-cache/main_test.go
+++ b/tools/charmhub-cache/main_test.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -450,6 +451,65 @@ func TestRevisionWithChannelNeverCached(t *testing.T) {
 	updateCheck := action{Name: "ubuntu", Revision: &rev, Channel: "2.0/stable"}
 	if _, ok := st.LookupRefresh(updateCheck); ok {
 		t.Fatalf("revision+channel request unexpectedly resolved from cache; must always miss to upstream")
+	}
+}
+
+// TestUpdateCheckDoesNotPoisonPinnedRevisionCache is an end-to-end
+// regression test for a real CI failure: LookupRefresh correctly refuses to
+// SERVE a revision+channel ("is there an update?") response from cache, but
+// handleRefresh still unconditionally STORED every single-action cache miss
+// — including that same revision+channel shape. Since it always misses on
+// lookup, it always falls through to upstream and gets written to the store
+// under the SAME canonical key a later plain pinned-revision request uses.
+// The update-check response reflects the CURRENT channel head (e.g.
+// embedded resource revisions), so it poisoned the entry for a later plain
+// resolve of that same revision: coredns@191's deploy-time resolve was
+// served a resources array reflecting whatever coredns-image the channel
+// currently points to (70) instead of resolving fresh, producing the wrong
+// resource revision deterministically on every run.
+func TestUpdateCheckDoesNotPoisonPinnedRevisionCache(t *testing.T) {
+	st, err := newStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("newStore: %v", err)
+	}
+
+	// The upstream always resolves coredns@191 with whatever the CURRENT
+	// channel-head image resource revision is (70), simulating Charmhub's
+	// real behaviour: the charm revision is pinned, but embedded resource
+	// revisions still reflect the channel's current state.
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"results":[{"charm":{"id":"charm-id-coredns","name":"coredns","revision":191,` +
+			`"resources":[{"name":"coredns-image","revision":70}]}}]}`))
+	}))
+	defer upstream.Close()
+
+	s := &server{store: st, upstream: upstream.URL}
+
+	// Step 1: an "is there an update?" check — revision AND channel both
+	// set, as RefreshOne sends. This must miss the (empty) cache, go
+	// upstream, and — critically — must NOT be stored afterwards.
+	updateCheckBody := []byte(`{
+		"context":[{"instance-key":"ik-1","id":"charm-id-coredns","revision":191,"tracking-channel":"latest/stable"}],
+		"actions":[{"action":"refresh","instance-key":"ik-1","id":"charm-id-coredns"}]
+	}`)
+	req := httptest.NewRequest(http.MethodPost, refreshPath, bytes.NewReader(updateCheckBody))
+	rec := httptest.NewRecorder()
+	s.handleRefresh(rec, req)
+	if rec.Header().Get("X-Charmhub-Cache") != "MISS" {
+		t.Fatalf("update-check: X-Charmhub-Cache = %q, want MISS", rec.Header().Get("X-Charmhub-Cache"))
+	}
+
+	// Step 2: a plain pinned-revision resolve for the SAME revision, no
+	// channel — the deploy's actual charm resolve. It must resolve fresh
+	// (cache miss), not be served the update-check's poisoned response.
+	pinnedBody := []byte(`{"actions":[{"action":"install","instance-key":"ik-2","name":"coredns","revision":191}]}`)
+	req2 := httptest.NewRequest(http.MethodPost, refreshPath, bytes.NewReader(pinnedBody))
+	rec2 := httptest.NewRecorder()
+	s.handleRefresh(rec2, req2)
+	if rec2.Header().Get("X-Charmhub-Cache") == "HIT" {
+		t.Fatalf("pinned-revision resolve was served from cache; the update-check response poisoned the entry")
 	}
 }
 

--- a/tools/charmhub-cache/main_test.go
+++ b/tools/charmhub-cache/main_test.go
@@ -5,6 +5,8 @@ package main
 
 import (
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -18,31 +20,25 @@ func refreshResponse(name string, revision int, hash, url string) []byte {
 		strconv.Itoa(revision) + `,"download":{"hash-sha-256":"` + hash + `","size":1,"url":"` + url + `"}},"effective-channel":"latest/stable"}]}`)
 }
 
-// TestCrossClientConvergence is the core offline guarantee: a charm the
-// provider deploys by pinned revision and the SAME charm the controller
-// resolves by channel must converge on the same cache entry, so a warm cache
-// serves both offline.
+// TestCrossClientConvergence is the core offline guarantee for pinned
+// revisions: once a (name, revision) has been resolved once, any later
+// request pinned to that SAME revision hits the same cache entry, regardless
+// of which client asked. Channel-only requests are never cached (see
+// TestChannelOnlyNeverCached) since the resolved revision can change.
 func TestCrossClientConvergence(t *testing.T) {
 	st, err := newStore(t.TempDir())
 	if err != nil {
 		t.Fatalf("newStore: %v", err)
 	}
 
-	// The controller resolves ubuntu via channel latest/stable (no revision).
-	controllerAction := action{Name: "ubuntu", Channel: "latest/stable", Base: "amd64/ubuntu/22.04"}
-	// Charmhub answers with resolved revision 77.
+	// Charmhub answers a resolve for ubuntu with revision 77.
 	resp := refreshResponse("ubuntu", 77, "abc123", "https://cdn.example/ubuntu_77.charm")
-	if err := st.PutRefresh([]action{controllerAction}, resp); err != nil {
+	if err := st.PutRefresh(resp); err != nil {
 		t.Fatalf("PutRefresh: %v", err)
 	}
 
-	// 1. The controller's channel-only request resolves offline via the index.
-	if _, ok := st.LookupRefresh(controllerAction); !ok {
-		t.Fatalf("channel-only request did not resolve from cache")
-	}
-
-	// 2. The provider's pinned-revision request for the SAME charm hits the
-	//    SAME canonical entry.
+	// A later pinned-revision request for the SAME charm+revision hits the
+	// SAME canonical entry, regardless of which client asked.
 	rev := 77
 	providerAction := action{Name: "ubuntu", Revision: &rev}
 	got, ok := st.LookupRefresh(providerAction)
@@ -53,10 +49,66 @@ func TestCrossClientConvergence(t *testing.T) {
 		t.Fatalf("provider got different body than stored")
 	}
 
-	// 3. A different revision is a distinct entry (miss).
+	// A different revision is a distinct entry (miss).
 	rev78 := 78
 	if _, ok := st.LookupRefresh(action{Name: "ubuntu", Revision: &rev78}); ok {
 		t.Fatalf("revision 78 unexpectedly resolved from cache")
+	}
+}
+
+// TestHandlePassthrough verifies that requests to Charmhub API paths this
+// proxy doesn't cache (e.g. resource revision lookups) are forwarded to
+// upstream with status, body and content-type preserved. Without this, an
+// unhandled path 404s with a plain-text body, which the Juju client rejects
+// with "unexpected charm-hub url ... when parsing headers".
+func TestHandlePassthrough(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v2/charms/resources/juju-qa-test/foo-file/revisions" {
+			t.Errorf("unexpected upstream path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"revisions":[]}`))
+	}))
+	defer upstream.Close()
+
+	s := &server{store: nil, upstream: upstream.URL}
+
+	req := httptest.NewRequest(http.MethodGet, "/v2/charms/resources/juju-qa-test/foo-file/revisions", nil)
+	rec := httptest.NewRecorder()
+	s.handlePassthrough(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Fatalf("content-type = %q, want application/json", ct)
+	}
+	if rec.Body.String() != `{"revisions":[]}` {
+		t.Fatalf("body = %q", rec.Body.String())
+	}
+}
+
+// TestChannelOnlyNeverCached verifies that channel-only requests (no pinned
+// revision) are never served from cache, even after the same charm has been
+// resolved and stored under a pinned revision. A channel's resolved revision
+// can change at any time, so serving it from cache would return stale data
+// once Charmhub advances the channel — this caused a real test failure
+// ("expected charm revision to be updated ... but it is still N").
+func TestChannelOnlyNeverCached(t *testing.T) {
+	st, err := newStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("newStore: %v", err)
+	}
+
+	resp := refreshResponse("ubuntu", 77, "abc123", "https://cdn.example/ubuntu_77.charm")
+	if err := st.PutRefresh(resp); err != nil {
+		t.Fatalf("PutRefresh: %v", err)
+	}
+
+	channelOnly := action{Name: "ubuntu", Channel: "latest/stable", Base: "amd64/ubuntu/22.04"}
+	if _, ok := st.LookupRefresh(channelOnly); ok {
+		t.Fatalf("channel-only request unexpectedly resolved from cache; must always miss to upstream")
 	}
 }
 
@@ -72,8 +124,7 @@ func TestRefreshByIDOffline(t *testing.T) {
 	// Store a response (as if from a deploy) — it carries the charmhub id.
 	resp := refreshResponse("ubuntu", 77, "abc123", "https://cdn.example/ubuntu_77.charm")
 	rev := 77
-	deployAction := action{Name: "ubuntu", Channel: "latest/stable", Revision: &rev}
-	if err := st.PutRefresh([]action{deployAction}, resp); err != nil {
+	if err := st.PutRefresh(resp); err != nil {
 		t.Fatalf("PutRefresh: %v", err)
 	}
 
@@ -288,7 +339,7 @@ func TestStorePutRefreshThenRead(t *testing.T) {
 	rev := 77
 	a := action{Name: "ubuntu", Revision: &rev}
 	body := refreshResponse("ubuntu", 77, "abc123", "https://cdn.example/u.charm")
-	if err := st.PutRefresh([]action{a}, body); err != nil {
+	if err := st.PutRefresh(body); err != nil {
 		t.Fatalf("PutRefresh: %v", err)
 	}
 	got, ok := st.LookupRefresh(a)

--- a/tools/charmhub-cache/main_test.go
+++ b/tools/charmhub-cache/main_test.go
@@ -20,6 +20,39 @@ func refreshResponse(name string, revision int, hash, url string) []byte {
 		strconv.Itoa(revision) + `,"download":{"hash-sha-256":"` + hash + `","size":1,"url":"` + url + `"}},"effective-channel":"latest/stable"}]}`)
 }
 
+// multiResultRefreshResponse builds a batched refresh response containing
+// results for two charms, as the charmrevisioner's RefreshMany can produce.
+func multiResultRefreshResponse(a, b string, revA, revB int) []byte {
+	one := `{"charm":{"id":"charm-id-` + a + `","name":"` + a + `","revision":` + strconv.Itoa(revA) + `},"effective-channel":"latest/stable"}`
+	two := `{"charm":{"id":"charm-id-` + b + `","name":"` + b + `","revision":` + strconv.Itoa(revB) + `},"effective-channel":"latest/stable"}`
+	return []byte(`{"results":[` + one + `,` + two + `]}`)
+}
+
+// TestPutRefreshRejectsMultiResult is a regression test: caching a batched
+// (multi-result) response under one canonical key would later be replayed
+// verbatim to an unrelated single-action request expecting exactly one
+// result. The Juju client rejects that with "more than 1 result found"
+// (core/charm/repository.(*CharmHubRepository).refreshOne requires len==1).
+// PutRefresh must refuse to store multi-result bodies.
+func TestPutRefreshRejectsMultiResult(t *testing.T) {
+	st, err := newStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("newStore: %v", err)
+	}
+
+	body := multiResultRefreshResponse("ubuntu", "postgresql", 77, 10)
+	if err := st.PutRefresh(body); err == nil {
+		t.Fatalf("PutRefresh accepted a multi-result response; must reject it")
+	}
+
+	// Confirm nothing was cached: a later single-action lookup for either
+	// charm must miss (go to upstream), not return the batched body.
+	rev := 77
+	if _, ok := st.LookupRefresh(action{Name: "ubuntu", Revision: &rev}); ok {
+		t.Fatalf("multi-result response was cached despite PutRefresh rejecting it")
+	}
+}
+
 // TestCrossClientConvergence is the core offline guarantee for pinned
 // revisions: once a (name, revision) has been resolved once, any later
 // request pinned to that SAME revision hits the same cache entry, regardless

--- a/tools/charmhub-cache/main_test.go
+++ b/tools/charmhub-cache/main_test.go
@@ -6,6 +6,8 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -510,6 +512,68 @@ func TestUpdateCheckDoesNotPoisonPinnedRevisionCache(t *testing.T) {
 	s.handleRefresh(rec2, req2)
 	if rec2.Header().Get("X-Charmhub-Cache") == "HIT" {
 		t.Fatalf("pinned-revision resolve was served from cache; the update-check response poisoned the entry")
+	}
+}
+
+// TestResourceRevisionRequestsNotConflated is the end-to-end regression test
+// for the real CI failure in TestAcc_ResourceRevisionUpdatesMicrok8s
+// (coredns-image "70" -> "59"). To resolve a SPECIFIC k8s image resource
+// revision, the controller (juju3 core/charm/repository.configsByName ->
+// charmhub.AddResource) sends a refresh with revision pinned (191, no
+// channel) plus a "resource-revisions" discriminator naming the wanted
+// resource revision. Two such requests for the SAME charm+revision but
+// DIFFERENT resource revisions (59 vs 70) differ ONLY in resource-revisions,
+// which the cache key ignores — so without excluding them from the cache the
+// first to populate coredns@191#fields wins and is replayed to the other,
+// serving the wrong resource revision. This is why the test failed on the
+// proxy branch but not on main (live Charmhub honours each request).
+func TestResourceRevisionRequestsNotConflated(t *testing.T) {
+	st, err := newStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("newStore: %v", err)
+	}
+
+	// Upstream echoes back the requested resource revision so we can tell
+	// which request a response actually came from.
+	var upstreamHits int
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamHits++
+		body, _ := io.ReadAll(r.Body)
+		rev := 70
+		if bytes.Contains(body, []byte(`"revision":59`)) {
+			rev = 59
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintf(w, `{"results":[{"charm":{"id":"charm-id-coredns","name":"coredns","revision":191,`+
+			`"resources":[{"name":"coredns-image","revision":%d}]}}]}`, rev)
+	}))
+	defer upstream.Close()
+
+	s := &server{store: st, upstream: upstream.URL}
+
+	resReq := func(resRev int) *httptest.ResponseRecorder {
+		body := []byte(fmt.Sprintf(`{"actions":[{"action":"install","instance-key":"ik","name":"coredns","revision":191,`+
+			`"resource-revisions":[{"name":"coredns-image","revision":%d}]}]}`, resRev))
+		req := httptest.NewRequest(http.MethodPost, refreshPath, bytes.NewReader(body))
+		rec := httptest.NewRecorder()
+		s.handleRefresh(rec, req)
+		return rec
+	}
+
+	// Resolve resource rev 70 first (populates any cache), then rev 59.
+	_ = resReq(70)
+	rec := resReq(59)
+
+	// The rev-59 request must NOT be served the rev-70 cached response.
+	if rec.Header().Get("X-Charmhub-Cache") == "HIT" {
+		t.Fatalf("resource-revision request was served from cache, conflating different resource revisions")
+	}
+	if !bytes.Contains(rec.Body.Bytes(), []byte(`"revision":59`)) {
+		t.Fatalf("resource rev 59 request got wrong response body: %s", rec.Body.String())
+	}
+	if upstreamHits != 2 {
+		t.Fatalf("expected both resource-revision requests to reach upstream, got %d hits", upstreamHits)
 	}
 }
 

--- a/tools/charmhub-cache/main_test.go
+++ b/tools/charmhub-cache/main_test.go
@@ -31,28 +31,52 @@ func multiResultRefreshResponse(a, b string, revA, revB int) []byte {
 	return []byte(`{"results":[` + one + `,` + two + `]}`)
 }
 
+// putRefresh stores a response the way handleRefresh does in production:
+// extract the resolved identity via rewriteDownloadURLs (the same single
+// parse), then PutRefresh. Fails the test if the response doesn't resolve
+// to exactly one identity.
+func putRefresh(t *testing.T, st *store, body []byte, variant string) {
+	t.Helper()
+	_, identities, err := rewriteDownloadURLs(body, st, "http://127.0.0.1:8080")
+	if err != nil {
+		t.Fatalf("rewriteDownloadURLs: %v", err)
+	}
+	if len(identities) != 1 {
+		t.Fatalf("expected exactly 1 resolved identity, got %d", len(identities))
+	}
+	if err := st.PutRefresh(body, identities[0], variant); err != nil {
+		t.Fatalf("PutRefresh: %v", err)
+	}
+}
+
 // TestPutRefreshRejectsMultiResult is a regression test: caching a batched
 // (multi-result) response under one canonical key would later be replayed
 // verbatim to an unrelated single-action request expecting exactly one
 // result. The Juju client rejects that with "more than 1 result found"
 // (core/charm/repository.(*CharmHubRepository).refreshOne requires len==1).
-// PutRefresh must refuse to store multi-result bodies.
+// handleRefresh must refuse to store multi-result bodies.
 func TestPutRefreshRejectsMultiResult(t *testing.T) {
 	st, err := newStore(t.TempDir())
 	if err != nil {
 		t.Fatalf("newStore: %v", err)
 	}
 
+	// The production store path: rewriteDownloadURLs extracts the
+	// identities, and handleRefresh only stores when there is exactly one.
 	body := multiResultRefreshResponse("ubuntu", "postgresql", 77, 10)
-	if err := st.PutRefresh(body, ""); err == nil {
-		t.Fatalf("PutRefresh accepted a multi-result response; must reject it")
+	_, identities, err := rewriteDownloadURLs(body, st, "http://127.0.0.1:8080")
+	if err != nil {
+		t.Fatalf("rewriteDownloadURLs: %v", err)
+	}
+	if len(identities) != 2 {
+		t.Fatalf("expected 2 resolved identities from a batched response, got %d", len(identities))
 	}
 
 	// Confirm nothing was cached: a later single-action lookup for either
 	// charm must miss (go to upstream), not return the batched body.
 	rev := 77
 	if _, ok := st.LookupRefresh(action{Name: "ubuntu", Revision: &rev}); ok {
-		t.Fatalf("multi-result response was cached despite PutRefresh rejecting it")
+		t.Fatalf("multi-result response was cached despite the store gate rejecting it")
 	}
 }
 
@@ -69,9 +93,7 @@ func TestCrossClientConvergence(t *testing.T) {
 
 	// Charmhub answers a resolve for ubuntu with revision 77.
 	resp := refreshResponse("ubuntu", 77, "abc123", "https://cdn.example/ubuntu_77.charm")
-	if err := st.PutRefresh(resp, ""); err != nil {
-		t.Fatalf("PutRefresh: %v", err)
-	}
+	putRefresh(t, st, resp, "")
 
 	// A later pinned-revision request for the SAME charm+revision hits the
 	// SAME canonical entry, regardless of which client asked.
@@ -138,81 +160,37 @@ func TestChannelOnlyNeverCached(t *testing.T) {
 	}
 
 	resp := refreshResponse("ubuntu", 77, "abc123", "https://cdn.example/ubuntu_77.charm")
-	if err := st.PutRefresh(resp, ""); err != nil {
-		t.Fatalf("PutRefresh: %v", err)
-	}
+	putRefresh(t, st, resp, "")
 
-	channelOnly := action{Name: "ubuntu", Channel: "latest/stable", Base: "amd64/ubuntu/22.04"}
+	channelOnly := action{Name: "ubuntu", Channel: "latest/stable"}
 	if _, ok := st.LookupRefresh(channelOnly); ok {
 		t.Fatalf("channel-only request unexpectedly resolved from cache; must always miss to upstream")
 	}
 }
 
-// TestRefreshByIDOffline verifies the charmrevisioner path: a refresh-by-id
-// request (no name, revision in the context) resolves offline via the id
-// index populated from a prior response.
-func TestRefreshByIDOffline(t *testing.T) {
+// TestByIDNeverCached verifies that by-id refreshes (the charmrevisioner
+// worker, which never fires within a CI job's lifetime) are never served
+// from cache: they carry no name, so they fail isCacheable and always pass
+// through to upstream.
+func TestByIDNeverCached(t *testing.T) {
 	st, err := newStore(t.TempDir())
 	if err != nil {
 		t.Fatalf("newStore: %v", err)
 	}
 
-	// Store a response (as if from a deploy) — it carries the charmhub id.
 	resp := refreshResponse("ubuntu", 77, "abc123", "https://cdn.example/ubuntu_77.charm")
+	putRefresh(t, st, resp, "")
+
 	rev := 77
-	if err := st.PutRefresh(resp, ""); err != nil {
-		t.Fatalf("PutRefresh: %v", err)
-	}
-
-	// The charmrevisioner sends refresh-by-id: action has only id, revision in
-	// context. The proxy parses this into action{ID, Revision} (name empty).
-	workerAction := action{ID: "charm-id-ubuntu", Revision: &rev}
-	got, ok := st.LookupRefresh(workerAction)
-	if !ok {
-		t.Fatalf("refresh-by-id did not resolve from cache")
-	}
-	if string(got) != string(resp) {
-		t.Fatalf("refresh-by-id got different body than stored")
-	}
-
-	// A refresh-by-id for a revision we haven't seen must miss.
-	rev99 := 99
-	if _, ok := st.LookupRefresh(action{ID: "charm-id-ubuntu", Revision: &rev99}); ok {
-		t.Fatalf("refresh-by-id for unseen revision unexpectedly resolved")
-	}
-}
-
-// TestParseRefreshByIDAction verifies that refresh-by-id requests pull
-// revision/channel/base from the context array (matched by instance-key),
-// since the action itself carries only the id.
-func TestParseRefreshByIDAction(t *testing.T) {
-	body := []byte(`{
-		"context":[{"instance-key":"ik-1","id":"charm-id-ubuntu","revision":77,"tracking-channel":"latest/stable","base":{"architecture":"amd64","name":"ubuntu","channel":"22.04"}}],
-		"actions":[{"action":"refresh","instance-key":"ik-1","id":"charm-id-ubuntu"}]
-	}`)
-	acts, err := parseRefreshActions(body)
-	if err != nil {
-		t.Fatalf("parse refresh-by-id: %v", err)
-	}
-	if len(acts) != 1 {
-		t.Fatalf("expected 1 action, got %d", len(acts))
-	}
-	a := acts[0]
-	if a.ID != "charm-id-ubuntu" || a.Name != "" {
-		t.Fatalf("id/name parsed wrong: %+v", a)
-	}
-	if a.Revision == nil || *a.Revision != 77 {
-		t.Fatalf("revision not pulled from context: %+v", a)
-	}
-	if a.Channel != "latest/stable" || a.Base != "amd64/ubuntu/22.04" {
-		t.Fatalf("channel/base not pulled from context: %+v", a)
+	if _, ok := st.LookupRefresh(action{Revision: &rev}); ok {
+		t.Fatalf("by-id request (no name) unexpectedly resolved from cache; must always miss to upstream")
 	}
 }
 
 // TestParseRefreshActions verifies action extraction across the different
 // serialisations the provider and controller produce.
 func TestParseRefreshActions(t *testing.T) {
-	// Provider style: pinned revision, no channel/base.
+	// Provider style: pinned revision, no channel.
 	p := []byte(`{"context":[],"actions":[{"action":"install","instance-key":"key-0","name":"ubuntu","revision":77}],"fields":["revision"]}`)
 	acts, err := parseRefreshActions(p)
 	if err != nil {
@@ -222,13 +200,14 @@ func TestParseRefreshActions(t *testing.T) {
 		t.Fatalf("provider action parsed wrong: %+v", acts)
 	}
 
-	// Controller style: channel + base, no revision.
+	// Controller style: channel, no revision (base is ignored by the
+	// parser — it doesn't feed the cacheability check or key).
 	c := []byte(`{"actions":[{"action":"install","instance-key":"k","name":"ubuntu","channel":"latest/stable","base":{"architecture":"amd64","name":"ubuntu","channel":"22.04"}}]}`)
 	acts, err = parseRefreshActions(c)
 	if err != nil {
 		t.Fatalf("parse controller request: %v", err)
 	}
-	if len(acts) != 1 || acts[0].Channel != "latest/stable" || acts[0].Revision != nil || acts[0].Base != "amd64/ubuntu/22.04" {
+	if len(acts) != 1 || acts[0].Channel != "latest/stable" || acts[0].Revision != nil {
 		t.Fatalf("controller action parsed wrong: %+v", acts)
 	}
 }
@@ -296,9 +275,14 @@ func TestRewriteDownloadURLs(t *testing.T) {
 		]
 	}`)
 
-	rewritten, err := rewriteDownloadURLs(body, st, "http://127.0.0.1:8080")
+	rewritten, identities, err := rewriteDownloadURLs(body, st, "http://127.0.0.1:8080")
 	if err != nil {
 		t.Fatalf("rewriteDownloadURLs: %v", err)
+	}
+
+	// The resolved identity is extracted from the same single parse.
+	if len(identities) != 1 || identities[0].name != "ubuntu" || identities[0].revision != 77 {
+		t.Errorf("resolved identity = %+v, want ubuntu@77", identities)
 	}
 
 	var doc map[string]any
@@ -350,9 +334,13 @@ func TestRewriteDownloadURLsNoResults(t *testing.T) {
 		t.Fatalf("newStore: %v", err)
 	}
 	body := []byte(`{"error-list":[{"code":"not-found","message":"no such charm"}]}`)
-	rewritten, err := rewriteDownloadURLs(body, st, "http://127.0.0.1:8080")
+	rewritten, identities, err := rewriteDownloadURLs(body, st, "http://127.0.0.1:8080")
 	if err != nil {
 		t.Fatalf("rewriteDownloadURLs: %v", err)
+	}
+	// No results means no identity: such responses are never cacheable.
+	if len(identities) != 0 {
+		t.Errorf("expected no identities from an error-list response, got %d", len(identities))
 	}
 	// The body should be semantically identical (key present, no results key).
 	var doc map[string]any
@@ -375,9 +363,7 @@ func TestStorePutRefreshThenRead(t *testing.T) {
 	rev := 77
 	a := action{Name: "ubuntu", Revision: &rev}
 	body := refreshResponse("ubuntu", 77, "abc123", "https://cdn.example/u.charm")
-	if err := st.PutRefresh(body, ""); err != nil {
-		t.Fatalf("PutRefresh: %v", err)
-	}
+	putRefresh(t, st, body, "")
 	got, ok := st.LookupRefresh(a)
 	if !ok {
 		t.Fatalf("LookupRefresh miss after PutRefresh")
@@ -411,9 +397,7 @@ func TestFieldsMismatchNotServedFromCache(t *testing.T) {
 	rev := 6
 	const controllerFields = "bases,config-yaml,download,id,license,metadata-yaml,name,publisher,resources,revision,summary,type,version"
 	controllerAction := action{Name: "juju-qa-dummy-source", Revision: &rev, FieldsKey: controllerFields}
-	if err := st.PutRefresh(resp, variantKey(controllerAction)); err != nil {
-		t.Fatalf("PutRefresh: %v", err)
-	}
+	putRefresh(t, st, resp, variantKey(controllerAction))
 
 	// Provider's ActionExists requests a different field set (includes
 	// actions-yaml). It must NOT hit the controller's cache entry.
@@ -445,9 +429,7 @@ func TestRevisionWithChannelNeverCached(t *testing.T) {
 	}
 
 	resp := refreshResponse("ubuntu", 25, "abc123", "https://cdn.example/ubuntu_25.charm")
-	if err := st.PutRefresh(resp, ""); err != nil {
-		t.Fatalf("PutRefresh: %v", err)
-	}
+	putRefresh(t, st, resp, "")
 
 	rev := 25
 	updateCheck := action{Name: "ubuntu", Revision: &rev, Channel: "2.0/stable"}

--- a/tools/charmhub-cache/main_test.go
+++ b/tools/charmhub-cache/main_test.go
@@ -406,16 +406,17 @@ func TestFieldsMismatchNotServedFromCache(t *testing.T) {
 	}
 
 	// Controller-style resolve: no actions-yaml in the response, cached
-	// under the controller's field set.
+	// under the controller's field set (via the same variantKey lookups use).
 	resp := refreshResponse("juju-qa-dummy-source", 6, "abc123", "https://cdn.example/dummy_6.charm")
+	rev := 6
 	const controllerFields = "bases,config-yaml,download,id,license,metadata-yaml,name,publisher,resources,revision,summary,type,version"
-	if err := st.PutRefresh(resp, controllerFields); err != nil {
+	controllerAction := action{Name: "juju-qa-dummy-source", Revision: &rev, FieldsKey: controllerFields}
+	if err := st.PutRefresh(resp, variantKey(controllerAction)); err != nil {
 		t.Fatalf("PutRefresh: %v", err)
 	}
 
 	// Provider's ActionExists requests a different field set (includes
 	// actions-yaml). It must NOT hit the controller's cache entry.
-	rev := 6
 	const providerFields = "actions-yaml,bases,metadata-yaml,name,resources,revision"
 	providerAction := action{Name: "juju-qa-dummy-source", Revision: &rev, FieldsKey: providerFields}
 	if _, ok := st.LookupRefresh(providerAction); ok {
@@ -423,7 +424,6 @@ func TestFieldsMismatchNotServedFromCache(t *testing.T) {
 	}
 
 	// A request with the SAME field set as what was cached still hits.
-	controllerAction := action{Name: "juju-qa-dummy-source", Revision: &rev, FieldsKey: controllerFields}
 	if _, ok := st.LookupRefresh(controllerAction); !ok {
 		t.Fatalf("request with matching fields unexpectedly missed cache")
 	}
@@ -522,11 +522,12 @@ func TestUpdateCheckDoesNotPoisonPinnedRevisionCache(t *testing.T) {
 // charmhub.AddResource) sends a refresh with revision pinned (191, no
 // channel) plus a "resource-revisions" discriminator naming the wanted
 // resource revision. Two such requests for the SAME charm+revision but
-// DIFFERENT resource revisions (59 vs 70) differ ONLY in resource-revisions,
-// which the cache key ignores — so without excluding them from the cache the
-// first to populate coredns@191#fields wins and is replayed to the other,
-// serving the wrong resource revision. This is why the test failed on the
-// proxy branch but not on main (live Charmhub honours each request).
+// DIFFERENT resource revisions (59 vs 70) differ ONLY in resource-revisions.
+// These ARE cached (folded into the cache key via variantKey), so this test
+// asserts correct partitioning: distinct resource revisions get distinct
+// entries (never conflated), while a repeat of the SAME resource revision is
+// served the correct cached body. Conflating them was why the test failed on
+// the proxy branch but not on main (live Charmhub honours each request).
 func TestResourceRevisionRequestsNotConflated(t *testing.T) {
 	st, err := newStore(t.TempDir())
 	if err != nil {
@@ -534,7 +535,8 @@ func TestResourceRevisionRequestsNotConflated(t *testing.T) {
 	}
 
 	// Upstream echoes back the requested resource revision so we can tell
-	// which request a response actually came from.
+	// which request a response actually came from, and counts hits so we can
+	// confirm the repeat is served from cache (not re-fetched).
 	var upstreamHits int
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		upstreamHits++
@@ -561,19 +563,35 @@ func TestResourceRevisionRequestsNotConflated(t *testing.T) {
 		return rec
 	}
 
-	// Resolve resource rev 70 first (populates any cache), then rev 59.
-	_ = resReq(70)
+	// Resolve resource rev 70 first (populates the cache), then rev 59.
+	if rec := resReq(70); rec.Header().Get("X-Charmhub-Cache") != "MISS" {
+		t.Fatalf("first rev-70 request: X-Charmhub-Cache = %q, want MISS", rec.Header().Get("X-Charmhub-Cache"))
+	}
 	rec := resReq(59)
 
-	// The rev-59 request must NOT be served the rev-70 cached response.
+	// The rev-59 request must NOT be served the rev-70 cached response: it
+	// must resolve fresh and return the rev-59 body.
 	if rec.Header().Get("X-Charmhub-Cache") == "HIT" {
-		t.Fatalf("resource-revision request was served from cache, conflating different resource revisions")
+		t.Fatalf("rev-59 request was served the rev-70 cache entry (resource revisions conflated)")
 	}
 	if !bytes.Contains(rec.Body.Bytes(), []byte(`"revision":59`)) {
 		t.Fatalf("resource rev 59 request got wrong response body: %s", rec.Body.String())
 	}
 	if upstreamHits != 2 {
-		t.Fatalf("expected both resource-revision requests to reach upstream, got %d hits", upstreamHits)
+		t.Fatalf("expected both distinct resource-revision requests to reach upstream, got %d hits", upstreamHits)
+	}
+
+	// A REPEAT of rev 70 must now be served from cache (proving resource
+	// revisions are cached, not skipped) and return the rev-70 body.
+	repeat := resReq(70)
+	if repeat.Header().Get("X-Charmhub-Cache") != "HIT" {
+		t.Fatalf("repeated rev-70 request: X-Charmhub-Cache = %q, want HIT", repeat.Header().Get("X-Charmhub-Cache"))
+	}
+	if !bytes.Contains(repeat.Body.Bytes(), []byte(`"revision":70`)) {
+		t.Fatalf("repeated rev-70 request got wrong body: %s", repeat.Body.String())
+	}
+	if upstreamHits != 2 {
+		t.Fatalf("repeat should have been served from cache, but upstream was hit again (%d)", upstreamHits)
 	}
 }
 

--- a/tools/charmhub-cache/main_test.go
+++ b/tools/charmhub-cache/main_test.go
@@ -41,7 +41,7 @@ func TestPutRefreshRejectsMultiResult(t *testing.T) {
 	}
 
 	body := multiResultRefreshResponse("ubuntu", "postgresql", 77, 10)
-	if err := st.PutRefresh(body); err == nil {
+	if err := st.PutRefresh(body, ""); err == nil {
 		t.Fatalf("PutRefresh accepted a multi-result response; must reject it")
 	}
 
@@ -66,7 +66,7 @@ func TestCrossClientConvergence(t *testing.T) {
 
 	// Charmhub answers a resolve for ubuntu with revision 77.
 	resp := refreshResponse("ubuntu", 77, "abc123", "https://cdn.example/ubuntu_77.charm")
-	if err := st.PutRefresh(resp); err != nil {
+	if err := st.PutRefresh(resp, ""); err != nil {
 		t.Fatalf("PutRefresh: %v", err)
 	}
 
@@ -135,7 +135,7 @@ func TestChannelOnlyNeverCached(t *testing.T) {
 	}
 
 	resp := refreshResponse("ubuntu", 77, "abc123", "https://cdn.example/ubuntu_77.charm")
-	if err := st.PutRefresh(resp); err != nil {
+	if err := st.PutRefresh(resp, ""); err != nil {
 		t.Fatalf("PutRefresh: %v", err)
 	}
 
@@ -157,7 +157,7 @@ func TestRefreshByIDOffline(t *testing.T) {
 	// Store a response (as if from a deploy) — it carries the charmhub id.
 	resp := refreshResponse("ubuntu", 77, "abc123", "https://cdn.example/ubuntu_77.charm")
 	rev := 77
-	if err := st.PutRefresh(resp); err != nil {
+	if err := st.PutRefresh(resp, ""); err != nil {
 		t.Fatalf("PutRefresh: %v", err)
 	}
 
@@ -372,7 +372,7 @@ func TestStorePutRefreshThenRead(t *testing.T) {
 	rev := 77
 	a := action{Name: "ubuntu", Revision: &rev}
 	body := refreshResponse("ubuntu", 77, "abc123", "https://cdn.example/u.charm")
-	if err := st.PutRefresh(body); err != nil {
+	if err := st.PutRefresh(body, ""); err != nil {
 		t.Fatalf("PutRefresh: %v", err)
 	}
 	got, ok := st.LookupRefresh(a)
@@ -383,8 +383,46 @@ func TestStorePutRefreshThenRead(t *testing.T) {
 		t.Fatalf("LookupRefresh body mismatch: got %q want %q", got, body)
 	}
 	// Confirm it landed on disk under the canonical path.
-	if _, err := os.Stat(filepath.Join(dir, "refresh", canonicalKey("ubuntu", 77)+".json")); err != nil {
+	if _, err := os.Stat(filepath.Join(dir, "refresh", canonicalKey("ubuntu", 77, "")+".json")); err != nil {
 		t.Fatalf("refresh file not on disk: %v", err)
+	}
+}
+
+// TestFieldsMismatchNotServedFromCache is a regression test for a real CI
+// failure: the provider's ActionExists requests "actions-yaml" (needed to
+// check for a defined action) while the controller's own deploy-time resolve
+// does not. If a response cached for one field set were replayed to a
+// request needing a different field set, the response could be missing
+// fields the caller depends on (e.g. actions-yaml), causing ActionExists to
+// incorrectly report the action as undefined. The cache must key on the
+// requested fields so these never conflate.
+func TestFieldsMismatchNotServedFromCache(t *testing.T) {
+	st, err := newStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("newStore: %v", err)
+	}
+
+	// Controller-style resolve: no actions-yaml in the response, cached
+	// under the controller's field set.
+	resp := refreshResponse("juju-qa-dummy-source", 6, "abc123", "https://cdn.example/dummy_6.charm")
+	const controllerFields = "bases,config-yaml,download,id,license,metadata-yaml,name,publisher,resources,revision,summary,type,version"
+	if err := st.PutRefresh(resp, controllerFields); err != nil {
+		t.Fatalf("PutRefresh: %v", err)
+	}
+
+	// Provider's ActionExists requests a different field set (includes
+	// actions-yaml). It must NOT hit the controller's cache entry.
+	rev := 6
+	const providerFields = "actions-yaml,bases,metadata-yaml,name,resources,revision"
+	providerAction := action{Name: "juju-qa-dummy-source", Revision: &rev, FieldsKey: providerFields}
+	if _, ok := st.LookupRefresh(providerAction); ok {
+		t.Fatalf("provider request with different fields incorrectly hit the controller's cache entry")
+	}
+
+	// A request with the SAME field set as what was cached still hits.
+	controllerAction := action{Name: "juju-qa-dummy-source", Revision: &rev, FieldsKey: controllerFields}
+	if _, ok := st.LookupRefresh(controllerAction); !ok {
+		t.Fatalf("request with matching fields unexpectedly missed cache")
 	}
 }
 

--- a/tools/charmhub-cache/main_test.go
+++ b/tools/charmhub-cache/main_test.go
@@ -146,6 +146,36 @@ func TestParseRefreshActions(t *testing.T) {
 	}
 }
 
+// TestRewriteInstanceKey verifies that the instance-key in a cached response
+// is rewritten to match the current request. Without this, the client's
+// Ensure() rejects the response with "install action key not valid" because
+// the cached response carries a stale per-request UUID.
+func TestRewriteInstanceKey(t *testing.T) {
+	body := []byte(`{"results":[{"instance-key":"old-uuid","charm":{"name":"ubuntu","revision":77}}]}`)
+	rewritten := rewriteInstanceKey(body, "new-uuid")
+
+	var doc struct {
+		Results []struct {
+			InstanceKey string `json:"instance-key"`
+			Charm       struct {
+				Name string `json:"name"`
+			} `json:"charm"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal(rewritten, &doc); err != nil {
+		t.Fatalf("rewritten body is not valid JSON: %v", err)
+	}
+	if len(doc.Results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(doc.Results))
+	}
+	if doc.Results[0].InstanceKey != "new-uuid" {
+		t.Fatalf("instance-key = %q, want %q", doc.Results[0].InstanceKey, "new-uuid")
+	}
+	if doc.Results[0].Charm.Name != "ubuntu" {
+		t.Fatalf("charm name not preserved: %q", doc.Results[0].Charm.Name)
+	}
+}
+
 // TestRewriteDownloadURLs verifies that:
 //   - the download.url in each result is rewritten to an absolute proxy URL,
 //   - the real upstream URL is recorded in the store for backfill,

--- a/tools/charmhub-cache/main_test.go
+++ b/tools/charmhub-cache/main_test.go
@@ -1,0 +1,296 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the Apache License, Version 2.0, see LICENCE file for details.
+
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+)
+
+// refreshResponse builds a minimal Charmhub refresh response body for the
+// given resolved charm, with an id, a download URL and hash.
+func refreshResponse(name string, revision int, hash, url string) []byte {
+	return []byte(`{"results":[{"charm":{"id":"charm-id-` + name + `","name":"` + name + `","revision":` +
+		strconv.Itoa(revision) + `,"download":{"hash-sha-256":"` + hash + `","size":1,"url":"` + url + `"}},"effective-channel":"latest/stable"}]}`)
+}
+
+// TestCrossClientConvergence is the core offline guarantee: a charm the
+// provider deploys by pinned revision and the SAME charm the controller
+// resolves by channel must converge on the same cache entry, so a warm cache
+// serves both offline.
+func TestCrossClientConvergence(t *testing.T) {
+	st, err := newStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("newStore: %v", err)
+	}
+
+	// The controller resolves ubuntu via channel latest/stable (no revision).
+	controllerAction := action{Name: "ubuntu", Channel: "latest/stable", Base: "amd64/ubuntu/22.04"}
+	// Charmhub answers with resolved revision 77.
+	resp := refreshResponse("ubuntu", 77, "abc123", "https://cdn.example/ubuntu_77.charm")
+	if err := st.PutRefresh([]action{controllerAction}, resp); err != nil {
+		t.Fatalf("PutRefresh: %v", err)
+	}
+
+	// 1. The controller's channel-only request resolves offline via the index.
+	if _, ok := st.LookupRefresh(controllerAction); !ok {
+		t.Fatalf("channel-only request did not resolve from cache")
+	}
+
+	// 2. The provider's pinned-revision request for the SAME charm hits the
+	//    SAME canonical entry.
+	rev := 77
+	providerAction := action{Name: "ubuntu", Revision: &rev}
+	got, ok := st.LookupRefresh(providerAction)
+	if !ok {
+		t.Fatalf("pinned-revision request did not resolve from cache")
+	}
+	if string(got) != string(resp) {
+		t.Fatalf("provider got different body than stored")
+	}
+
+	// 3. A different revision is a distinct entry (miss).
+	rev78 := 78
+	if _, ok := st.LookupRefresh(action{Name: "ubuntu", Revision: &rev78}); ok {
+		t.Fatalf("revision 78 unexpectedly resolved from cache")
+	}
+}
+
+// TestRefreshByIDOffline verifies the charmrevisioner path: a refresh-by-id
+// request (no name, revision in the context) resolves offline via the id
+// index populated from a prior response.
+func TestRefreshByIDOffline(t *testing.T) {
+	st, err := newStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("newStore: %v", err)
+	}
+
+	// Store a response (as if from a deploy) — it carries the charmhub id.
+	resp := refreshResponse("ubuntu", 77, "abc123", "https://cdn.example/ubuntu_77.charm")
+	rev := 77
+	deployAction := action{Name: "ubuntu", Channel: "latest/stable", Revision: &rev}
+	if err := st.PutRefresh([]action{deployAction}, resp); err != nil {
+		t.Fatalf("PutRefresh: %v", err)
+	}
+
+	// The charmrevisioner sends refresh-by-id: action has only id, revision in
+	// context. The proxy parses this into action{ID, Revision} (name empty).
+	workerAction := action{ID: "charm-id-ubuntu", Revision: &rev}
+	got, ok := st.LookupRefresh(workerAction)
+	if !ok {
+		t.Fatalf("refresh-by-id did not resolve from cache")
+	}
+	if string(got) != string(resp) {
+		t.Fatalf("refresh-by-id got different body than stored")
+	}
+
+	// A refresh-by-id for a revision we haven't seen must miss.
+	rev99 := 99
+	if _, ok := st.LookupRefresh(action{ID: "charm-id-ubuntu", Revision: &rev99}); ok {
+		t.Fatalf("refresh-by-id for unseen revision unexpectedly resolved")
+	}
+}
+
+// TestParseRefreshByIDAction verifies that refresh-by-id requests pull
+// revision/channel/base from the context array (matched by instance-key),
+// since the action itself carries only the id.
+func TestParseRefreshByIDAction(t *testing.T) {
+	body := []byte(`{
+		"context":[{"instance-key":"ik-1","id":"charm-id-ubuntu","revision":77,"tracking-channel":"latest/stable","base":{"architecture":"amd64","name":"ubuntu","channel":"22.04"}}],
+		"actions":[{"action":"refresh","instance-key":"ik-1","id":"charm-id-ubuntu"}]
+	}`)
+	acts, err := parseRefreshActions(body)
+	if err != nil {
+		t.Fatalf("parse refresh-by-id: %v", err)
+	}
+	if len(acts) != 1 {
+		t.Fatalf("expected 1 action, got %d", len(acts))
+	}
+	a := acts[0]
+	if a.ID != "charm-id-ubuntu" || a.Name != "" {
+		t.Fatalf("id/name parsed wrong: %+v", a)
+	}
+	if a.Revision == nil || *a.Revision != 77 {
+		t.Fatalf("revision not pulled from context: %+v", a)
+	}
+	if a.Channel != "latest/stable" || a.Base != "amd64/ubuntu/22.04" {
+		t.Fatalf("channel/base not pulled from context: %+v", a)
+	}
+}
+
+// TestParseRefreshActions verifies action extraction across the different
+// serialisations the provider and controller produce.
+func TestParseRefreshActions(t *testing.T) {
+	// Provider style: pinned revision, no channel/base.
+	p := []byte(`{"context":[],"actions":[{"action":"install","instance-key":"key-0","name":"ubuntu","revision":77}],"fields":["revision"]}`)
+	acts, err := parseRefreshActions(p)
+	if err != nil {
+		t.Fatalf("parse provider request: %v", err)
+	}
+	if len(acts) != 1 || acts[0].Name != "ubuntu" || acts[0].Revision == nil || *acts[0].Revision != 77 {
+		t.Fatalf("provider action parsed wrong: %+v", acts)
+	}
+
+	// Controller style: channel + base, no revision.
+	c := []byte(`{"actions":[{"action":"install","instance-key":"k","name":"ubuntu","channel":"latest/stable","base":{"architecture":"amd64","name":"ubuntu","channel":"22.04"}}]}`)
+	acts, err = parseRefreshActions(c)
+	if err != nil {
+		t.Fatalf("parse controller request: %v", err)
+	}
+	if len(acts) != 1 || acts[0].Channel != "latest/stable" || acts[0].Revision != nil || acts[0].Base != "amd64/ubuntu/22.04" {
+		t.Fatalf("controller action parsed wrong: %+v", acts)
+	}
+}
+
+// TestRewriteDownloadURLs verifies that:
+//   - the download.url in each result is rewritten to an absolute proxy URL,
+//   - the real upstream URL is recorded in the store for backfill,
+//   - all other fields are preserved verbatim (including unknown ones).
+func TestRewriteDownloadURLs(t *testing.T) {
+	st, err := newStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("newStore: %v", err)
+	}
+
+	const realURL = "https://storage.example.com/charms/ubuntu_77.charm"
+	const hash = "abc123def456"
+	// Include an unknown field ("future-field") to prove the rewrite is
+	// lossless for fields the transport package doesn't model.
+	body := []byte(`{
+		"results": [
+			{
+				"charm": {
+					"name": "ubuntu",
+					"revision": 77,
+					"download": {
+						"hash-sha-256": "` + hash + `",
+						"hash-sha-384": "deadbeef",
+						"size": 12345,
+						"url": "` + realURL + `"
+					},
+					"future-field": {"keep": "me"}
+				},
+				"effective-channel": "latest/stable"
+			}
+		]
+	}`)
+
+	rewritten, err := rewriteDownloadURLs(body, st, "http://127.0.0.1:8080")
+	if err != nil {
+		t.Fatalf("rewriteDownloadURLs: %v", err)
+	}
+
+	var doc map[string]any
+	if err := json.Unmarshal(rewritten, &doc); err != nil {
+		t.Fatalf("rewritten body is not valid JSON: %v", err)
+	}
+	results := doc["results"].([]any)
+	result := results[0].(map[string]any)
+	entity := result["charm"].(map[string]any)
+	download := entity["download"].(map[string]any)
+
+	gotURL := download["url"].(string)
+	wantURL := "http://127.0.0.1:8080/blob/" + hash
+	if gotURL != wantURL {
+		t.Fatalf("download.url = %q, want %q", gotURL, wantURL)
+	}
+
+	// Other download fields preserved.
+	if download["hash-sha-384"] != "deadbeef" {
+		t.Errorf("hash-sha-384 not preserved: %v", download["hash-sha-384"])
+	}
+	if download["size"] != float64(12345) {
+		t.Errorf("size not preserved: %v", download["size"])
+	}
+	// Unknown field preserved.
+	if ff, ok := entity["future-field"].(map[string]any); !ok || ff["keep"] != "me" {
+		t.Errorf("future-field not preserved: %v", entity["future-field"])
+	}
+	// Sibling fields preserved.
+	if result["effective-channel"] != "latest/stable" {
+		t.Errorf("effective-channel not preserved: %v", result["effective-channel"])
+	}
+
+	// The real URL was recorded for backfill.
+	recorded, ok := st.BlobURL(hash)
+	if !ok {
+		t.Fatalf("BlobURL(%q) not recorded", hash)
+	}
+	if recorded != realURL {
+		t.Fatalf("recorded URL = %q, want %q", recorded, realURL)
+	}
+}
+
+// TestRewriteDownloadURLsNoResults verifies that responses without a results
+// array (e.g. error-list responses) pass through unchanged.
+func TestRewriteDownloadURLsNoResults(t *testing.T) {
+	st, err := newStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("newStore: %v", err)
+	}
+	body := []byte(`{"error-list":[{"code":"not-found","message":"no such charm"}]}`)
+	rewritten, err := rewriteDownloadURLs(body, st, "http://127.0.0.1:8080")
+	if err != nil {
+		t.Fatalf("rewriteDownloadURLs: %v", err)
+	}
+	// The body should be semantically identical (key present, no results key).
+	var doc map[string]any
+	if err := json.Unmarshal(rewritten, &doc); err != nil {
+		t.Fatalf("rewritten body is not valid JSON: %v", err)
+	}
+	if _, ok := doc["error-list"]; !ok {
+		t.Errorf("error-list dropped from response")
+	}
+}
+
+// TestStorePutRefreshThenRead verifies the refresh store round-trips and is
+// persisted to disk (so an actions/cache restore picks it up).
+func TestStorePutRefreshThenRead(t *testing.T) {
+	dir := t.TempDir()
+	st, err := newStore(dir)
+	if err != nil {
+		t.Fatalf("newStore: %v", err)
+	}
+	rev := 77
+	a := action{Name: "ubuntu", Revision: &rev}
+	body := refreshResponse("ubuntu", 77, "abc123", "https://cdn.example/u.charm")
+	if err := st.PutRefresh([]action{a}, body); err != nil {
+		t.Fatalf("PutRefresh: %v", err)
+	}
+	got, ok := st.LookupRefresh(a)
+	if !ok {
+		t.Fatalf("LookupRefresh miss after PutRefresh")
+	}
+	if string(got) != string(body) {
+		t.Fatalf("LookupRefresh body mismatch: got %q want %q", got, body)
+	}
+	// Confirm it landed on disk under the canonical path.
+	if _, err := os.Stat(filepath.Join(dir, "refresh", canonicalKey("ubuntu", 77)+".json")); err != nil {
+		t.Fatalf("refresh file not on disk: %v", err)
+	}
+}
+
+// TestStoreBlobURLRoundTrip verifies the blob URL index persists.
+func TestStoreBlobURLRoundTrip(t *testing.T) {
+	st, err := newStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("newStore: %v", err)
+	}
+	if _, ok := st.BlobURL("nope"); ok {
+		t.Fatalf("BlobURL returned ok for missing key")
+	}
+	if err := st.PutBlobURL("abc", "https://cdn.example/blob"); err != nil {
+		t.Fatalf("PutBlobURL: %v", err)
+	}
+	got, ok := st.BlobURL("abc")
+	if !ok {
+		t.Fatalf("BlobURL miss after PutBlobURL")
+	}
+	if got != "https://cdn.example/blob" {
+		t.Fatalf("got %q, want cdn url", got)
+	}
+}


### PR DESCRIPTION
## Description

Adds a caching Charmhub proxy (`tools/charmhub-cache`) to make integration tests resilient to Charmhub slowness/outages. The proxy caches refresh responses and charm blobs, replaying them offline once warm. CI starts it before bootstrap and routes all charm fetches (every deploy's provider+controller refreshes, and blob downloads) through it via `juju model-defaults charmhub-url=...` (inherited by all test models) and a `CHARMHUB_URL` env override in the provider's direct Charmhub client.

Refresh responses are cached by resolved charm identity (name+revision) plus a variant key covering the requested `fields` and `resource-revisions`. Different callers request different field sets for the same charm+revision, and resource-revision-pinned resolves must not conflate. Requests that are inherently time-varying are never cached: channel-only resolves, and revision+channel "is there an update?" checks.

## Type of change

- Maintenance work
- Logic changes in resources (honouring `CHARMHUB_URL`)

## Additional notes

- `CHARMHUB_URL` is honored by the provider's `charmhub.DefaultURL()`; unset means production behavior is unchanged.
- Periodic charm-revision worker (batched) is not cached, but it first fires ~24h after model creation, so it never runs in a 90-min job.
- Only `test_integration.yml` is wired; cross-controller/JAAS/k8s-tunnel workflows can follow the same pattern later.
