### PR TITLE
refactor: set foreBase flag true for charm updates

### DIFF
--- a/internal/juju/applications.go
+++ b/internal/juju/applications.go
@@ -351,6 +351,7 @@ type UpdateApplicationInput struct {
 	Revision  *int
 	Channel   string
 	Trust     *bool
+	ForceBase bool
 	Expose    map[string]interface{}
 	// Unexpose indicates what endpoints to unexpose
 	Unexpose          []string
@@ -1339,6 +1340,7 @@ func (c applicationsClient) UpdateCharmAndResources(
 			CharmID:           charmID,
 			ResourceIDs:       resourceIds,
 			StorageDirectives: input.StorageDirectives,
+			ForceBase:         input.ForceBase,
 		}
 		err = applicationAPIClient.SetCharm(ctx, charmConfig)
 		if err != nil {

--- a/internal/provider/resource_application.go
+++ b/internal/provider/resource_application.go
@@ -1123,6 +1123,11 @@ func (r *applicationResource) Update(ctx context.Context, req resource.UpdateReq
 	updateApplicationInput := juju.UpdateApplicationInput{
 		ModelUUID: state.ModelUUID.ValueString(),
 		AppName:   state.ApplicationName.ValueString(),
+		// Juju 3 did not require the force-base flag to be true to change
+		// the base of a Kubernetes charm, but Juju 4 does, so we always
+		// set it. A machine application with a new base requires
+		// recreation, so we shouldn't reach this code path if the base changes.
+		ForceBase: true,
 	}
 
 	if !plan.ApplicationName.IsUnknown() && !plan.ApplicationName.Equal(state.ApplicationName) {


### PR DESCRIPTION
## Description

This change brings a tweak from v2.3 where we correctly handle charm updates for Kubernetes charms in Juju 4.