### PR TITLE
fix: tweak revision invalidator modifier

### DIFF
--- a/internal/provider/modifier_revision_invalidate.go
+++ b/internal/provider/modifier_revision_invalidate.go
@@ -10,16 +10,16 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-// InvalidateRevisionIfChannelChanges returns a plan modifier that sets the
-// revision to Unknown if the channel has changed.
-func InvalidateRevisionIfChannelChanges() planmodifier.Int64 {
+// InvalidateRevisionIfChannelOrBaseChanges returns a plan modifier that sets the
+// revision to Unknown if either the channel or base has changed.
+func InvalidateRevisionIfChannelOrBaseChanges() planmodifier.Int64 {
 	return &invalidateRevisionModifier{}
 }
 
 type invalidateRevisionModifier struct{}
 
 func (m *invalidateRevisionModifier) Description(_ context.Context) string {
-	return "If the channel changes, the revision must be recalculated unless pinned."
+	return "If the channel or base changes, the revision must be recalculated unless pinned."
 }
 
 func (m *invalidateRevisionModifier) MarkdownDescription(ctx context.Context) string {
@@ -32,11 +32,12 @@ func (m *invalidateRevisionModifier) PlanModifyInt64(ctx context.Context, req pl
 		return
 	}
 
-	// We need to check if the channel (a sibling attribute) is changing.
+	// Check whether the channel or base (sibling attributes) is changing.
 	// Because 'charm' is a ListNestedBlock, we look at the first element [0].
 	channelPath := req.Path.ParentPath().AtName("channel")
+	basePath := req.Path.ParentPath().AtName("base")
 
-	var stateChannel, planChannel types.String
+	var stateChannel, planChannel, stateBase, planBase types.String
 	diags := req.State.GetAttribute(ctx, channelPath, &stateChannel)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -47,9 +48,22 @@ func (m *invalidateRevisionModifier) PlanModifyInt64(ctx context.Context, req pl
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	diags = req.State.GetAttribute(ctx, basePath, &stateBase)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	diags = req.Plan.GetAttribute(ctx, basePath, &planBase)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
-	// If the channel is changing, mark the revision as Unknown (Known After Apply)
-	if !planChannel.Equal(stateChannel) {
+	// If the channel or base is changing, mark the revision as Unknown (Known After Apply).
+	// An unknown value does not indicate a change, so only invalidate the revision when the
+	// planned value is known and differs from state.
+	if (!planChannel.IsUnknown() && !planChannel.Equal(stateChannel)) ||
+		(!planBase.IsUnknown() && !planBase.Equal(stateBase)) {
 		resp.PlanValue = types.Int64Unknown()
 	}
 }

--- a/internal/provider/modifier_revision_invalidate_test.go
+++ b/internal/provider/modifier_revision_invalidate_test.go
@@ -1,0 +1,138 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the Apache License, Version 2.0, see LICENCE file for details.
+
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/require"
+)
+
+type revisionModifierTestModel struct {
+	Charm types.List `tfsdk:"charm"`
+}
+
+func TestInvalidateRevisionIfChannelOrBaseChanges(t *testing.T) {
+	testCases := []struct {
+		name           string
+		stateChannel   string
+		planChannel    types.String
+		stateBase      types.String
+		planBase       types.String
+		configRevision types.Int64
+		wantUnknown    bool
+	}{
+		{
+			name:           "channel changes with unpinned revision",
+			stateChannel:   "latest/stable",
+			planChannel:    types.StringValue("latest/edge"),
+			stateBase:      types.StringValue("ubuntu@22.04"),
+			planBase:       types.StringValue("ubuntu@22.04"),
+			configRevision: types.Int64Null(),
+			wantUnknown:    true,
+		},
+		{
+			name:           "base changes with unpinned revision",
+			stateChannel:   "latest/stable",
+			planChannel:    types.StringValue("latest/stable"),
+			stateBase:      types.StringValue("ubuntu@22.04"),
+			planBase:       types.StringValue("ubuntu@24.04"),
+			configRevision: types.Int64Null(),
+			wantUnknown:    true,
+		},
+		{
+			name:           "base remains unchanged with unpinned revision",
+			stateChannel:   "latest/stable",
+			planChannel:    types.StringValue("latest/stable"),
+			stateBase:      types.StringValue("ubuntu@22.04"),
+			planBase:       types.StringValue("ubuntu@22.04"),
+			configRevision: types.Int64Null(),
+			wantUnknown:    false,
+		},
+		{
+			name:           "base changes with pinned revision",
+			stateChannel:   "latest/stable",
+			planChannel:    types.StringValue("latest/stable"),
+			stateBase:      types.StringValue("ubuntu@22.04"),
+			planBase:       types.StringValue("ubuntu@24.04"),
+			configRevision: types.Int64Value(123),
+			wantUnknown:    false,
+		},
+		{
+			name:           "unknown computed base does not invalidate revision",
+			stateChannel:   "latest/stable",
+			planChannel:    types.StringValue("latest/stable"),
+			stateBase:      types.StringValue("ubuntu@22.04"),
+			planBase:       types.StringUnknown(),
+			configRevision: types.Int64Null(),
+			wantUnknown:    false,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			testSchema := revisionModifierTestSchema()
+			state := revisionModifierTestState(t, ctx, testSchema, types.StringValue(tt.stateChannel), tt.stateBase)
+			plan := revisionModifierTestState(t, ctx, testSchema, tt.planChannel, tt.planBase)
+			response := planmodifier.Int64Response{PlanValue: types.Int64Value(100)}
+
+			InvalidateRevisionIfChannelOrBaseChanges().PlanModifyInt64(ctx, planmodifier.Int64Request{
+				Path:        path.Root("charm").AtListIndex(0).AtName("revision"),
+				ConfigValue: tt.configRevision,
+				Plan:        tfsdk.Plan{Raw: plan.Raw, Schema: testSchema},
+				State:       state,
+			}, &response)
+
+			require.False(t, response.Diagnostics.HasError(), response.Diagnostics.Errors())
+			require.Equal(t, tt.wantUnknown, response.PlanValue.IsUnknown())
+		})
+	}
+}
+
+func revisionModifierTestSchema() schema.Schema {
+	return schema.Schema{
+		Blocks: map[string]schema.Block{
+			"charm": schema.ListNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"channel":  schema.StringAttribute{Optional: true},
+						"base":     schema.StringAttribute{Optional: true},
+						"revision": schema.Int64Attribute{Optional: true},
+					},
+				},
+			},
+		},
+	}
+}
+
+func revisionModifierTestState(t *testing.T, ctx context.Context, testSchema schema.Schema, channel, base types.String) tfsdk.State {
+	t.Helper()
+
+	charmType := types.ObjectType{AttrTypes: map[string]attr.Type{
+		"channel":  types.StringType,
+		"base":     types.StringType,
+		"revision": types.Int64Type,
+	}}
+	state := tfsdk.State{Schema: testSchema}
+	diags := state.Set(ctx, revisionModifierTestModel{
+		Charm: types.ListValueMust(charmType, []attr.Value{
+			types.ObjectValueMust(charmType.AttrTypes, map[string]attr.Value{
+				"channel":  channel,
+				"base":     base,
+				"revision": types.Int64Value(100),
+			}),
+		}),
+	})
+	require.False(t, diags.HasError(), diags.Errors())
+
+	return state
+}

--- a/internal/provider/resource_application.go
+++ b/internal/provider/resource_application.go
@@ -398,7 +398,7 @@ func (r *applicationResource) Schema(ctx context.Context, _ resource.SchemaReque
 							Computed:    true,
 							PlanModifiers: []planmodifier.Int64{
 								int64planmodifier.UseStateForUnknown(),
-								InvalidateRevisionIfChannelChanges(),
+								InvalidateRevisionIfChannelOrBaseChanges(),
 							},
 						},
 						BaseKey: schema.StringAttribute{

--- a/internal/provider/resource_application_test.go
+++ b/internal/provider/resource_application_test.go
@@ -521,7 +521,9 @@ func TestAcc_ResourceApplication_UpdatesRevisionConfig(t *testing.T) {
 	})
 }
 
-func TestAcc_CharmUpdatesNoRevision(t *testing.T) {
+// TestAcc_CharmUpdatesNoRevisionChannelChange tests that when the charm
+// revision is not pinned, changing the channel recomputes the charm revision.
+func TestAcc_CharmUpdatesNoRevisionChannelChange(t *testing.T) {
 	modelName := acctest.RandomWithPrefix("tf-test-charmupdates")
 	initialVersion := 0
 	channelOne := "latest/stable"
@@ -570,6 +572,85 @@ func TestAcc_CharmUpdatesNoRevision(t *testing.T) {
 				Config: testAccResourceApplicationUpdatesCharm(modelName, channelTwo),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("juju_application.this", "charm.0.channel", channelTwo),
+					func(s *terraform.State) error {
+						// Check that the charm revision has been updated to a new revision different from the initialVersion.
+						rs, ok := s.RootModule().Resources["juju_application.this"]
+						if !ok {
+							return fmt.Errorf("not found: juju_application.this")
+						}
+						newVersionStr := rs.Primary.Attributes["charm.0.revision"]
+						var err error
+						newVersion, err := strconv.Atoi(newVersionStr)
+						if err != nil {
+							return fmt.Errorf("error converting revision to int: %v", err)
+						}
+						if newVersion == initialVersion {
+							return fmt.Errorf("expected charm revision to be updated from %d, but it is still %d", initialVersion, newVersion)
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+// TestAcc_CharmUpdatesNoRevisionBaseChange tests that when the charm revision
+// is not pinned, changing the base recomputes the charm revision and the
+// update succeeds. This is the base-change equivalent of the channel change
+// tested in TestAcc_CharmUpdatesNoRevisionChannelChange.
+//
+// The test only runs on MicroK8s because changing the base requires replacement
+// for machines. The traefik-k8s charm is used because in the latest/stable
+// channel different revisions support different bases (revision 377 supports
+// ubuntu@20.04 while revisions 378+ support ubuntu@26.04), so a base change
+// should result in a different charm revision. Since the revision is not pinned,
+// the test relies on Charmhub state; if traefik-k8s ever drops ubuntu@20.04
+// support from latest/stable, the first step will fail.
+func TestAcc_CharmUpdatesNoRevisionBaseChange(t *testing.T) {
+	if testingCloud != MicroK8sTesting {
+		t.Skip(t.Name() + " only runs with Microk8s")
+	}
+	modelName := acctest.RandomWithPrefix("tf-test-charmupdates")
+	baseChannel := "latest/stable"
+	initialVersion := 0
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: frameworkProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceApplicationUpdatesCharmWithBase(modelName, baseChannel, "ubuntu@20.04"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("juju_application.this", "charm.0.channel", baseChannel),
+					resource.TestCheckResourceAttr("juju_application.this", "charm.0.base", "ubuntu@20.04"),
+					func(s *terraform.State) error {
+						// Use a check to grab the application revision and set it to initialVersion variable to be used in the next step.
+						rs, ok := s.RootModule().Resources["juju_application.this"]
+						if !ok {
+							return fmt.Errorf("not found: juju_application.this")
+						}
+						initialVersionStr := rs.Primary.Attributes["charm.0.revision"]
+						var err error
+						initialVersion, err = strconv.Atoi(initialVersionStr)
+						if err != nil {
+							return fmt.Errorf("error converting revision to int: %v", err)
+						}
+						if initialVersion == 0 {
+							return fmt.Errorf("expected initial charm revision to be non-zero, got %d", initialVersion)
+						}
+						return nil
+					},
+				),
+			},
+			{
+				// Update the base while the channel stays the same and the
+				// revision is not pinned. The update should succeed with the
+				// revision recomputed for the new base.
+				Config: testAccResourceApplicationUpdatesCharmWithBase(modelName, baseChannel, "ubuntu@26.04"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("juju_application.this", "charm.0.channel", baseChannel),
+					resource.TestCheckResourceAttr("juju_application.this", "charm.0.base", "ubuntu@26.04"),
 					func(s *terraform.State) error {
 						// Check that the charm revision has been updated to a new revision different from the initialVersion.
 						rs, ok := s.RootModule().Resources["juju_application.this"]
@@ -2406,6 +2487,24 @@ func testAccResourceApplicationUpdatesCharmWithRevision(modelName string, channe
 		"Channel":   channel,
 		"Revision":  revision,
 	})
+}
+
+func testAccResourceApplicationUpdatesCharmWithBase(modelName string, channel string, base string) string {
+	return fmt.Sprintf(`
+		resource "juju_model" "this" {
+		  name = %q
+		}
+
+		resource "juju_application" "this" {
+		  model_uuid = juju_model.this.uuid
+		  name = "test-app"
+		  charm {
+			name     = "traefik-k8s"
+			channel  = %q
+			base     = %q
+		  }
+		}
+		`, modelName, channel, base)
 }
 
 func testAccApplicationUpdateBaseCharm(modelName string, base string) string {


### PR DESCRIPTION
## Description

Resolves https://github.com/juju/terraform-provider-juju/issues/1351 to allow a plan author to update a `juju_application` resource where a charm block does not specify a revision and subsequently changes the deployed `base`. This is only possible for K8s charms where the base can be updated without replacement.

This is the exact same problem that was resolved in https://github.com/juju/terraform-provider-juju/pull/1222 but for the charm channel. Essentially, when the charm revision is not defined in the plan, its value is re-used from state to avoid unintentionally updating the charm. But when the charm revision is not pinned, changes to the `channel` or `base` should recompute a new charm revision.

We resolved this previously by adding a plan modifier in `internal/provider/modifier_revision_invalidate.go` that zeros the stored charm revision if the channel changes. Here we extend that to do the same if the base changes. I haven't added a test because while I could extend the test `TestAcc_CharmUpdatesNoRevision` to also have a case where the base changes, my thinking was:
1. The test charm we use, `coredns`, may stop supporting the specified base making our tests potentially fail in the future and we can't pin a revision as that is the entire point of the problem.
2. The behaviour of the modifier to invalidate the charm revision is already tested by this test case. So the additional tests specifically for the charm modifier seem acceptable.

But I can add adjust the acceptance tests so that we cover this case directly if desired.

Additionally it's worth noting, as described in the issue, that this problem dissapears if one uses the `juju_charm` data source.

Fixes: https://github.com/juju/terraform-provider-juju/issues/1351
Fixes [JUJU-10300](https://warthogs.atlassian.net/browse/JUJU-10300)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## QA steps

Manual QA steps should be done to test this PR.

```tf
resource "juju_model" "exp" {
  name = "tf-exp"
}

resource "juju_application" "traefik" {
  name       = "traefik"
  model_uuid = juju_model.exp.uuid

  charm {
    name    = "traefik-k8s"
    channel = "latest/stable"
    base    = "ubuntu@20.04"
  }

  trust = true
}
```
Apply the above plan. Then change the `base` field to `ubuntu@26.04`. The apply should fail with `Unable to update application resource, got error: the new charm does not support the current operating system "ubuntu@26.04/stable"` before the change. After the change it works.

[JUJU-10300]: https://warthogs.atlassian.net/browse/JUJU-10300?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ