### PR TITLE
docs: explain how to use `terraform query` to import a manual deploy

### DIFF
--- a/docs-rtd/conf.py
+++ b/docs-rtd/conf.py
@@ -337,6 +337,7 @@ markdown_http_base = "https://documentation.ubuntu.com/terraform-provider-juju/l
 exclude_patterns = [
     "doc-cheat-sheet*",
     ".venv*",  # Exclude virtual environment
+    "skills/*", # Agent skills
 ]
 
 # Adds custom CSS files, located under 'html_static_path'

--- a/docs-rtd/howto/manage-models.md
+++ b/docs-rtd/howto/manage-models.md
@@ -1,7 +1,7 @@
 ---
 myst:
   html_meta:
-    description: "Learn how to reference, add, configure, and manage Juju models with constraints and configuration keys using Terraform."
+    description: "Learn how to reference, add, configure, and manage Juju models with constraints and configuration keys using Terraform, and how to export and import them."
 ---
 
 (manage-models)=
@@ -69,7 +69,8 @@ resource "juju_integration" "juju-dashboard" {
 }
 ```
 
-```{note} Note that JAAS does not expose the controller model for controllers that it manages.
+```{note}
+JAAS does not expose the controller model for controllers that it manages.
 ```
 
 > See more: [`juju_model` (data source)](../reference/terraform-provider/data-sources/model), [`juju_application` (resource)](../reference/terraform-provider/resources/application), [`juju_integration` (resource)](../reference/terraform-provider/resources/integration)
@@ -312,15 +313,19 @@ To destroy a model, remove its resource definition from your Terraform plan.
 
 > See more: [`juju_model` (resource)](../reference/terraform-provider/resources/model)
 
-## Export a model
+## Export a manually deployed model to a Terraform plan
 
-To export the Terraform configuration from a model, you can use `terraform query`.
+To export the Terraform configuration from a model, you can use `terraform query`: it generates a Terraform config (plus `import` blocks) that reproduces the model's current resources, so you can bring it under Terraform management.
 
 > See also: [terraform query](https://developer.hashicorp.com/terraform/language/v1.14.x/import/bulk?page=import&page=bulk)
 
 ### Ensure the provider is connected to the model's host controller
 
 To export the Terraform configuration for a model, configure the provider to connect to the controller that hosts the model.
+
+```{tip}
+Consider using read-only credentials for the export, to ensure no changes can be accidentally made to the model during the process. See [Juju | User access levels](https://documentation.ubuntu.com/juju/latest/reference/user/#valid-access-levels-for-models).
+```
 
 For example:
 
@@ -357,6 +362,8 @@ For example, create `example.tfquery.hcl` with:
 - storage pools
 - integrations
 - offers
+- secrets
+- spaces
 
 ```{code-block} terraform
 :caption: `example.tfquery.hcl`
@@ -463,6 +470,30 @@ list "juju_storage_pool" "all_storage_pools" {
     model_uuid = var.model_uuid
   }
 }
+
+# ---------------------------------------------------------------------------
+# List all secrets in the test model
+# ---------------------------------------------------------------------------
+list "juju_secret" "all_secrets" {
+  provider         = juju
+  include_resource = true
+
+  config {
+    model_uuid = var.model_uuid
+  }
+}
+
+# ---------------------------------------------------------------------------
+# List all spaces in the test model
+# ---------------------------------------------------------------------------
+list "juju_space" "all_spaces" {
+  provider         = juju
+  include_resource = true
+
+  config {
+    model_uuid = var.model_uuid
+  }
+}
 ```
 
 ### Query and generate the configuration file
@@ -470,6 +501,10 @@ list "juju_storage_pool" "all_storage_pools" {
 To generate the config with the specified list resources into the `test.tf` file, run:
 
 `TF_VAR_model_uuid="<model-uuid>" terraform query --generate-config-out=test.tf`
+
+```{tip}
+You can get the model UUID with `juju show-model <model-name> --format yaml | grep model-uuid` or `juju models --format yaml`.
+```
 
 An example of the generated config:
 
@@ -603,3 +638,16 @@ juju_storage_pool.all_storage_pools_3: Destroying... [id=c1cecf1e-fe66-4589-8585
 ```
 
 It is advisable to either remove these resources from the generated configuration before importing, or to simply avoid deleting them via Terraform.
+
+(refine-the-generated-config-with-an-ai-agent)=
+### Refine the generated config with an AI agent
+
+The `model export cleanup` skill ({download skill}`download <../skills/tf-model-export-cleanup.md>`) guides an AI agent through the fixes described above: cross-referencing resources (UUIDs and names), pruning un-settable attributes and defaults, removing unmanageable resources, and iterating on `terraform plan` until it reports no changes and would re-create the model from scratch.
+
+Download the skill file (or point your agent at the URL) and invoke it on the generated config. The agent will ask you to confirm judgment calls and may ask you to run `terraform plan` or `juju status` and paste the output if it can't reach the controller itself.
+
+```{warning}
+Always review what commands the agent is trying to run before letting it proceed. The skill instructs the agent to never run `terraform apply`, but that is not a guarantee.
+```
+
+Some spurious diffs (e.g., config defaults) may remain. When you are satisfied, review the final config before applying.

--- a/docs-rtd/skills/tf-model-export-cleanup.md
+++ b/docs-rtd/skills/tf-model-export-cleanup.md
@@ -1,0 +1,123 @@
+---
+name: tf-model-export-cleanup
+description: Turn a `terraform query` export of a Juju model into a clean, maintainable Terraform config. Rewrite literals into cross-resource references, prune attributes that can't be set, iterate `terraform plan` to no changes, then split into modules.
+---
+
+# Terraform model export cleanup
+
+The user has a `terraform query` export of a Juju model — the exported file
+(`exported.tf unless the user says otherwise). The goal is a config that **both**
+imports cleanly (`terraform plan` → no changes) **and** would recreate the model from
+scratch (see section 5). This is best-effort; some spurious diffs may remain and the
+user may accept them.
+
+**NEVER run `terraform apply`.** Applying would have surprising side-effects on real
+infrastructure, and complex models need review before applying. The same applies to 
+any other commands that may mutate infrastructure.
+
+## 1. Set up the config for `terraform plan`
+
+If there's no `terraform`/`required_providers` block yet, add one for `juju/juju` in a
+sibling `versions.tf`, then run `terraform init`.
+
+## 2. Rewrite literals into references
+
+`terraform query` emits every field as a literal. Rewrite them so Terraform can see
+the dependency graph:
+
+| Literal | Reference |
+| --- | --- |
+| `model_uuid = "<uuid>"` | `model_uuid = juju_model.<label>.uuid` |
+| `machines = ["1"]` | `machines = [juju_machine.<label>.machine_id]` |
+| integration `application { name = "app" }` | `application { name = juju_application.<label>.name }` |
+
+To match a literal to the right resource, use the `import` blocks, which
+`terraform query` always emits and which carry the composite identity in
+`identity.id`:
+
+- `juju_model`: the `id` is the model UUID.
+- `juju_application`: `<model-uuid>:<app-name>`
+- `juju_machine`: `<model-uuid>:<machine-id>:<machine-name>`
+- `juju_integration`: `<model-uuid>:<app1>:<ep1>:<app2>:<ep2>`
+
+Rules:
+
+- `model_uuid` values that are already references are left untouched.
+- `model_uuid` literals with no matching `juju_model` resource in the file are left
+  as literals; warn the user and suggest re-running `terraform query` with the model
+  included.
+- Default/implicit resources emitted by `terraform query` (such as the `loop` storage
+  pool) are kept; only their references are rewritten.
+
+## 3. Prune attributes that can't or shouldn't be set
+
+- **`null` attributes**: `terraform query` emits every Optional attribute as `null`
+  when unset. Remove them; the provider default is already `null`.
+- **Computed-only attributes** (Computed, not Optional or Required) cannot be set in
+  config and fail validation on apply. Remove them. Common ones:
+  - `juju_model`: `uuid`, `id`
+  - `juju_application`: `id`, `model_type`, `unit_numbers`, `storage`
+  - `juju_machine`: `id`, `machine_id`, `instance_id`, `hostname`
+  - `juju_secret`: `id`, `secret_id`, `secret_uri`
+  - `juju_integration`, `juju_access_model`, `juju_access_secret`: `id`
+
+  Computed-only attributes can still be *referenced* from other resources (that's
+  what section 2 does with `juju_model.<label>.uuid`); they just can't be set in
+  config.
+- Attributes that are both Computed and Optional (e.g. application `name`) are kept;
+  the user may set those.
+
+## 4. Iterate on `terraform plan`
+
+1. Run `terraform plan`. If you can't reach the controller, ask the user to run it
+   and paste the output.
+2. For each error or unexpected change, classify and fix it (see common cases
+   below). Use `juju status --format yaml -m <model-name>` (or ask the user to run
+   it) as the source of truth when the plan and the config disagree.
+3. Re-run `terraform plan`. Repeat until `No changes` or the user accepts the
+   remaining diffs.
+
+Common cases:
+
+- **Unmanageable resources** — resources the controller creates automatically and
+  that can't be imported or managed (e.g. the default `alpha` space): remove the
+  resource block and its `import` block together.
+- **Controller-set defaults** (e.g. `juju_model.config` full of defaults): the export
+  captures every value the controller reports. Look up Juju model config defaults,
+  mark likely-default keys, and offer the user: (1) keep all, (2) drop likely
+  defaults, or (3) case by case.
+- **`cloud` block on `juju_model`**: often controller-inferred, not user-set. Ask
+  the user; if not set explicitly, remove it.
+- **`juju_machine` resources / application `machines`**: often auto-allocated. Ask
+  whether to drop them and let the provider allocate on recreate.
+- **`juju_storage_pool` resources**: often implicit defaults. Ask whether to drop
+  them or keep them explicit.
+- **Resources to destroy ("not in configuration")**: expected when replacing an old
+  config. Confirm with the user; don't re-add to prevent destruction. If a destroyed
+  resource matches an imported one by identity (check `juju status`), suggest
+  renaming the exported resource to the original label and dropping its `import`
+  block so the existing state entry is reused.
+
+## 5. When done
+
+First, verify the config would also recreate the model from scratch: temporarily
+move the `import` blocks out of the config (e.g. into a scratch file), run
+`terraform plan`, and confirm it shows only creates. Then restore the `import`
+blocks.
+
+Once the plan is clean (or accepted), split for maintainability:
+
+- Move `required_providers` into `versions.tf` if not already there.
+- Group resources by concern into separate files.
+- Rename auto-generated labels to meaningful names. Update all references and
+  `import` block `to` addresses in the same edit.
+- Collect all `import` blocks into `imports.tf`.
+- Remove generated-by comments and other boilerplate. Drop redundant
+  `provider = juju` attributes. Empty collections (e.g. `annotations = {}`) may be
+  meaningful — only remove them if the schema, the user, or the plan confirms
+  they're redundant.
+- Run `terraform fmt -recursive`, then `terraform plan` once more to confirm.
+
+Tell the user: the export only covers resources with `list` support (users,
+credentials, etc. won't appear). The config is best-effort and **NEEDS** careful
+manual review before applying.

--- a/examples/list-resources/export-all-model.tfquery.hcl
+++ b/examples/list-resources/export-all-model.tfquery.hcl
@@ -1,0 +1,96 @@
+# Example: export every supported resource from a single Juju model.
+#
+# Usage:
+#
+#   TF_VAR_model_uuid="<model-uuid>" terraform query \
+#     --generate-config-out=exported.tf
+#
+# Then use an AI agent with the model export cleanup skill to rewrite literal
+# UUIDs/names into cross-resource references and get `terraform plan` clean.
+# See the "Export a model" how-to in the provider docs for the full workflow.
+
+variable "model_uuid" {
+  description = "UUID of the model to export"
+  type        = string
+}
+
+list "juju_model" "model" {
+  provider         = juju
+  include_resource = true
+
+  config {
+    model_uuid = var.model_uuid
+  }
+}
+
+list "juju_application" "all_apps" {
+  provider         = juju
+  include_resource = true
+
+  config {
+    model_uuid = var.model_uuid
+  }
+}
+
+list "juju_machine" "all_machines" {
+  provider         = juju
+  include_resource = true
+
+  config {
+    model_uuid = var.model_uuid
+  }
+}
+
+list "juju_integration" "all_integrations" {
+  provider         = juju
+  include_resource = true
+
+  config {
+    model_uuid = var.model_uuid
+  }
+}
+
+list "juju_secret" "all_secrets" {
+  provider         = juju
+  include_resource = true
+
+  config {
+    model_uuid = var.model_uuid
+  }
+}
+
+list "juju_offer" "all_offers" {
+  provider         = juju
+  include_resource = true
+
+  config {
+    model_uuid = var.model_uuid
+  }
+}
+
+list "juju_ssh_key" "all_ssh_keys" {
+  provider         = juju
+  include_resource = true
+
+  config {
+    model_uuid = var.model_uuid
+  }
+}
+
+list "juju_space" "all_spaces" {
+  provider         = juju
+  include_resource = true
+
+  config {
+    model_uuid = var.model_uuid
+  }
+}
+
+list "juju_storage_pool" "all_storage_pools" {
+  provider         = juju
+  include_resource = true
+
+  config {
+    model_uuid = var.model_uuid
+  }
+}


### PR DESCRIPTION
## Description

Add a how-to for importing a manually deployed Juju model into a Terraform plan: export the model with `terraform query`, then let an AI agent clean up the generated config using the included export cleanup skill.

The skill guides an agent through the whole process: rewriting literal UUIDs and names into cross-resource references, pruning attributes that can't be set in config, iterating on `terraform plan` until the config imports cleanly and would also recreate the model from scratch, and splitting the result into maintainable files.

Also adds an example query file (`examples/list-resources/export-all-model.tfquery.hcl`) that exports every supported resource type from a single model.

## Type of change

- Documentation

## QA steps

1. Set up a deployment manually (outside Terraform).
2. Follow the how-to from start to finish.
3. Check the result
