### PR TITLE
docs: update minimum supported juju version

### DIFF
--- a/docs-rtd/reference/terraform-provider/index.md
+++ b/docs-rtd/reference/terraform-provider/index.md
@@ -35,7 +35,8 @@ Work is ongoing to include support for more of the juju CLIs capabilities within
 
 ## Prerequisites
 
-* [Juju][0] `2.9.49+`
+* [Juju][0] `3.x` or higher
+* If using [JAAS][1], Juju controller `3.6.5` or higher
 
 ## Authentication
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,7 +35,8 @@ Work is ongoing to include support for more of the juju CLIs capabilities within
 
 ## Prerequisites
 
-* [Juju][0] `2.9.49+`
+* [Juju][0] `3.x` or higher
+* If using [JAAS][1], Juju controller `3.6.5` or higher
 
 ## Authentication
 

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -35,7 +35,8 @@ Work is ongoing to include support for more of the juju CLIs capabilities within
 
 ## Prerequisites
 
-* [Juju][0] `2.9.49+`
+* [Juju][0] `3.x` or higher
+* If using [JAAS][1], Juju controller `3.6.5` or higher
 
 ## Authentication
 


### PR DESCRIPTION
## Description

Fixes:
- Update minimum supported juju version in docs

## Type of change

- Requires a documentation update

## Notes
Fixes https://github.com/juju/terraform-provider-juju/issues/1354
