### PR TITLE
fix(application): resolve charm by channel+base when revision is unpinned

### DIFF
--- a/internal/juju/applications.go
+++ b/internal/juju/applications.go
@@ -1380,7 +1380,7 @@ func (c applicationsClient) computeCharmID(
 	ctx context.Context,
 	input *UpdateApplicationInput,
 	applicationAPIClient ApplicationAPIClient,
-	charmsAPIClient *apicharms.Client,
+	charmsAPIClient CharmsAPIResolver,
 ) (apiapplication.CharmID, error) {
 	oldURL, oldOrigin, err := applicationAPIClient.GetCharmURLOrigin(ctx, input.AppName)
 	if err != nil {
@@ -1423,6 +1423,14 @@ func (c applicationsClient) computeCharmID(
 			return apiapplication.CharmID{}, err
 		}
 		newOrigin.Base = base
+		// When base changes and revision is not pinned, drop the revision from
+		// the URL so resolution floats by channel+base instead of pinning the
+		// currently-deployed revision (whose supported bases, used by the
+		// validation below, would incorrectly reject the base change).
+		if input.Revision == nil && input.Channel != "" {
+			newURL = newURL.WithRevision(-1)
+			newOrigin.Revision = nil
+		}
 	}
 	resolvedURL, resolvedOrigin, supportedBases, err := resolveCharm(ctx, charmsAPIClient, newURL, newOrigin)
 	if err != nil {
@@ -1452,6 +1460,9 @@ func (c applicationsClient) computeCharmID(
 	}
 	if input.Base != "" {
 		oldOrigin.Base = newOrigin.Base
+		if input.Revision == nil && input.Channel != "" {
+			oldOrigin.Revision = resolvedOrigin.Revision
+		}
 	}
 
 	if !basesContain(oldOrigin.Base, supportedBases) {
@@ -1470,7 +1481,12 @@ func (c applicationsClient) computeCharmID(
 	}, nil
 }
 
-func resolveCharm(ctx context.Context, charmsAPIClient *apicharms.Client, curl *charm.URL, origin apicommoncharm.Origin) (*charm.URL, apicommoncharm.Origin, []corebase.Base, error) {
+type CharmsAPIResolver interface {
+	ResolveCharms(ctx context.Context, charms []apicharms.CharmToResolve) ([]apicharms.ResolvedCharm, error)
+	AddCharm(ctx context.Context, url *charm.URL, origin apicommoncharm.Origin, dry bool) (apicommoncharm.Origin, error)
+}
+
+func resolveCharm(ctx context.Context, charmsAPIClient CharmsAPIResolver, curl *charm.URL, origin apicommoncharm.Origin) (*charm.URL, apicommoncharm.Origin, []corebase.Base, error) {
 	// Charm or bundle has been supplied as a URL, so we resolve and
 	// deploy using the store but pass in the origin command line
 	// argument so users can target a specific origin.

--- a/internal/juju/applications_test.go
+++ b/internal/juju/applications_test.go
@@ -13,11 +13,13 @@ import (
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"
 	apiapplication "github.com/juju/juju/api/client/application"
+	apicharms "github.com/juju/juju/api/client/charms"
 	apiresources "github.com/juju/juju/api/client/resources"
 	apicharm "github.com/juju/juju/api/common/charm"
 	corebase "github.com/juju/juju/core/base"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/resource"
+	charmURL "github.com/juju/juju/domain/deployment/charm"
 	charmresources "github.com/juju/juju/domain/deployment/charm/resource"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/utils/v4"
@@ -550,6 +552,88 @@ func (s *ApplicationSuite) TestPartialApplicationDeployError() {
 		}},
 	})
 	s.Assert().ErrorAs(err, &ApplicationPartiallyCreatedError{})
+}
+
+// fakeCharmsResolver is a hand-written fake implementing CharmsAPIResolver
+// for unit tests, avoiding mockgen churn for a two-method interface.
+type fakeCharmsResolver struct {
+	resolveResult  []apicharms.ResolvedCharm
+	resolveErr     error
+	addCharmResult apicharm.Origin
+	addCharmErr    error
+
+	gotResolveURL *charmURL.URL
+	gotAddOrigin  apicharm.Origin
+}
+
+func (f *fakeCharmsResolver) ResolveCharms(_ context.Context, charms []apicharms.CharmToResolve) ([]apicharms.ResolvedCharm, error) {
+	if len(charms) == 1 {
+		f.gotResolveURL = charms[0].URL
+	}
+	return f.resolveResult, f.resolveErr
+}
+
+func (f *fakeCharmsResolver) AddCharm(_ context.Context, curl *charmURL.URL, origin apicharm.Origin, _ bool) (apicharm.Origin, error) {
+	f.gotAddOrigin = origin
+	return f.addCharmResult, f.addCharmErr
+}
+
+// TestComputeCharmIDBaseChangeWithoutRevisionResolution tests that when
+// base changes and revision is not pinned, resolution floats by channel+base
+// and the base-compat guard does not block the update.
+func (s *ApplicationSuite) TestComputeCharmIDBaseChangeWithoutRevisionResolution() {
+	defer s.setupMocks(s.T()).Finish()
+	appName := "traefik"
+
+	oldRev := 377
+	oldURL := charmURL.MustParseURL("ch:amd64/traefik-k8s-377")
+	oldOrigin := apicharm.Origin{
+		Source:       "charm-hub",
+		Risk:         "stable",
+		Revision:     &oldRev,
+		Architecture: "amd64",
+		Base: corebase.Base{
+			OS:      "ubuntu",
+			Channel: corebase.Channel{Track: "20.04", Risk: "stable"},
+		},
+	}
+
+	s.mockApplicationClient.EXPECT().GetCharmURLOrigin(gomock.Any(), appName).Return(oldURL, oldOrigin, nil)
+
+	newBase := corebase.Base{OS: "ubuntu", Channel: corebase.Channel{Track: "26.04", Risk: "stable"}}
+	supportedBases := []corebase.Base{newBase}
+	resolvedOrigin := oldOrigin
+	resolvedOrigin.Base = newBase
+	resolvedOrigin.Revision = nil
+	resolvedURL := charmURL.MustParseURL("ch:amd64/traefik-k8s-378")
+
+	fake := &fakeCharmsResolver{
+		resolveResult: []apicharms.ResolvedCharm{
+			{
+				URL:            resolvedURL,
+				Origin:         resolvedOrigin,
+				SupportedBases: supportedBases,
+			},
+		},
+		addCharmResult: resolvedOrigin,
+	}
+
+	client := s.getApplicationsClient()
+	charmID, err := client.computeCharmID(s.T().Context(), &UpdateApplicationInput{
+		AppName: appName,
+		Channel: "latest/stable",
+		Base:    "ubuntu@26.04",
+	}, s.mockApplicationClient, fake)
+
+	s.Assert().NoError(err)
+	s.Assert().Equal("ch:amd64/traefik-k8s-378", charmID.URL)
+	s.Assert().Equal(newBase, charmID.Origin.Base)
+	// Resolve was asked with the revision dropped so the resolver can float
+	// by channel+base rather than pinning the currently-deployed revision.
+	s.Assert().Equal(-1, fake.gotResolveURL.Revision)
+	// AddCharm received the origin with the resolved revision so the apiserver
+	// is not silently re-resolved to the pre-update revision.
+	s.Assert().Equal(resolvedOrigin.Revision, fake.gotAddOrigin.Revision)
 }
 
 // In order for 'go test' to run this suite, we need to create

--- a/internal/provider/resource_application.go
+++ b/internal/provider/resource_application.go
@@ -1148,9 +1148,24 @@ func (r *applicationResource) Update(ctx context.Context, req resource.UpdateReq
 		updateApplicationInput.Channel = planCharm.Channel.ValueString()
 		updateApplicationInput.Base = planCharm.Base.ValueString()
 
-		// If the revision was left empty in the plan, leave it empty here
-		// to ensure we use the latest from the channel, otherwise keep it pinned.
-		if planCharm.Revision.IsUnknown() || planCharm.Revision.IsNull() {
+		var stateCharms []nestedCharm
+		resp.Diagnostics.Append(state.Charm.ElementsAs(ctx, &stateCharms, false)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		var stateRevision types.Int64
+		if len(stateCharms) == 1 {
+			stateRevision = stateCharms[0].Revision
+		}
+
+		// If the revision was not changed in the plan relative to state,
+		// leave it empty so resolution floats by channel+base. Because
+		// Revision is Optional+Computed, plan.Revision inherits the state's
+		// value when the user didn't set one explicitly; treating that as
+		// "user asked to stay on the deployed revision" incorrectly pins
+		// the update to the currently-deployed revision.
+		if planCharm.Revision.IsUnknown() || planCharm.Revision.IsNull() ||
+			(!stateRevision.IsNull() && planCharm.Revision.Equal(stateRevision)) {
 			updateApplicationInput.Revision = nil
 		} else {
 			updateApplicationInput.Revision = intPtr(planCharm.Revision)


### PR DESCRIPTION
When the plan changes only the charm base without pinning a revision (e.g. charm { base = "ubuntu@26.04" } without revision), the deployed revision stays in the resolution URL/origin and ResolveCharms re-resolves to that deployed revision. The client-side base-compat guard then rejects the request because the deployed revision's supported-bases don't include the new base, applying the false error "the new charm does not support the current operating system "ubuntu@26.04/stable"".

When only the charm base changes (no revision pinned), resolution must float by channel+base instead of pinning the currently-deployed revision. This change has two parts:

1. internal/provider/resource_application.go — stop treating the state-inherited Revision (because charm.revision is Optional+Computed) as user-pinned. If plan.Revision equals state.Revision, leave UpdateApplicationInput.Revision nil so resolution can float.

2. internal/juju/applications.go — in computeCharmID, when base changes and revision is unpinned, drop the revision from the resolution URL and nil newOrigin.Revision so the apiserver resolves by channel+base. Propagate the resolved revision back into oldOrigin so AddCharm records a consistent origin.

Fixes: https://github.com/juju/terraform-provider-juju/issues/1351
 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Environment

- Juju controller version: 3.6.27 

- Terraform version: 1.15.9

## QA steps

Manual QA steps should be done to test this PR.

see https://github.com/juju/terraform-provider-juju/issues/1351

## Additional notes


